### PR TITLE
[GHATD-X] Updated how correlation id passed with ctx (+ other tweaks)

### DIFF
--- a/external/logger/middleware/middleware.go
+++ b/external/logger/middleware/middleware.go
@@ -29,8 +29,9 @@ func getOrCreateCorrelationId(req *http.Request) string {
 	return correlationId
 }
 
-// HTTPLogger creates a middleware that affixes the correlation Id to the logger, and as well logs
-// request specific data
+// HTTPLogger is a middleware that adds correlation ID tracking and logging to HTTP requests.
+// It generates or retrieves a correlation ID, attaches it to the request context and response headers,
+// creates a logger with the correlation ID, and logs request details after the handler completes.
 func (m *Middleware) HTTPLogger(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 

--- a/external/logger/middleware/middleware.go
+++ b/external/logger/middleware/middleware.go
@@ -37,6 +37,10 @@ func (m *Middleware) HTTPLogger(handler http.Handler) http.Handler {
 		fetchedCorrelationId := getOrCreateCorrelationId(req)
 		w.Header().Add("X-Correlation-Id", fetchedCorrelationId)
 
+		// attach correlation id to request context
+		req = req.WithContext(toolbox.TransitWithCtxByKey[string](req.Context(), toolbox.CtxKeyCorrelationId, fetchedCorrelationId))
+
+		// attach correlation id to logger
 		reqLogger := m.logger.With(zap.String("correlation-id", fetchedCorrelationId))
 		//nolint Sync the request logger
 		defer reqLogger.Sync()

--- a/external/logger/middleware/middleware.go
+++ b/external/logger/middleware/middleware.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/logger"
@@ -52,7 +53,8 @@ func (m *Middleware) HTTPLogger(handler http.Handler) http.Handler {
 		handler.ServeHTTP(responseWriter, request)
 
 		// Log request data
-		reqLogger.Info("request",
+		reqLogger.Info(
+			fmt.Sprintf("concluded request for %s [correlation-id: %s]", req.URL.RequestURI(), fetchedCorrelationId),
 			zap.Int("status", responseWriter.statusCode),
 			zap.String("method", req.Method),
 			zap.String("clientip", req.RemoteAddr),

--- a/external/spa/routes.go
+++ b/external/spa/routes.go
@@ -15,12 +15,6 @@ import (
 type SpaHandler interface {
 }
 
-// SpaUpdatePathToIndexHandler expected methods for handler
-// that specifies the request that fo to spa root path
-type SpaUpdatePathToIndexHandler interface {
-	HandleUpdatePathToIndex(r *http.Request) *http.Request
-}
-
 // AttachRoutesRequest holds everything needed to attach spa
 // routes to router
 type AttachRoutesRequest struct {
@@ -34,8 +28,9 @@ type AttachRoutesRequest struct {
 	// EmbeddedContentFilePathPrefix the prefix used to access the embedded files
 	EmbeddedContentFilePathPrefix string
 
-	// SpaUpdatePathToIndexHandler handles updating request path
-	SpaUpdatePathToIndexHandler SpaUpdatePathToIndexHandler
+	// HandleUpdatePathToIndex is the function that handles updating
+	// request path that should be sent to the / path
+	HandleUpdatePathToIndex func(r *http.Request) *http.Request
 }
 
 // AttachRoutes attaches spa handler to corresponding
@@ -65,7 +60,7 @@ func AttachRoutes(request *AttachRoutesRequest) {
 			// if the r.URL.Path does not have a suffix such as .js,
 			// .css, .png, .jpg, .jpeg, .gif, .svg, or .ico then we
 			// should update path to go to /
-			r = request.SpaUpdatePathToIndexHandler.HandleUpdatePathToIndex(r)
+			r = request.HandleUpdatePathToIndex(r)
 
 			fileServer.ServeHTTP(w, r)
 		}

--- a/external/spa/routes.go
+++ b/external/spa/routes.go
@@ -28,9 +28,9 @@ type AttachRoutesRequest struct {
 	// EmbeddedContentFilePathPrefix the prefix used to access the embedded files
 	EmbeddedContentFilePathPrefix string
 
-	// HandleUpdatePathToIndex is the function that handles updating
+	// HandleUpdatePathToIndexFunc is the function that handles updating
 	// request path that should be sent to the / path
-	HandleUpdatePathToIndex func(r *http.Request) *http.Request
+	HandleUpdatePathToIndexFunc func(r *http.Request) *http.Request
 }
 
 // AttachRoutes attaches spa handler to corresponding
@@ -60,7 +60,7 @@ func AttachRoutes(request *AttachRoutesRequest) {
 			// if the r.URL.Path does not have a suffix such as .js,
 			// .css, .png, .jpg, .jpeg, .gif, .svg, or .ico then we
 			// should update path to go to /
-			r = request.HandleUpdatePathToIndex(r)
+			r = request.HandleUpdatePathToIndexFunc(r)
 
 			fileServer.ServeHTTP(w, r)
 		}

--- a/external/toolbox/context.go
+++ b/external/toolbox/context.go
@@ -1,0 +1,34 @@
+package toolbox
+
+import (
+	"context"
+)
+
+// CtxKey is a type alias for string used for context keys.
+type CtxKey string
+
+const (
+	// CtxKeyCorrelationId is the key used for correlation ID in context.
+	CtxKeyCorrelationId CtxKey = "correlation-id"
+)
+
+// TransitWithCtxByKey creates a new context with the specified key-value pair, allowing transit of contextual information.
+// It takes an existing context, a key string, and a value of any type, and returns a new context with the added value.
+func TransitWithCtxByKey[T any](ctx context.Context, key CtxKey, value any) context.Context {
+	return context.WithValue(ctx, key, value)
+}
+
+// AcquireFromCtxByKey retrieves a value of type T from the context by the given key.
+// It returns the retrieved value and a boolean indicating whether the value was successfully retrieved.
+// If the value is not found or cannot be type-asserted to T, it returns the zero value of T and false.
+func AcquireFromCtxByKey[T any](ctx context.Context, key CtxKey) (T, bool) {
+	var retrievedValue T
+
+	value := ctx.Value(key)
+	if value == nil {
+		return retrievedValue, false
+	}
+
+	retrievedValue, ok := value.(T)
+	return retrievedValue, ok
+}


### PR DESCRIPTION
### Context:

As a user, I want to be able to explicitly pass the correlation ID with the context so that I can retrieve it on demand as and when needed.

As a user, I want to be able to specify a list of URIs for which I do not want to log request information, so that I can limit the number of throw-away log entries in my logs.

### What has been done:

- Updated `NewLogger` signature to accept an explicit ignore list that can be used in `HTTPLoggerWithCustomUriIgnoreList` middleware to 
- Added correlation ID context information, i.e. key, transit, and acquire methods, to the toolbox so that it can be referenced later
- Updated SPA handler to simplify how the function to handle the index file is passed

### How to test:

- `tbc`
