### PR TITLE
[GHATD-X] Update to use reply's errormap type and updated handlers/middleware to use provided errormap

### DIFF
--- a/external/accessmanager/errormap.go
+++ b/external/accessmanager/errormap.go
@@ -7,7 +7,7 @@ import (
 // AccessmanagerErrorMap holds Error keys, their corresponding human-friendly message, and response status code
 // TODO: remove nolint
 // nolint will be used later
-var AccessmanagerErrorMap = map[string]reply.ErrorManifestItem{
+var AccessmanagerErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyBadRequest:                                          {Title: "Bad Request", StatusCode: 400, Code: "AM00-001"},
 	ErrKeyInvalidUserBody:                                     {Title: "Bad Request", Detail: "Check submitted user information", StatusCode: 400, Code: "AM00-002"},
 	ErrKeyInvalidVerificationToken:                            {Title: "Bad Request", Detail: "User token missing or malformatted", StatusCode: 400, Code: "AM00-003"},

--- a/external/accessmanager/handler.go
+++ b/external/accessmanager/handler.go
@@ -64,8 +64,6 @@ type NewHandlerRequest struct {
 // NewHandler returns accessmanager handler
 func NewHandler(r *NewHandlerRequest) *Handler {
 
-	r.ErrorMaps = append(r.ErrorMaps, AccessmanagerErrorMap)
-
 	return &Handler{
 		Service:                  r.Service,
 		Validator:                r.Validator,

--- a/external/accessmanager/middleware/middleware.go
+++ b/external/accessmanager/middleware/middleware.go
@@ -50,12 +50,10 @@ type NewMiddlewareRequest struct {
 // NewMiddleware creates new accessmanager middleware
 func NewMiddleware(r *NewMiddlewareRequest) *Middleware {
 
-	errorMaps := append(r.ErrorMaps, accessmanager.AccessmanagerErrorMap)
-
 	return &Middleware{
 		newRelicApplication:      r.NewRelicConf,
 		service:                  r.Service,
-		errorMaps:                errorMaps,
+		errorMaps:                r.ErrorMaps,
 		cookiePrefixAuthToken:    r.CookiePrefixAuthToken,
 		cookiePrefixRefreshToken: r.CookiePrefixRefreshToken,
 		environment:              r.Environment,

--- a/external/apitoken/errormap.go
+++ b/external/apitoken/errormap.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ApitokenErrorMap holds Error keys, their corresponding human-friendly message, and response status code
-var ApitokenErrorMap = map[string]reply.ErrorManifestItem{
+var ApitokenErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyPageOutOfRange:               {Title: "Bad Request", Detail: "Page out of range", StatusCode: 400},
 	ErrKeyTokenStatusInvalid:           {Title: "Bad Request", Detail: "Please verify token status", StatusCode: 400},
 	ErrKeyNoMatchingUserAPITokenFound:  {Title: "Unauthorized", Code: "200", StatusCode: 401},

--- a/external/auth/errormap.go
+++ b/external/auth/errormap.go
@@ -6,7 +6,7 @@ import (
 
 // AuthErrorMap holds Error keys, their corresponding human-friendly message, and response status code
 // Use https://docs.microsoft.com/en-us/troubleshoot/iis/http-status-code to expand messages i.e. AccessDenied1
-var AuthErrorMap = map[string]reply.ErrorManifestItem{
+var AuthErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyUnauthorized:                             {Title: "Unauthorized", StatusCode: 401},
 	ErrKeyUnauthorizedNoTokenUUID:                  {Title: "Unauthorized", Code: "1", StatusCode: 401},
 	ErrKeyUnauthorizedNoUserIDFound:                {Title: "Unauthorized", Code: "2", StatusCode: 401},

--- a/external/contacter/errormap.go
+++ b/external/contacter/errormap.go
@@ -4,6 +4,6 @@ import "github.com/ooaklee/reply"
 
 // ContacterErrorMap holds Error keys, their corresponding human-friendly message, and response status code
 // nolint will be used later
-var ContacterErrorMap = map[string]reply.ErrorManifestItem{
+var ContacterErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyInvalidCommsPayload: {Title: "Bad Request", Detail: "Invalid comms payload", StatusCode: 400, Code: "CT00-01"},
 }

--- a/external/ephemeral/errormap.go
+++ b/external/ephemeral/errormap.go
@@ -7,6 +7,6 @@ import (
 // EphemeralStoreErrorMap holds Error keys, their corresponding human-friendly message, and response status code
 // TODO: remove nolint
 // nolint will be used later
-var EphemeralStoreErrorMap = map[string]reply.ErrorManifestItem{
+var EphemeralStoreErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyRequestorLimitExceeded: {Title: "Rate Limited", Detail: "You have used up allocated requests allowance; please try again later or verify you have authenticated yourself.", StatusCode: 429},
 }

--- a/external/logger/middleware/middleware_test.go
+++ b/external/logger/middleware/middleware_test.go
@@ -68,7 +68,7 @@ func TestMiddleware_HTTPLogger(t *testing.T) {
 			request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost%s", tt.clientReqURI), nil)
 			request.Header.Set("X-Correlation-Id", tt.clientReqCorrelationId)
 			response := httptest.NewRecorder()
-			handler := middleware.NewLogger(logger).HTTPLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler := middleware.NewLogger(logger, []string{}).HTTPLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 			}))
 

--- a/external/policy/errormap.go
+++ b/external/policy/errormap.go
@@ -6,7 +6,7 @@ import (
 
 // PolicyErrorMap holds Error keys, their corresponding human-friendly message, and response status code
 // nolint will be used later
-var PolicyErrorMap = map[string]reply.ErrorManifestItem{
+var PolicyErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyPolicyError:       {Title: "Bad Request", Detail: "Some policy error", StatusCode: 400, Code: "P0-001"},
 	ErrKeyPolicyNotFound:    {Title: "Not Found", Detail: "Policy not found", StatusCode: 404, Code: "P0-002"},
 	ErrKeyInvalidpolicyName: {Title: "Bad Request", Detail: "Invalid policy name", StatusCode: 400, Code: "P0-003"},

--- a/external/response/response.go
+++ b/external/response/response.go
@@ -12,7 +12,7 @@ const (
 	ErrKeyResourceNotFound = "DefaultResourceNotFound"
 )
 
-var defaultErrorMap = map[string]reply.ErrorManifestItem{
+var defaultErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyResourceNotFound: {Title: "Resource not found.", StatusCode: 404},
 }
 

--- a/external/spa/handler.go
+++ b/external/spa/handler.go
@@ -71,7 +71,7 @@ const (
 	ErrKeyResourceNotFound = "DefaultResourceNotFound"
 )
 
-var defaultErrorMap = map[string]reply.ErrorManifestItem{
+var defaultErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	// DefaultResourceNotFound is the default resource not found error
 	ErrKeyResourceNotFound: {Title: "Not Found", StatusCode: 404, Detail: "The requested resource could not be found", Code: "SPA0-001"},
 }

--- a/external/toolbox/paginator.go
+++ b/external/toolbox/paginator.go
@@ -17,8 +17,8 @@ const (
 )
 
 // GetResourcePaginationErrorMap holds Error keys, their corresponding human-friendly message, and response status code
-var GetResourcePaginationErrorMap = map[string]reply.ErrorManifestItem{
-	ErrKeyPageOutOfRange: {Title: "Bad Request", Detail: "Page out of range", StatusCode: 400},
+var GetResourcePaginationErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
+	ErrKeyPageOutOfRange: {Title: "Bad Request", Detail: "Page out of range", StatusCode: 400, Code: "TLBPG-001"},
 }
 
 // ResponseMetaKey is a string type used as the keys in the map returned

--- a/external/user/errormap.go
+++ b/external/user/errormap.go
@@ -6,7 +6,7 @@ import (
 
 // UserErrorMap holds Error keys, their corresponding human-friendly message, and response status code
 // Use https://docs.microsoft.com/en-us/troubleshoot/iis/http-status-code to expand messages i.e. AccessDenied1
-var UserErrorMap = map[string]reply.ErrorManifestItem{
+var UserErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyInvalidUserBody:         {Title: "Bad Request", Detail: "Check submitted user information.", StatusCode: 400},
 	ErrKeyInvalidUserID:           {Title: "Bad Request", Detail: "User ID missing or malformatted.", StatusCode: 400},
 	ErrKeyUserNeverActivated:      {Title: "Invalid User State", Detail: "User resource state conflicts with request.", StatusCode: 409},

--- a/external/usermanager/errormap.go
+++ b/external/usermanager/errormap.go
@@ -4,10 +4,10 @@ import (
 	"github.com/ooaklee/reply"
 )
 
-// usermanagerErrorMap holds Error keys, their corresponding human-friendly message, and response status code
+// UsermanagerErrorMap holds Error keys, their corresponding human-friendly message, and response status code
 // TODO: remove nolint
 // nolint will be used later
-var usermanagerErrorMap = map[string]reply.ErrorManifestItem{
+var UsermanagerErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
 	ErrKeyUserManagerError:        {Title: "Bad Request", Detail: "Some user manager related error.", StatusCode: 400, Code: "USM00-001"},
 	ErrKeyUnableToIdentifyUser:    {Title: "Unauthorized", Detail: "Please contact support.", StatusCode: 401, Code: "USM00-002"},
 	ErrKeyInvalidUserBody:         {Title: "Bad Request", Detail: "Check your submitted user information.", StatusCode: 400, Code: "USM00-003"},

--- a/external/usermanager/handler.go
+++ b/external/usermanager/handler.go
@@ -49,8 +49,6 @@ type NewHandlerRequest struct {
 // NewHandler returns usermanager handler
 func NewHandler(r *NewHandlerRequest) *Handler {
 
-	r.ErrorMaps = append(r.ErrorMaps, usermanagerErrorMap)
-
 	return &Handler{
 		Service:                  r.Service,
 		Validator:                r.Validator,


### PR DESCRIPTION
### Context:

**Related Link(s)**:  `N/A`

### What has been done:

- Set the errormap type explicitly to prepare for reply v2 update.
- Update handlers & middleware to use the provided errormaps instead of combining them with built-in ones, which is less flexible