### PR TITLE
[GHATD-X] add group package

### DIFF
--- a/docs/getting-started/billing-manager/README.md
+++ b/docs/getting-started/billing-manager/README.md
@@ -1,36 +1,36 @@
-# Getting Started With Billing Manager
+# Billing Manager
 
-The recommended billing functionality comes in the form of three independent, composable packages: [**paymentprovider**](../../../external/holder/paymentprovider/), [**billing**](../../../external/holder/billing/), and [**billingmanager**](../../../external/holder/billingmanager/). For most application features, you should use the high-level `billingmanager` package, which handles webhook processing, subscription management, and billing event tracking with integrated audit logging.
+The recommended billing functionality comes in three independent, composable packages: `paymentprovider`, `billing`, and `billingmanager`. For most application features, you should use the high-level `billingmanager` package, which handles webhook processing, subscription management, and billing event tracking with integrated audit logging.
 
 ## Core Packages Overview
 
-See below an overview of the core packages mentioned above:
+Here's an overview of the core packages:
 
-| Package | Purpose | Use Case (Recommended) | Examples Location |
-|---------|---------|------------------------|-------------------|
-| **`paymentprovider`** | Abstracts payment provider webhook verification and payload normalisation (e.g., Stripe, Lemon Squeezy, Ko-fi). | Building custom webhook handlers or testing provider integrations. | [external/holder/paymentprovider/examples](../../../external/holder/paymentprovider/examples/examples.go) |
-| **`billing`** | Manages subscription and billing event data persistence with repository pattern. | Direct database operations or building custom billing workflows. | [external/holder/billing/examples](../../../external/holder/billing/examples/examples.go) |
-| **`billingmanager`** | Orchestrates paymentprovider and billing with high-level API methods for webhook processing. | Building application features (Standard)—provides the full workflow and audit logging. | [external/holder/billingmanager/examples](../../../external/holder/billingmanager/examples/examples.go) |
+| Package | Purpose | Recommended Use Case | Examples |
+|---|---|---|---|
+| `paymentprovider` | Abstracts payment provider webhook verification and payload normalisation (e.g., Stripe, Lemon Squeezy). | Building custom webhook handlers or testing provider integrations. | [`paymentprovider/examples`](../../../external/paymentprovider/examples/examples.go) |
+| `billing` | Manages subscription and billing event data persistence with a repository pattern. | Direct database operations or building custom billing workflows. | [`billing/examples`](../../../external/billing/examples/examples.go) |
+| `billingmanager` | Orchestrates `paymentprovider` and `billing` with high-level API methods for webhook processing. | Building application features (Standard)—provides the full workflow and audit logging. | [`billingmanager/examples`](../../../external/billingmanager/examples/examples.go) |
 
 ### Usage Overview
 
-For a high-level overview of how this might fit into your GHAT(D) project, please [**visit this section**](#high-level-overview).
+For a high-level overview of how this might fit into your project, please [**visit this section**](#high-level-overview).
 
 ## Quick Start: Setup and Processing Webhooks
 
-In the following section we'll demonstrate how to set up the `billingmanager` and process payment provider webhooks, which is the recommended way to use the system for standard application operations. For more examples [please check out the reference examples above](#core-packages-overview).
+This section shows how to set up the `billingmanager` and process payment provider webhooks. This is the recommended way to use the system for standard operations. For more examples, [check out the reference examples above](#core-packages-overview).
 
 ### 1. Import Packages and Configure
 
-You'll need configuration for the `paymentprovider`, a `billing` service instance, and an [`audit` service](../../../external/audit/).
+You'll need configuration for the `paymentprovider`, a `billing` service instance, and an `audit` service.
 
 ```go
 import (
     "context"
     "net/http"
-    "github.com/ooaklee/ghatd/external/holder/paymentprovider"
-    "github.com/ooaklee/ghatd/external/holder/billing"
-    "github.com/ooaklee/ghatd/external/holder/billingmanager"
+    "github.com/ooaklee/ghatd/external/paymentprovider"
+    "github.com/ooaklee/ghatd/external/billing"
+    "github.com/ooaklee/ghatd/external/billingmanager"
 )
 
 // Assume auditService and userService are initialised dependencies
@@ -76,7 +76,7 @@ manager.WithUserService(userService)    // Optional: Enables email->user ID reso
 
 ### 2. Process Webhook
 
-You'll be able to use the high-level methods on the `billingmanager` to process incoming webhooks.
+You can use the high-level methods on the `billingmanager` to process incoming webhooks.
 
 ```go
 // 6. Process a webhook from a payment provider
@@ -148,7 +148,7 @@ for _, event := range eventsResp.Events {
 
 ### 4. Development Environment Setup
 
-If you don't want to use your payment provider's webhook endpoints when running locally, you can leverage the `MockProvider` to simulate webhook payloads for testing.
+If you don't want to use your payment provider's webhook endpoints when running locally, you can use the `MockProvider` to simulate webhook payloads for testing.
 
 ```go
 // Use mock provider for local development
@@ -175,7 +175,7 @@ manager := billingmanager.NewService(
 )
 ```
 
-> **Note on Environments:** You can also use the `LoggingProvider` wrapper to log webhook payloads for debugging without actually processing them in your billing system.
+> **Note on Environments:** You can also use the `LoggingProvider` wrapper to log webhook payloads for debugging without processing them in your billing system.
 
 ## Advanced Use Cases
 
@@ -210,7 +210,7 @@ subsResp, err := billingService.GetSubscriptions(ctx, &billing.GetSubscriptionsR
     Order:       "created_at_desc",
 })
 
-// Create billing events for audit trail
+// Create billing events for an audit trail
 eventResp, err := billingService.CreateBillingEvent(ctx, &billing.CreateBillingEventRequest{
     SubscriptionID:           "sub_123",
     IntegratorEventID:        "evt_stripe_456",
@@ -242,7 +242,7 @@ func (p *MyCustomProvider) VerifyWebhook(ctx context.Context, req *http.Request)
 }
 
 func (p *MyCustomProvider) ParsePayload(ctx context.Context, req *http.Request) (*paymentprovider.WebhookPayload, error) {
-    // Parse provider-specific payload into normalised format
+    // Parse provider-specific payload into a normalised format
     return &paymentprovider.WebhookPayload{
         EventType:      paymentprovider.EventTypePaymentSucceeded,
         SubscriptionID: "sub_from_provider",
@@ -266,7 +266,7 @@ manager := billingmanager.NewService(registry, billingService)
 
 ### Custom Repository Implementation
 
-You can implement custom repositories for different databases while maintaining the same service layer.
+You can implement custom repositories for different databases while keeping the same service layer.
 
 ```go
 // Implement the repository interfaces for your database
@@ -295,7 +295,7 @@ billingService := billing.NewService(postgresRepo, postgresRepo)
 
 ## High-level Overview
 
-See below high-level overviews of this billing solution (and its component packages) and a few examples of how it can be used in your GHAT(D) application for different use-cases.
+Here are some high-level overviews of this billing solution and its packages, with examples of how it can be used in your application for different use-cases.
 
 ### Usage Patterns
 
@@ -422,11 +422,11 @@ func SetupBillingRoutes(r *mux.Router, manager *billingmanager.Service) {
 
 #### Using AttachRoutes
 
-For a more comprehensive setup that includes all billing manager endpoints with proper middleware, use the `AttachRoutes` function:
+For a more comprehensive setup that includes all billing manager endpoints with the correct middleware, use the `AttachRoutes` function:
 
 ```go
 import (
-    "github.com/ooaklee/ghatd/external/holder/billingmanager"
+    "github.com/ooaklee/ghatd/external/billingmanager"
     "github.com/ooaklee/ghatd/external/router"
     "github.com/gorilla/mux"
 )
@@ -452,14 +452,14 @@ This sets up the following routes automatically:
 - `POST /api/v1/bms/billings/{providerName}/webhooks` - Process payment provider webhooks
 
 **Authenticated User Routes:**
-- `GET /api/v1/bms/billings/users/{userId}/events` - Get user's billing events
-- `GET /api/v1/bms/users/{userId}/details/subscription` - Get user's subscription status
-- `GET /api/v1/bms/users/{userId}/details/billing` - Get user's billing details
+- `GET /api/v1/bms/billings/users/{userId}/events` - Get a user's billing events.
+- `GET /api/v1/bms/users/{userId}/details/subscription` - Get a user's subscription status.
+- `GET /api/v1/bms/users/{userId}/details/billing` - Get a user's billing details.
 
 **Admin Only Routes:**
-- `GET /api/v1/bms/admin/billings/users/{userId}/events` - Get any user's billing events
-- `GET /api/v1/bms/admin/users/{userId}/details/subscription` - Get any user's subscription status
-- `GET /api/v1/bms/admin/users/{userId}/details/billing` - Get any user's billing details
+- `GET /api/v1/bms/admin/billings/users/{userId}/events` - Get any user's billing events.
+- `GET /api/v1/bms/admin/users/{userId}/details/subscription` - Get any user's subscription status.
+- `GET /api/v1/bms/admin/users/{userId}/details/billing` - Get any user's billing details.
 
 ## Subscription Lifecycle
 
@@ -484,30 +484,30 @@ Understanding the subscription lifecycle helps you work effectively with the bil
    │
 4. Subscription Management
    │
-   ├──► Create new subscription (if first event)
-   ├──► Update existing subscription (status, dates, etc.)
+   ├──► Create a new subscription (if it's the first event)
+   ├──► Update an existing subscription (status, dates, etc.)
    │
 5. Event Recording
    │
-   ├──► Create billing event for audit trail
+   ├──► Create a billing event for the audit trail
    │
 6. Audit Logging (Optional)
    │
-   └──► Log to audit service
+   └──► Log to the audit service
 ```
 
 ### Subscription States
 
 The billing system tracks various subscription states:
 
-- **`active`** - Subscription is active and in good standing
-- **`trialing`** - Subscription is in trial period
-- **`past_due`** - Payment failed but subscription still active
-- **`cancelled`** - Subscription has been cancelled
-- **`paused`** - Subscription is temporarily paused
-- **`expired`** - Subscription has expired
-- **`incomplete`** - Subscription setup incomplete
-- **`unpaid`** - Subscription unpaid
+- **`active`** - The subscription is active and in good standing.
+- **`trialing`** - The subscription is in a trial period.
+- **`past_due`** - Payment has failed, but the subscription is still active.
+- **`cancelled`** - The subscription has been cancelled.
+- **`paused`** - The subscription is temporarily paused.
+- **`expired`** - The subscription has expired.
+- **`incomplete`** - The subscription setup is incomplete.
+- **`unpaid`** - The subscription is unpaid.
 
 ## Authorisation & Security
 
@@ -525,7 +525,7 @@ statusResp, err := manager.GetUserSubscriptionStatus(ctx, &billingmanager.GetUse
 // Admin querying another user's subscription (requires admin role via UserService)
 statusResp, err := manager.GetUserSubscriptionStatus(ctx, &billingmanager.GetUserSubscriptionStatusRequest{
     UserID:           "user-456",
-    RequestingUserID: "admin-user-123", // Must be admin
+    RequestingUserID: "admin-user-123", // Must be an admin
 })
 ```
 
@@ -533,9 +533,9 @@ statusResp, err := manager.GetUserSubscriptionStatus(ctx, &billingmanager.GetUse
 
 Each provider has its own webhook verification mechanism:
 
-- **Stripe**: HMAC-SHA256 signature verification
-- **Lemon Squeezy**: HMAC-SHA256 signature verification
-- **Ko-fi**: Verification token validation
+- **Stripe**: HMAC-SHA256 signature verification.
+- **Lemon Squeezy**: HMAC-SHA256 signature verification.
+- **Ko-fi**: Verification token validation.
 
 The `paymentprovider` package handles all verification automatically before processing webhooks.
 
@@ -546,8 +546,8 @@ The `paymentprovider` package handles all verification automatically before proc
 ```go
 import (
     "testing"
-    "github.com/ooaklee/ghatd/external/holder/paymentprovider"
-    "github.com/ooaklee/ghatd/external/holder/billing"
+    "github.com/ooaklee/ghatd/external/paymentprovider"
+    "github.com/ooaklee/ghatd/external/billing"
 )
 
 func TestWebhookProcessing(t *testing.T) {
@@ -597,18 +597,18 @@ func TestSubscriptionLifecycle(t *testing.T) {
     
     provider, _ := paymentprovider.NewStripeProvider(stripeConfig)
     
-    // Use MongoDB test database
+    // Use a MongoDB test database
     mongoRepo := billing.NewRepository(mongoStore)
     billingService := billing.NewService(mongoRepo, mongoRepo)
     
-    // Test full webhook flow
+    // Test the full webhook flow
     // ...
 }
 ```
 
 ## Potential Future Improvements
 
-Below is a list of areas for improvement in future iterations of `billingmanager`, `billing`, and `paymentprovider`. Please note that these suggestions are not prioritised.
+Here's a list of areas for improvement in future iterations of `billingmanager`, `billing`, and `paymentprovider`. Please note that these suggestions are not prioritised.
 
 ### Additional Providers
 - [ ] Paddle provider

--- a/docs/getting-started/billing/README.md
+++ b/docs/getting-started/billing/README.md
@@ -1,4 +1,4 @@
-# Billing Package
+# Billing
 
 The `billing` package (`external/billing`) gives you the tools for core subscription and billing event management, with MongoDB persistence. It acts as the data layer for your billing system, handling how you store, retrieve, and manage subscriptions and billing events, using optimised indexes for better performance.
 

--- a/docs/getting-started/billing/README.md
+++ b/docs/getting-started/billing/README.md
@@ -1,8 +1,6 @@
-# Billing Package Documentation
+# Billing Package
 
-## Overview
-
-The `billing` package (`external/billing`) provides core subscription and billing event management with MongoDB persistence. It forms the data layer of the billing system, handling storage, retrieval, and management of subscriptions and billing events with optimised indexes for performance.
+The `billing` package (`external/billing`) gives you the tools for core subscription and billing event management, with MongoDB persistence. It acts as the data layer for your billing system, handling how you store, retrieve, and manage subscriptions and billing events, using optimised indexes for better performance.
 
 ## Table of Contents
 
@@ -17,35 +15,35 @@ The `billing` package (`external/billing`) provides core subscription and billin
 ## Key Features
 
 ### 1. **Email-Based Subscriptions**
-Subscriptions can be created with just an email address, enabling pre-registration purchases:
-- Users can purchase before signing up
-- Automatic association when user creates account
-- Orphan subscription management tools
+Create subscriptions with just an email address, allowing for pre-registration purchases:
+- Users can purchase before signing up.
+- Automatic association when a user creates an account.
+- Tools for managing orphan subscriptions.
 
 ### 2. **Optimised MongoDB Indexes**
-Purpose-built indexes for efficient queries:
-- Standard user/email lookups
-- Partial indexes for orphaned subscriptions
-- Unique constraints preventing duplicates
-- Time-based sorting and filtering
+Comes with purpose-built indexes for efficient queries:
+- Standard user/email lookups.
+- Partial indexes for orphaned subscriptions.
+- Unique constraints to prevent duplicates.
+- Time-based sorting and filtering.
 
 ### 3. **Dual Repository Pattern**
-Flexible data access with two implementations:
-- **MongoDbStore**: Production-ready MongoDB persistence
-- **InMemoryRepositoryStore**: Testing and development
+A flexible data access layer with two implementations:
+- **MongoDbStore**: Production-ready MongoDB persistence.
+- **InMemoryRepositoryStore**: For testing and development.
 
 ### 4. **Comprehensive Event Tracking**
-Every billing action is recorded:
-- Payment events
-- Subscription changes
-- Status updates
-- Full audit trail
+Records every billing action:
+- Payment events.
+- Subscription changes.
+- Status updates.
+- A full audit trail.
 
 ## Architecture
 
 ### Service Layer
 
-The billing service provides business logic and orchestration:
+The billing service holds the business logic and orchestration:
 
 ```
 Application
@@ -83,16 +81,16 @@ Application
 
 The billing package uses two MongoDB collections:
 
-1. **`billing_subscriptions`** - Subscription records
-2. **`billing_events`** - Billing event history
+1. **`billing_subscriptions`** - Stores subscription records.
+2. **`billing_events`** - Holds the billing event history.
 
 ## MongoDB Setup
 
 ### Prerequisites
 
-- MongoDB 4.2 or higher
-- mongo-migrate library: `github.com/xakep666/mongo-migrate`
-- Go mongo driver: `go.mongodb.org/mongo-driver/mongo`
+- MongoDB 4.2 or higher.
+- `mongo-migrate` library: `github.com/xakep666/mongo-migrate`.
+- Go mongo driver: `go.mongodb.org/mongo-driver/mongo`.
 
 ### Installing Dependencies
 
@@ -103,7 +101,7 @@ go get go.mongodb.org/mongo-driver/mongo
 
 ### Running Migrations
 
-Create a migration runner to set up indexes:
+Create a migration runner to set up the indexes:
 
 ```go
 package main
@@ -185,11 +183,11 @@ Five indexes are created for the `billing_subscriptions` collection:
 
 | Index Name | Fields | Type | Purpose | Example Query |
 |------------|--------|------|---------|---------------|
-| `idx_subscriptions_user_id` | `user_id` | Standard | Fetch all subscriptions for a user | `db.billing_subscriptions.find({user_id: "user-123"})` |
-| `idx_subscriptions_email` | `email` | Standard | Query subscriptions by email | `db.billing_subscriptions.find({email: "user@example.com"})` |
-| `idx_subscriptions_email_no_user` | `email` | Partial | Find orphaned subscriptions (no user ID) | `db.billing_subscriptions.find({email: "user@example.com", user_id: {$in: ["", null]}})` |
-| `idx_subscriptions_integrator` | `integrator`, `integrator_subscription_id` | Unique Compound | Prevent duplicate subscriptions from same provider | Used internally by MongoDB for uniqueness |
-| `idx_subscriptions_created_at` | `created_at` | Standard (Descending) | Sort/filter by date | `db.billing_subscriptions.find().sort({created_at: -1})` |
+| `idx_subscriptions_user_id` | `user_id` | Standard | Fetch all subscriptions for a user. | `db.billing_subscriptions.find({user_id: "user-123"})` |
+| `idx_subscriptions_email` | `email` | Standard | Query subscriptions by email. | `db.billing_subscriptions.find({email: "user@example.com"})` |
+| `idx_subscriptions_email_no_user` | `email` | Partial | Find orphaned subscriptions (no user ID). | `db.billing_subscriptions.find({email: "user@example.com", user_id: {$in: ["", null]}})` |
+| `idx_subscriptions_integrator` | `integrator`, `integrator_subscription_id` | Unique Compound | Prevent duplicate subscriptions from the same provider. | Used internally by MongoDB for uniqueness. |
+| `idx_subscriptions_created_at` | `created_at` | Standard (Descending) | Sort/filter by date. | `db.billing_subscriptions.find().sort({created_at: -1})` |
 
 **Partial Index Details:**
 
@@ -213,10 +211,10 @@ Four indexes are created for the `billing_events` collection:
 
 | Index Name | Fields | Type | Purpose | Example Query |
 |------------|--------|------|---------|---------------|
-| `idx_billing_events_user_id` | `user_id` | Standard | Fetch event history for a user | `db.billing_events.find({user_id: "user-123"})` |
-| `idx_billing_events_email` | `email` | Standard | Query events by email | `db.billing_events.find({email: "user@example.com"})` |
-| `idx_billing_events_subscription_id` | `integrator_subscription_id` | Standard | Get all events for a subscription | `db.billing_events.find({integrator_subscription_id: "sub-123"})` |
-| `idx_billing_events_created_at` | `created_at` | Standard (Descending) | Sort/filter by date | `db.billing_events.find().sort({created_at: -1})` |
+| `idx_billing_events_user_id` | `user_id` | Standard | Fetch event history for a user. | `db.billing_events.find({user_id: "user-123"})` |
+| `idx_billing_events_email` | `email` | Standard | Query events by email. | `db.billing_events.find({email: "user@example.com"})` |
+| `idx_billing_events_subscription_id` | `integrator_subscription_id` | Standard | Get all events for a subscription. | `db.billing_events.find({integrator_subscription_id: "sub-123"})` |
+| `idx_billing_events_created_at` | `created_at` | Standard (Descending) | Sort/filter by date. | `db.billing_events.find().sort({created_at: -1})` |
 
 ### Verifying Indexes
 
@@ -265,22 +263,22 @@ go run cmd/mongo-migrator/migrator.go down 1
 
 ### Overview
 
-The billing package supports subscriptions without a user ID, enabling pre-registration purchases. This allows users to purchase subscriptions before creating an account.
+The billing package supports subscriptions without a user ID, enabling pre-registration purchases. This allows users to buy subscriptions before creating an account.
 
 ### Core Concept
 
 **Subscription States:**
 
-1. **Orphaned**: `UserID=""`, `Email="user@example.com"` (pre-registration)
-2. **Associated**: `UserID="user-123"`, `Email="user@example.com"` (after signup)
+1. **Orphaned**: `UserID=""`, `Email="user@example.com"` (pre-registration).
+2. **Associated**: `UserID="user-123"`, `Email="user@example.com"` (after signup).
 
 ### Flow Diagram
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  1. Pre-Registration Purchase                               │
-│     User purchases without account                          │
-│     Webhook creates subscription with email only            │
+│     User purchases without an account                       │
+│     Webhook creates a subscription with email only          │
 └────────────────────────┬────────────────────────────────────┘
                          │
                          ▼
@@ -298,8 +296,8 @@ The billing package supports subscriptions without a user ID, enabling pre-regis
                          ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  2. User Signs Up                                           │
-│     User creates account with same email                    │
-│     accessmanager calls AssociateSubscriptionsWithUser      │
+│     User creates an account with the same email             │
+│     `accessmanager` calls `AssociateSubscriptionsWithUser`  │
 └────────────────────────┬────────────────────────────────────┘
                          │
                          ▼
@@ -320,26 +318,26 @@ The billing package supports subscriptions without a user ID, enabling pre-regis
 **1. Pre-Launch Sales**
 ```
 Marketing campaign before platform launch
-→ Users purchase early bird subscriptions
+→ Users purchase early-bird subscriptions
 → Platform launches
 → Users sign up
-→ Subscriptions automatically associated
+→ Subscriptions are automatically associated
 ```
 
 **2. Gift Subscriptions**
 ```
-Alice buys subscription for bob@example.com
-→ Bob doesn't have account yet
-→ Subscription stored with email
+Alice buys a subscription for bob@example.com
+→ Bob doesn't have an account yet
+→ Subscription is stored with the email
 → Bob signs up weeks later
-→ Gets subscription automatically
+→ Gets the subscription automatically
 ```
 
 **3. Corporate Bulk Purchases**
 ```
-Company admin buys 10 licenses
-→ Provides list of employee emails
-→ Subscriptions created for each email
+A company admin buys 10 licenses
+→ Provides a list of employee emails
+→ Subscriptions are created for each email
 → Employees sign up at their convenience
 → Each gets their subscription
 ```
@@ -348,7 +346,7 @@ Company admin buys 10 licenses
 
 #### Query by Email
 
-Retrieve subscriptions before user account exists:
+Retrieve subscriptions before a user account exists:
 
 ```go
 // Get all subscriptions for an email (regardless of user_id)
@@ -401,7 +399,7 @@ for _, event := range response.Events {
 Manually link email-based subscriptions to a user:
 
 ```go
-// When user signs up or when you want to manually associate
+// When a user signs up or when you want to manually associate
 result, err := billingService.AssociateSubscriptionsWithUser(ctx, 
     &billing.AssociateSubscriptionsWithUserRequest{
         UserID: "user-123",
@@ -525,24 +523,24 @@ db.billing_subscriptions.aggregate([
 ### Best Practices
 
 **1. Email Normalisation**
-- Emails are automatically converted to lowercase
-- Ensures consistent matching between purchase and signup
-- No manual normalisation required
+- Emails are automatically converted to lowercase.
+- This ensures consistent matching between purchase and signup.
+- No manual normalisation is required.
 
 **2. Monitoring**
-- Set up alerts for subscriptions orphaned > 30 days
-- Track conversion rate from orphaned to associated
-- Monitor by provider and date range
+- Set up alerts for subscriptions orphaned for more than 30 days.
+- Track the conversion rate from orphaned to associated.
+- Monitor by provider and date range.
 
 **3. User Experience**
-- Show "You have a pending subscription" message on signup page if email matches orphaned subscription
-- Send reminder emails to users with orphaned subscriptions
-- Provide clear instructions for claiming subscriptions
+- Show a "You have a pending subscription" message on the signup page if the email matches an orphaned subscription.
+- Send reminder emails to users with orphaned subscriptions.
+- Provide clear instructions for claiming subscriptions.
 
 **4. Administrative Tools**
-- Build admin dashboard showing orphaned subscriptions
-- Allow manual association via UI
-- Export orphaned subscriptions for analysis
+- Build an admin dashboard showing orphaned subscriptions.
+- Allow manual association via the UI.
+- Export orphaned subscriptions for analysis.
 
 ## Service Methods
 
@@ -559,7 +557,7 @@ response, err := billingService.CreateSubscription(ctx,
     &billing.CreateSubscriptionRequest{
         IntegratorSubscriptionID: "stripe_sub_abc123",
         Integrator:               "stripe",
-        UserID:                   "user-123",     // Can be empty for pre-reg
+        UserID:                   "user-123",     // Can be empty for pre-registration
         Email:                    "user@example.com",
         PlanName:                 "Pro Plan",
         Status:                   billing.StatusActive,

--- a/docs/getting-started/email-manager/README.md
+++ b/docs/getting-started/email-manager/README.md
@@ -1,33 +1,33 @@
-# Getting Started With Email Manager
+# Email Manager
 
-The recommended email functionality comes in the form of three independent, composable packages: [**emailtemplater**](../../../external/emailtemplater/), [**emailprovider**](../../../external/emailprovider/), and [**emailmanager](../../../external/emailmanager/). For most application features, you should use the high-level `emailmanager` package, which handles both templating and sending with integrated audit logging. 
+The recommended email functionality comes in three independent, composable packages: `emailtemplater`, `emailprovider`, and `emailmanager`. For most application features, you should use the high-level `emailmanager` package, which handles both templating and sending with integrated audit logging.
 
 ## Core Packages Overview
 
-See below an overview of the core packages mentioned above
+Here's an overview of the core packages:
 
-
-|Package |	Purpose	Use Case (Recommended) | Examples Location |
-|**`emailtemplater`** |	Generates HTML email templates (e.g., login, verification, and custom) with variable substitution.	Generating email previews or testing template rendering.	| [external/emailtemplater/examples](../../../external/emailtemplater/examples/examples.go) |
-|**`emailprovider`**	| Abstracts the logic for sending an email through a service (e.g., SparkPost).	Sending pre-rendered HTML or custom email workflows.	| [external/emailprovider/examples](../../../external/emailprovider/examples/examples.go) |
-|**`emailmanager`**	| Orchestrates the templater and emailprovider with high-level API methods.	Building application features (Standard)—provides the full workflow and audit logging.	| [external/emailmanager/examples](../../../external/emailmanager/examples/examples.go) |
+| Package | Purpose | Recommended Use Case | Examples |
+|---|---|---|---|
+| `emailtemplater` | Generates HTML email templates (e.g., login, verification) with variable substitution. | Generating email previews or testing template rendering. | [`emailtemplater/examples`](../../../external/emailtemplater/examples/examples.go) |
+| `emailprovider` | Abstracts the logic for sending an email through a service (e.g., SparkPost). | Sending pre-rendered HTML or custom email workflows. | [`emailprovider/examples`](../../../external/emailprovider/examples/examples.go) |
+| `emailmanager` | Orchestrates the templater and email provider with high-level API methods. | Building application features (Standard)—provides the full workflow and audit logging. | [`emailmanager/examples`](../../../external/emailmanager/examples/examples.go) |
 
 ### Usage Overview
 
-For a high-level overview of how this might fit into your GHAT(D) project, please [**visit this section**.](#high-level-overview).
+For a high-level overview of how this might fit into your project, please [**visit this section**](#high-level-overview).
 
 ## Quick Start: Setup and Sending
 
-In the following section we'll demonstrate how to set up the `emailmanager` and send a verification email, which is the recommended way to use the  system for standard application operations, for more examples [please check out the reference examples above](#core-packages-overview).
+This section shows how to set up the `emailmanager` and send a verification email. This is the recommended way to use the system for standard operations. For more examples, [check out the reference examples above](#core-packages-overview).
 
 ### 1. Import Packages and Configure
 
-You'll need configuration for the `emailtemplater`, an `emailprovider` instance, and an [`audit` service](../../../external/audit/).
+You'll need configuration for the `emailtemplater`, an `emailprovider` instance, and an [`audit` service](../../../external/audit).
 
 ```go
 import (
     "context"
-    "github.com/ooaklee/ghatd/external/templater"
+    "github.com/ooaklee/ghatd/external/emailtemplater"
     "github.com/ooaklee/ghatd/external/emailprovider"
     "github.com/ooaklee/ghatd/external/emailmanager"
 )
@@ -56,7 +56,7 @@ templaterConfig := &emailtemplater.Config{
 			emailtemplater.EmailTemplateTypeBase: templates.NewBaseHtmlEmailTemplate,
 		},
 	}
-tmpltr := templater.NewEmailTemplater(templaterConfig)
+tmpltr := emailtemplater.NewEmailTemplater(templaterConfig)
 
 // 2. Create email provider (using SparkPost for Production)
 provider := emailprovider.NewSparkPostEmailProvider(sparkpostClient)
@@ -70,7 +70,7 @@ manager := emailmanager.NewEmailManager(tmpltr, provider, auditService, &emailma
 
 ### 2. Send an Email
 
-You'll be able to use the high-level methods on the `emailmanager`.
+You can use the high-level methods on the `emailmanager`.
 
 ```go
 // 4. Send a verification email
@@ -92,17 +92,16 @@ if err != nil {
 
 ### 3. Development Environment Setup
 
-If you don't want to use your email providers allowance when running your code locally, you can also leverage the `LoggingEmailProvider` to log the email content instead of actually sending it via an external API like `SparkPost`.
-
+If you don't want to use your email provider's allowance when running your code locally, you can use the `LoggingEmailProvider` to log the email content instead of sending it.
 
 ```go
 // Use logging provider to see emails in logs instead of sending
 provider := emailprovider.NewLoggingEmailProvider(&emailprovider.LoggingEmailProviderConfig{
-    DisableFullHtmlBodyPreview: false, // The login and verification token by default contain the token/ magic link url for you to sign in
+    DisableFullHtmlBodyPreview: false, // The login and verification token by default contain the token/magic link URL for you to sign in
 }) 
 
 manager := emailmanager.NewEmailManager(
-    templater.NewEmailTemplater(templaterConfig),
+    emailtemplater.NewEmailTemplater(templaterConfig),
     provider,
     auditService,
     &emailmanager.Config{
@@ -114,7 +113,6 @@ manager := emailmanager.NewEmailManager(
 
 > **Note on Environments:** The `emailtemplater` is also **environment-aware**; for example, setting the `Environment` config to `"staging"` will add `[staging]` to the email subject line.
 
-
 ## Advanced Use Cases
 
 While `emailmanager` is recommended, the packages can be used independently for specialised needs.
@@ -123,10 +121,9 @@ While `emailmanager` is recommended, the packages can be used independently for 
 
 You can generate the HTML body without sending an email.
 
-
 ```go
 // Use templater alone
-rendered, err := tmpltr.GenerateVerificationEmail(&templater.GenerateVerificationEmailRequest{
+rendered, err := tmpltr.GenerateVerificationEmail(&emailtemplater.GenerateVerificationEmailRequest{
     FirstName: "Test",
     // ...
 })
@@ -136,7 +133,6 @@ rendered, err := tmpltr.GenerateVerificationEmail(&templater.GenerateVerificatio
 ### Custom Provider
 
 Adding a new provider (e.g., SendGrid, AWS SES) only requires implementing the `emailprovider.EmailProvider` interface and integrating it with the `emailmanager`.
-
 
 ```go
 type MyCustomProvider struct{}
@@ -163,7 +159,7 @@ manager := emailmanager.NewEmailManager(tmpl, provider, audit, config)
 
 ## High-level Overview
 
-See below high-level overviews of this email solution (and its component packages) and a few examples of how it can be used in your GHATD application or different use-cases.
+Here are some high-level overviews of this email solution and its packages, with examples of how it can be used in your application for different use-cases.
 
 ### Usage Patterns
 
@@ -206,7 +202,6 @@ Application Code
        │         ▼
        └──► emailprovider ──► Send when ready
 ```
-
 
 ### Environment Usage & Outputs Flow
 
@@ -259,7 +254,7 @@ Application Code
 
 ## Potential Future Improvements
 
-Below is a list of areas for improvement in future iterations of `emailmanager`, `emailtemplater`, and `emailprovider`. Please note that these suggestions are not prioritised.
+Here's a list of areas for improvement in future iterations of `emailmanager`, `emailtemplater`, and `emailprovider`. Please note that these suggestions are not prioritised.
 
 ### Additional Providers
 - [ ] SendGrid provider
@@ -272,7 +267,7 @@ Below is a list of areas for improvement in future iterations of `emailmanager`,
 - [ ] Email templating with layouts
 - [ ] Multi-language support
 - [ ] Email preview generation
-- [ ] Batch sending optimization
+- [ ] Batch sending optimisation
 - [ ] Rate limiting
 - [ ] Retry mechanisms
 - [ ] Email queueing

--- a/docs/getting-started/group/README.md
+++ b/docs/getting-started/group/README.md
@@ -1,0 +1,157 @@
+# Group Package Getting Started
+
+The `group` package provides a robust and flexible system for managing user groups, teams, organisations, and other collections. It is built with a "universal model" approach, allowing a single data structure to represent various types of groups with support for hierarchical nesting.
+
+This guide will walk you through the architecture, setup, and common use cases of the `group` package.
+
+## Architecture
+
+The package follows a standard layered architecture common throughout this project:
+
+1.  **Routes (`routes.go`)**: Defines the HTTP API endpoints (e.g., `POST /v1/groups`, `GET /v1/groups/{id}`). It maps URLs to specific handlers.
+2.  **Handler (`handler.go`)**: Receives HTTP requests, parses them, and validates input. It acts as the bridge between the transport layer (HTTP) and the business logic.
+3.  **Fender (`fender.go`)**: An authorisation layer that checks if the authenticated user has the necessary permissions to perform an action on a group.
+4.  **Service (`service.go`)**: Contains the core business logic. It orchestrates operations like creating, updating, and retrieving groups, and it interacts with the repository.
+5.  **Repository (`repository.go`)**: The data access layer. It is responsible for all database operations (Create, Read, Update, Delete) for the `groups` collection in MongoDB.
+6.  **Model (`model.go`)**: Defines the `UniversalGroup` data structure and its associated helper methods. This is the core entity of the package.
+
+## MongoDB Setup & Migrations
+
+The `group` package relies on a MongoDB collection named `groups`. To ensure optimal query performance, a set of database indexes must be created.
+
+### Initial Indexes
+
+The initial migration script, located at `external/group/migrations/indexes_groups.go`, creates 19 indexes to support the various query patterns used by the repository. These include:
+
+-   **Unique Indexes**: To enforce uniqueness on `_id` and `_nano_id`.
+-   **Standard Indexes**: On individual fields like `name`, `type`, `status`, and `metadata.created_at` for efficient filtering and sorting.
+-   **Compound Indexes**: For common multi-field queries, such as filtering by type and status simultaneously.
+-   **Member & Leadership Indexes**: To quickly find groups based on their members (`members.id`), owner (`leadership.owner_id`), or other leadership roles.
+-   **Text Index**: A text index on `name` and `display_info.name_aliases` to enable full-text search capabilities.
+
+### Running Migrations
+
+To apply these indexes, you must integrate the provided migration functions into your application's startup process using a migration tool like `mongo-migrate`.
+
+The migration provides two key functions:
+
+-   `InitGroupsIndexesUp(db *mongo.Database) error`: Creates all 19 indexes on the `groups` collection.
+-   `InitGroupsIndexesDown(db *mongo.Database) error`: Drops all indexes created by the `Up` function.
+
+**Example Integration:**
+
+```go
+// In your main application setup
+import (
+    "github.com/xakep666/mongo-migrate"
+    groupMigrations "github.com/ooaklee/ghatd/external/group/migrations"
+)
+
+func main() {
+    // ... database connection setup ...
+    db := client.Database("your_db_name")
+    migrate.SetDatabase(db)
+
+    // Add the group migrations
+    migrate.Add(migrate.NewMigration(
+        "initial_groups_indexes",
+        groupMigrations.InitGroupsIndexesUp,
+        groupMigrations.InitGroupsIndexesDown,
+    ))
+
+    // Apply migrations
+    if err := migrate.Up(migrate.AllAvailable); err != nil {
+        log.Fatalf("Migration failed: %v", err)
+    }
+}
+```
+
+## API Endpoints
+
+The following are the primary API endpoints provided by the `group` service.
+
+-   `POST /v1/groups`: Create a new group.
+-   `GET /v1/groups`: Retrieve a paginated list of groups with filtering and sorting options.
+-   `GET /v1/groups/{id}`: Get a single group by its ID.
+-   `PUT /v1/groups/{id}`: Update a group's details.
+-   `DELETE /v1/groups/{id}`: Delete a group.
+-   `POST /v1/groups/{id}/members`: Add a member to a group.
+-   `DELETE /v1/groups/{id}/members/{memberId}`: Remove a member from a group.
+
+## Using the Model (`UniversalGroup`)
+
+The `UniversalGroup` model is the heart of the package. It is designed to be used both within the service and potentially in other parts of your application.
+
+### Creating a New Group
+
+Always use the `NewUniversalGroup` constructor to ensure all dependencies are injected correctly.
+
+```go
+import (
+    "github.com/ooaklee/ghatd/external/group"
+    "github.com/ooaklee/ghatd/external/toolbox"
+)
+
+// Setup dependencies (typically done once)
+config := group.DefaultGroupConfig()
+idGen := toolbox.NewIDGenerator()
+timeProvider := toolbox.NewTimeProvider()
+stringUtils := toolbox.NewStringUtils()
+
+// Create a new group
+g := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+g.Name = "My Awesome Team"
+g.Type = group.GroupTypeTeam
+g.SetInitialState() // Sets ID, NanoID, default status, and timestamps
+
+// The group is now ready to be saved to the database.
+if err := g.Validate(); err != nil {
+    // Handle validation error
+}
+```
+
+### Modifying an Existing Group
+
+When you retrieve a group from the database, you must re-inject its dependencies to use its methods safely.
+
+```go
+// Assume 'existingGroup' is loaded from MongoDB
+var existingGroup group.UniversalGroup
+// ... unmarshal from BSON ...
+
+// Set dependencies before using methods
+existingGroup.SetDependencies(config, idGen, timeProvider, stringUtils)
+
+// Now you can safely use methods
+existingGroup.AddMember("user-123", group.MemberTypeUser, group.MemberRoleAdmin)
+existingGroup.SetUpdatedAtNow()
+```
+
+### Key Model Features
+
+-   **Hierarchical Nesting**: Add a group as a member of another group by using `MemberTypeGroup`. The model prevents circular references.
+
+-   **Flexible Membership**: Members can be users (`MemberTypeUser`) or other groups (`MemberTypeGroup`). Each member is assigned a role, such as:
+    -   `MemberRoleOwner`
+    -   `MemberRoleAdmin`
+    -   `MemberRoleMember`
+    -   `MemberRoleModerator`
+    -   `MemberRoleGuest`
+
+-   **Custom Data**: Use `SetExtension(key, value)` to store any project-specific data on a group.
+
+-   **Status Control**: Use `UpdateStatus(newStatus)` to safely transition between states. The model supports several built-in statuses:
+    -   `GroupStatusActive`
+    -   `GroupStatusInactive`
+    -   `GroupStatusArchived`
+    -   `GroupStatusSuspended`
+    -   `GroupStatusProvisioned`
+
+-   **Configuration**: Create a `CustomGroupConfig` to define your own valid group types, status transitions, and required fields. The package includes many default types:
+    -   `GroupTypeTeam`
+    -   `GroupTypeDepartment`
+    -   `GroupTypeOrganization`
+    -   `GroupTypeProject`
+    -   `GroupTypeCommunity`
+
+-   **Rich Metadata**: The model includes dedicated structures for `DisplayInfo` (description, avatar), `Leadership` (owner, head), `Settings` (visibility, max members), and `Integrations` (e.g., Slack).

--- a/docs/getting-started/group/README.md
+++ b/docs/getting-started/group/README.md
@@ -1,4 +1,4 @@
-# Group Package Getting Started
+# Group
 
 The `group` package provides a robust and flexible system for managing user groups, teams, organisations, and other collections. It is built with a "universal model" approach, allowing a single data structure to represent various types of groups with support for hierarchical nesting.
 

--- a/docs/getting-started/router/README.md
+++ b/docs/getting-started/router/README.md
@@ -1,20 +1,20 @@
-# Router Package
+# Router
 
-The `router` package provides a standardised, project-specific wrapper around the `gorilla/mux` router. It is designed to simplify the setup of common application-level routing concerns, such as default handlers, middleware, and authentication endpoints.
+The `router` package provides a standardised, project-specific wrapper around `gorilla/mux`. It's designed to simplify setting up common application-level routing concerns, like default handlers, middleware, and authentication endpoints.
 
 ## Architecture
 
 -   **`router.go`**: Contains the `Router` struct and the `NewRouter` constructor. It initialises a `mux.Router` and applies any provided default handlers or global middleware.
--   **`handler.go`**: Provides handlers for common, cross-cutting concerns. A key example is the `NewAuthVerifyHandler`, which manages the redirection flow for email and login verification links.
+-   **`handler.go`**: Provides handlers for common, cross-cutting concerns. A key example is `NewAuthVerifyHandler`, which manages the redirection flow for email and login verification links.
 -   **`const.go`**: Defines constant URI paths for shared endpoints like health checks (`/v0/health/check`) and authentication verification (`/v0/auth/verify`).
 
 ## Getting Started
 
-The following example demonstrates how to initialise the `ghatdRouter`, configure it with default handlers and middleware, and attach a verification endpoint.
+The following example shows how to initialise the `ghatdRouter`, configure it with default handlers and middleware, and attach a verification endpoint.
 
 ### Example Initialisation
 
-This setup is typically performed once in your application's `main` function or wherever you configure your HTTP server.
+This setup is typically done once in your application's `main` function or wherever you configure your HTTP server.
 
 ```go
 package main
@@ -75,7 +75,7 @@ func main() {
 	// 4. Add Application-Specific Handlers
 	// The AuthVerifyEndpoint is a special handler for processing verification links from emails.
 	ghatdRouter.GetRouter().HandleFunc(
-		router.AuthVerfiyEndpoint,
+		router.AuthVerifyEndpoint,
 		router.NewAuthVerifyHandler(
 			backendBaseURL+"/api/v1/ams/verify/email?t=%s", // URL to verify an email
 			backendBaseURL+"/api/v1/ams/login?t=%s",      // URL to process a magic login link

--- a/docs/getting-started/router/README.md
+++ b/docs/getting-started/router/README.md
@@ -1,0 +1,102 @@
+# Router Package
+
+The `router` package provides a standardised, project-specific wrapper around the `gorilla/mux` router. It is designed to simplify the setup of common application-level routing concerns, such as default handlers, middleware, and authentication endpoints.
+
+## Architecture
+
+-   **`router.go`**: Contains the `Router` struct and the `NewRouter` constructor. It initialises a `mux.Router` and applies any provided default handlers or global middleware.
+-   **`handler.go`**: Provides handlers for common, cross-cutting concerns. A key example is the `NewAuthVerifyHandler`, which manages the redirection flow for email and login verification links.
+-   **`const.go`**: Defines constant URI paths for shared endpoints like health checks (`/v0/health/check`) and authentication verification (`/v0/auth/verify`).
+
+## Getting Started
+
+The following example demonstrates how to initialise the `ghatdRouter`, configure it with default handlers and middleware, and attach a verification endpoint.
+
+### Example Initialisation
+
+This setup is typically performed once in your application's `main` function or wherever you configure your HTTP server.
+
+```go
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/ooaklee/ghatd/external/router"
+	// ... other imports
+)
+
+func main() {
+	// ... initialise logger and other dependencies
+
+	// Define base URLs for the application (this will be the same if packaging your UI with the ghatd backend)
+	backendBaseURL := "http://localhost:8080"
+	frontendBaseURL := "http://localhost:3000"
+
+	// 1. Define Default Handlers
+	// These handlers are used by the router for unhandled routes or health checks.
+	default404Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "Not Found")
+	})
+	defaultHealthcheckHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "OK")
+	})
+
+	// 2. Define Global Middleware (e.g., CORS)
+	// This is a mock CORS middleware for demonstration purposes.
+	// In a real project, you would use a proper CORS library.
+	corsMiddleware := func(allowedOrigins []string) mux.MiddlewareFunc {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Access-Control-Allow-Origin", "*") // Be more restrictive in production
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+				if r.Method == "OPTIONS" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+
+	// 3. Create a New Router
+	// Initialise the router with the default handlers and global middleware.
+	ghatdRouter := router.NewRouter(
+		default404Handler,
+		defaultHealthcheckHandler,
+		corsMiddleware([]string{frontendBaseURL}),
+	)
+
+	// 4. Add Application-Specific Handlers
+	// The AuthVerifyEndpoint is a special handler for processing verification links from emails.
+	ghatdRouter.GetRouter().HandleFunc(
+		router.AuthVerfiyEndpoint,
+		router.NewAuthVerifyHandler(
+			backendBaseURL+"/api/v1/ams/verify/email?t=%s", // URL to verify an email
+			backendBaseURL+"/api/v1/ams/login?t=%s",      // URL to process a magic login link
+			frontendBaseURL+"/auth/login",                // Fallback URL for failed attempts
+			frontendBaseURL,                              // Success URL after verification
+		),
+	)
+
+	// 5. Attach Service-Specific Routes
+	// At this point, you would attach the routes for each of your services.
+	// For example:
+	//
+	// usermanager.AttachRoutes(&usermanager.AttachRoutesRequest{
+	// 	Router:  ghatdRouter,
+	// 	Handler: umsHandler,
+	// 	// ... middleware
+	// })
+
+	// 6. Start the HTTP Server
+	// http.ListenAndServe(":8080", ghatdRouter.GetRouter())
+}
+```
+
+By following this pattern, you establish a consistent foundation for routing across your entire application, which can then be referenced by other "Getting Started" guides.

--- a/docs/getting-started/user-manager/README.md
+++ b/docs/getting-started/user-manager/README.md
@@ -1,0 +1,109 @@
+# User Manager Package Getting Started
+
+The `usermanager` package is a high-level, full-stack service designed to simplify the management of users and their associated data. It acts as an orchestrator, integrating with various other packages such as `user`, `group`, and `contacter` to provide a unified API for common user-centric operations.
+
+This guide provides an overview of the `usermanager` architecture, its key features, and how to interact with its API.
+
+## Architecture
+
+The package follows a standard layered architecture, consistent with other services in this project. Its primary role is to orchestrate calls to other services rather than managing its own data directly.
+
+1.  **Routes (`routes.go`)**: Defines the HTTP API endpoints for user management, such as `/api/v1/ums/users/{userId}/profile`. It maps incoming requests to the appropriate handlers.
+2.  **Handler (`handler.go`)**: Acts as the intermediary between the HTTP transport layer and the business logic. It is responsible for parsing requests, calling the service layer, and formatting responses.
+3.  **Service (`service.go`, `service.group.go`)**: Contains the core business logic. The service layer makes calls to other downstream services (e.g., `UserService`, `GroupService`, `ContacterService`) to gather and assemble the data needed to fulfil a request.
+4.  **Request/Response (`request.go`, `response.go`)**: Defines the data structures used for API communication, ensuring a clear and consistent contract for clients.
+5.  **Fender (`fender.go`)**: An authorisation layer that can be used to secure endpoints, ensuring that the authenticated user has the correct permissions for the requested action.
+
+Unlike other packages, the `usermanager` does not have its own repository or database collection, as it exclusively deals with orchestrating data from other services.
+
+## Key Features
+
+The `usermanager` is designed to streamline complex user-related workflows into single API calls.
+
+-   **Enriched User Profiles**: Fetch a complete user profile, enriched with data from multiple sources. For example, a single request can return a user's core details along with a list of all the groups they are a member of.
+-   **Simplified Group Management**: Provides intuitive endpoints for managing a user's membership in groups. This includes adding a user to a group, removing them, and listing their current groups, without needing to interact directly with the `group` service.
+-   **Communication Management**: Integrates with the `contacter` service to manage a user's communication preferences and history.
+-   **Administrative Functions**: Offers secure, admin-only endpoints for performing privileged actions, such as creating a new group.
+
+## API Endpoints
+
+The following are the primary API endpoints provided by the `usermanager` service:
+
+-   `GET /api/v1/ums/users/{userId}/profile`: Retrieves a user's enriched profile, including their group memberships.
+-   `GET /api/v1/ums/users/{userId}/groups`: Lists all groups that the specified user is a member of.
+-   `POST /api/v1/ums/users/{userId}/groups/{groupId}`: Adds a user to a specified group.
+-   `DELETE /api/v1/ums/users/{userId}/groups/{groupId}`: Removes a user from a specified group.
+-   `POST /api/v1/ums/admin/groups`: An admin-only endpoint to create a new group.
+
+## Configuration and Initialisation
+
+To use the `usermanager` service, you must initialise it and attach its routes to a configured `ghatdRouter`. This is typically done during your application's startup process.
+
+For a detailed guide on setting up the main application router, please see the [Router Package Getting Started documentation](../router/README.md).
+
+**Example Initialisation:**
+
+```go
+import (
+	"net/http"
+
+	"github.com/ooaklee/ghatd/external/router"
+	"github.com/ooaklee/ghatd/external/usermanager"
+	"github.com/ooaklee/ghatd/external/validator"
+	// ... import other required services (user, group, etc.)
+)
+
+func main() {
+	// ... assume ghatdRouter is already initialised as per the router documentation
+	var ghatdRouter *router.Router
+
+	// Initialise a validator
+	validator := validator.New()
+
+	// Initialise downstream services
+	userService := user.NewService(...)
+	groupService := group.NewService(...)
+	contacterService := contacter.NewService(...)
+	auditService := audit.NewService(...)
+	apiTokenService := apitoken.NewService(...)
+
+	// Create the usermanager service
+	umsService := usermanager.NewService(&usermanager.NewServiceRequest{
+		UserService:      userService,
+		ApiTokenService:  apiTokenService,
+		AuditService:     auditService,
+		ContacterService: contacterService,
+	})
+
+	// Add optional services
+	umsService.WithGroupService(groupService)
+
+	// Create the usermanager handler
+	umsHandler := usermanager.NewHandler(&usermanager.NewHandlerRequest{
+		Service:   umsService,
+		Validator: validator,
+		// ... other options like ErrorMaps, Environment, etc.
+	})
+
+	// Mock middleware for the example
+	mockMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	// Attach the usermanager routes
+	usermanager.AttachRoutes(&usermanager.AttachRoutesRequest{
+		Router:                             ghatdRouter,
+		Handler:                            umsHandler,
+		AuthenticatedMiddleware:            mockMiddleware,
+		ActiveOnlyMiddleware:               mockMiddleware,
+		AdminOnlyMiddleware:                mockMiddleware,
+		ActiveValidApiTokenOrJWTMiddleware: mockMiddleware,
+		ValidApiTokenOrJWTMiddleware:       mockMiddleware,
+		RateLimitOrActiveMiddleware:        mockMiddleware,
+	})
+
+	// ... set up and start the HTTP server with ghatdRouter
+}
+```

--- a/docs/getting-started/user-manager/README.md
+++ b/docs/getting-started/user-manager/README.md
@@ -1,26 +1,26 @@
-# User Manager Package Getting Started
+# User Manager
 
-The `usermanager` package is a high-level, full-stack service designed to simplify the management of users and their associated data. It acts as an orchestrator, integrating with various other packages such as `user`, `group`, and `contacter` to provide a unified API for common user-centric operations.
+The `usermanager` package is a high-level, full-stack service designed to simplify managing users and their associated data. It acts as an orchestrator, integrating with various other packages like `user`, `group`, and `contacter` to provide a unified API for common user-centric operations.
 
-This guide provides an overview of the `usermanager` architecture, its key features, and how to interact with its API.
+This guide gives an overview of the `usermanager` architecture, its key features, and how to interact with its API.
 
 ## Architecture
 
 The package follows a standard layered architecture, consistent with other services in this project. Its primary role is to orchestrate calls to other services rather than managing its own data directly.
 
-1.  **Routes (`routes.go`)**: Defines the HTTP API endpoints for user management, such as `/api/v1/ums/users/{userId}/profile`. It maps incoming requests to the appropriate handlers.
-2.  **Handler (`handler.go`)**: Acts as the intermediary between the HTTP transport layer and the business logic. It is responsible for parsing requests, calling the service layer, and formatting responses.
+1.  **Routes (`routes.go`)**: Defines the HTTP API endpoints for user management, like `/api/v1/ums/users/{userId}/profile`, mapping incoming requests to the appropriate handlers.
+2.  **Handler (`handler.go`)**: Acts as the intermediary between the HTTP transport layer and the business logic. It's responsible for parsing requests, calling the service layer, and formatting responses.
 3.  **Service (`service.go`, `service.group.go`)**: Contains the core business logic. The service layer makes calls to other downstream services (e.g., `UserService`, `GroupService`, `ContacterService`) to gather and assemble the data needed to fulfil a request.
-4.  **Request/Response (`request.go`, `response.go`)**: Defines the data structures used for API communication, ensuring a clear and consistent contract for clients.
-5.  **Fender (`fender.go`)**: An authorisation layer that can be used to secure endpoints, ensuring that the authenticated user has the correct permissions for the requested action.
+4.  **Request/Response (`request.go`, `response.go`)**: Defines the data structures for API communication, ensuring a clear and consistent contract for clients.
+5.  **Fender (`fender.go`)**: An authorisation layer that can be used to secure endpoints, ensuring the authenticated user has the correct permissions for the requested action.
 
-Unlike other packages, the `usermanager` does not have its own repository or database collection, as it exclusively deals with orchestrating data from other services.
+Unlike other packages, the `usermanager` doesn't have its own repository or database collection, as it exclusively deals with orchestrating data from other services.
 
 ## Key Features
 
 The `usermanager` is designed to streamline complex user-related workflows into single API calls.
 
--   **Enriched User Profiles**: Fetch a complete user profile, enriched with data from multiple sources. For example, a single request can return a user's core details along with a list of all the groups they are a member of.
+-   **Expanded User Profiles**: Fetch a complete user profile, expanded with data from multiple sources. For example, a single request can return a user's core details alongside a list of all the groups they are a member of.
 -   **Simplified Group Management**: Provides intuitive endpoints for managing a user's membership in groups. This includes adding a user to a group, removing them, and listing their current groups, without needing to interact directly with the `group` service.
 -   **Communication Management**: Integrates with the `contacter` service to manage a user's communication preferences and history.
 -   **Administrative Functions**: Offers secure, admin-only endpoints for performing privileged actions, such as creating a new group.
@@ -29,7 +29,7 @@ The `usermanager` is designed to streamline complex user-related workflows into 
 
 The following are the primary API endpoints provided by the `usermanager` service:
 
--   `GET /api/v1/ums/users/{userId}/profile`: Retrieves a user's enriched profile, including their group memberships.
+-   `GET /api/v1/ums/users/{userId}/profile`: Retrieves a user's expanded profile, including their group memberships.
 -   `GET /api/v1/ums/users/{userId}/groups`: Lists all groups that the specified user is a member of.
 -   `POST /api/v1/ums/users/{userId}/groups/{groupId}`: Adds a user to a specified group.
 -   `DELETE /api/v1/ums/users/{userId}/groups/{groupId}`: Removes a user from a specified group.

--- a/external/group/config.go
+++ b/external/group/config.go
@@ -1,0 +1,105 @@
+package group
+
+// DefaultGroupConfig returns a default configuration
+func DefaultGroupConfig() *GroupConfig {
+	return &GroupConfig{
+		DefaultStatus: GroupStatusActive,
+		StatusTransitions: map[string][]string{
+			GroupStatusActive: {
+				GroupStatusProvisioned,
+				GroupStatusInactive,
+			},
+			GroupStatusInactive: {
+				GroupStatusActive,
+				GroupStatusArchived,
+			},
+			GroupStatusArchived: {
+				GroupStatusInactive,
+				GroupStatusActive,
+			},
+			GroupStatusSuspended: {
+				GroupStatusActive,
+				GroupStatusInactive,
+			},
+		},
+		RequiredFields: []string{"name", "type"},
+		ValidTypes: []string{
+			GroupTypeTeam,
+			GroupTypeTribe,
+			GroupTypeSquad,
+			GroupTypeDepartment,
+			GroupTypeOrganisation,
+			GroupTypeCompany,
+			GroupTypeProject,
+			GroupTypeCommunity,
+			GroupTypeFamily,
+			GroupTypeFriends,
+			GroupTypeCustom,
+		},
+		ValidMemberTypes: []string{
+			MemberTypeUser,
+			MemberTypeGroup,
+		},
+		AllowNestedGroups:   true,
+		MaxNestingDepth:     5,
+		MultipleIdentifiers: true,
+	}
+}
+
+// NewCustomGroupConfig creates a custom group config builder
+func NewCustomGroupConfig() *GroupConfig {
+	return &GroupConfig{
+		StatusTransitions: make(map[string][]string),
+		RequiredFields:    []string{},
+		ValidTypes:        []string{},
+		ValidMemberTypes:  []string{},
+	}
+}
+
+// WithDefaultStatus sets the default status
+func (c *GroupConfig) WithDefaultStatus(status string) *GroupConfig {
+	c.DefaultStatus = status
+	return c
+}
+
+// WithStatusTransition adds a status transition
+func (c *GroupConfig) WithStatusTransition(toStatus string, fromStatuses []string) *GroupConfig {
+	c.StatusTransitions[toStatus] = fromStatuses
+	return c
+}
+
+// WithRequiredFields sets required fields
+func (c *GroupConfig) WithRequiredFields(fields ...string) *GroupConfig {
+	c.RequiredFields = append(c.RequiredFields, fields...)
+	return c
+}
+
+// WithValidTypes sets valid group types
+func (c *GroupConfig) WithValidTypes(types ...string) *GroupConfig {
+	c.ValidTypes = append(c.ValidTypes, types...)
+	return c
+}
+
+// WithValidMemberTypes sets valid member types
+func (c *GroupConfig) WithValidMemberTypes(types ...string) *GroupConfig {
+	c.ValidMemberTypes = append(c.ValidMemberTypes, types...)
+	return c
+}
+
+// WithNestedGroups enables/disables nested groups
+func (c *GroupConfig) WithNestedGroups(allow bool) *GroupConfig {
+	c.AllowNestedGroups = allow
+	return c
+}
+
+// WithMaxNestingDepth sets maximum nesting depth
+func (c *GroupConfig) WithMaxNestingDepth(depth int) *GroupConfig {
+	c.MaxNestingDepth = depth
+	return c
+}
+
+// WithMultipleIdentifiers enables/disables multiple identifier types
+func (c *GroupConfig) WithMultipleIdentifiers(allow bool) *GroupConfig {
+	c.MultipleIdentifiers = allow
+	return c
+}

--- a/external/group/const.go
+++ b/external/group/const.go
@@ -1,0 +1,83 @@
+package group
+
+const (
+	// Group Type Keys
+	GroupTypeTeam         = "TEAM"
+	GroupTypeTribe        = "TRIBE"
+	GroupTypeSquad        = "SQUAD"
+	GroupTypeDepartment   = "DEPARTMENT"
+	GroupTypeOrganisation = "ORGANISATION"
+	GroupTypeCompany      = "COMPANY"
+	GroupTypeProject      = "PROJECT"
+	GroupTypeCommunity    = "COMMUNITY"
+	GroupTypeFamily       = "FAMILY"
+	GroupTypeFriends      = "FRIENDS"
+	GroupTypeCustom       = "CUSTOM"
+
+	// Member Type Keys
+	MemberTypeUser  = "USER"
+	MemberTypeGroup = "GROUP"
+
+	// Group Status Keys
+	GroupStatusActive      = "ACTIVE"
+	GroupStatusInactive    = "INACTIVE"
+	GroupStatusArchived    = "ARCHIVED"
+	GroupStatusSuspended   = "SUSPENDED"
+	GroupStatusProvisioned = "PROVISIONED"
+
+	// Membership Role Keys
+	MemberRoleOwner       = "OWNER"
+	MemberRoleAdmin       = "ADMIN"
+	MemberRoleMember      = "MEMBER"
+	MemberRoleModerator   = "MODERATOR"
+	MemberRoleGuest       = "GUEST"
+	MemberRoleHead        = "HEAD"
+	MemberRoleLead        = "LEAD"
+	MemberRoleCoordinator = "COORDINATOR"
+
+	// Visibility Keys
+	VisibilityPublic   = "PUBLIC"
+	VisibilityPrivate  = "PRIVATE"
+	VisibilityInternal = "INTERNAL"
+)
+
+const (
+	// Error Keys
+	ErrKeyGroupConfigNotSet         = "GroupConfigNotSet"
+	ErrKeyInvalidGroupType          = "InvalidGroupType"
+	ErrKeyInvalidGroupStatus        = "InvalidGroupStatus"
+	ErrKeyInvalidStatusTransition   = "InvalidStatusTransition"
+	ErrKeyRequiredFieldMissingName  = "RequiredFieldMissingName"
+	ErrKeyRequiredFieldMissingType  = "RequiredFieldMissingType"
+	ErrKeyValidationFailed          = "GroupValidationFailed"
+	ErrKeyResourceNotFound          = "GroupResourceNotFound"
+	ErrKeyResourceConflict          = "GroupResourceConflict"
+	ErrKeyDatabaseError             = "GroupDatabaseError"
+	ErrKeyInvalidQueryParam         = "GroupInvalidQueryParam"
+	ErrKeyNoChangesDetected         = "GroupNoChangesDetected"
+	ErrKeyInvalidMemberType         = "InvalidMemberType"
+	ErrKeyMemberNotFound            = "MemberNotFound"
+	ErrKeyMemberAlreadyExists       = "MemberAlreadyExists"
+	ErrKeyInsufficientPermissions   = "InsufficientPermissions"
+	ErrKeyCircularReferenceDetected = "CircularReferenceDetected"
+	ErrKeyMaxDepthExceeded          = "MaxDepthExceeded"
+	ErrKeyPageOutOfRange            = "PageOutOfRange"
+	ErrKeyInvalidNanoID             = "GroupInvalidNanoID"
+	ErrKeyNameAlreadyExists         = "GroupNameAlreadyExists"
+	ErrKeyUnableToFindGroupWithName = "UnableToFindGroupWithGivenName"
+	ErrKeyInvalidGroupID            = "GroupInvalidID"
+	ErrKeyInvalidGroupBody          = "GroupInvalidBody"
+	ErrKeyInvalidMemberID           = "GroupInvalidMemberID"
+)
+
+const (
+	// Group Order Constants
+	GetGroupOrderCreatedAtDesc   = "created_at_desc"
+	GetGroupOrderCreatedAtAsc    = "created_at_asc"
+	GetGroupOrderUpdatedAtDesc   = "updated_at_desc"
+	GetGroupOrderUpdatedAtAsc    = "updated_at_asc"
+	GetGroupOrderNameAsc         = "name_asc"
+	GetGroupOrderNameDesc        = "name_desc"
+	GetGroupOrderMemberCountDesc = "member_count_desc"
+	GetGroupOrderMemberCountAsc  = "member_count_asc"
+)

--- a/external/group/errormap.go
+++ b/external/group/errormap.go
@@ -1,0 +1,141 @@
+package group
+
+import (
+	"net/http"
+)
+
+// ResponseSchema defines the structure for error responses
+type ResponseSchema struct {
+	HttpStatusCode int    `json:"http_status_code"`
+	ErrCode        string `json:"err_code"`
+	Message        string `json:"message"`
+}
+
+// DefaultGroupErrorResponseMap returns the default error response mapping
+func DefaultGroupErrorResponseMap() map[string]ResponseSchema {
+	return map[string]ResponseSchema{
+		// Configuration errors
+		ErrKeyGroupConfigNotSet: {
+			HttpStatusCode: http.StatusInternalServerError,
+			ErrCode:        ErrKeyGroupConfigNotSet,
+			Message:        "Group configuration not set",
+		},
+
+		// Validation errors
+		ErrKeyInvalidGroupType: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyInvalidGroupType,
+			Message:        "Invalid group type provided",
+		},
+		ErrKeyInvalidGroupStatus: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyInvalidGroupStatus,
+			Message:        "Invalid group status provided",
+		},
+		ErrKeyInvalidStatusTransition: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyInvalidStatusTransition,
+			Message:        "Invalid status transition",
+		},
+		ErrKeyRequiredFieldMissingName: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyRequiredFieldMissingName,
+			Message:        "Group name is required",
+		},
+		ErrKeyRequiredFieldMissingType: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyRequiredFieldMissingType,
+			Message:        "Group type is required",
+		},
+		ErrKeyValidationFailed: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyValidationFailed,
+			Message:        "Group validation failed",
+		},
+		ErrKeyInvalidNanoID: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyInvalidNanoID,
+			Message:        "Invalid nano ID format",
+		},
+
+		// Resource errors
+		ErrKeyResourceNotFound: {
+			HttpStatusCode: http.StatusNotFound,
+			ErrCode:        ErrKeyResourceNotFound,
+			Message:        "Group not found",
+		},
+		ErrKeyResourceConflict: {
+			HttpStatusCode: http.StatusConflict,
+			ErrCode:        ErrKeyResourceConflict,
+			Message:        "Group already exists",
+		},
+		ErrKeyNameAlreadyExists: {
+			HttpStatusCode: http.StatusConflict,
+			ErrCode:        ErrKeyNameAlreadyExists,
+			Message:        "Group with this name already exists",
+		},
+		ErrKeyUnableToFindGroupWithName: {
+			HttpStatusCode: http.StatusNotFound,
+			ErrCode:        ErrKeyUnableToFindGroupWithName,
+			Message:        "Unable to find group with given name",
+		},
+
+		// Member errors
+		ErrKeyInvalidMemberType: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyInvalidMemberType,
+			Message:        "Invalid member type provided",
+		},
+		ErrKeyMemberNotFound: {
+			HttpStatusCode: http.StatusNotFound,
+			ErrCode:        ErrKeyMemberNotFound,
+			Message:        "Member not found in group",
+		},
+		ErrKeyMemberAlreadyExists: {
+			HttpStatusCode: http.StatusConflict,
+			ErrCode:        ErrKeyMemberAlreadyExists,
+			Message:        "Member already exists in group",
+		},
+		ErrKeyInsufficientPermissions: {
+			HttpStatusCode: http.StatusForbidden,
+			ErrCode:        ErrKeyInsufficientPermissions,
+			Message:        "Insufficient permissions to perform this action",
+		},
+
+		// Hierarchy errors
+		ErrKeyCircularReferenceDetected: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyCircularReferenceDetected,
+			Message:        "Circular reference detected in group hierarchy",
+		},
+		ErrKeyMaxDepthExceeded: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyMaxDepthExceeded,
+			Message:        "Maximum nesting depth exceeded",
+		},
+
+		// Database errors
+		ErrKeyDatabaseError: {
+			HttpStatusCode: http.StatusInternalServerError,
+			ErrCode:        ErrKeyDatabaseError,
+			Message:        "Database error occurred",
+		},
+		ErrKeyNoChangesDetected: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyNoChangesDetected,
+			Message:        "No changes detected",
+		},
+
+		// Query errors
+		ErrKeyInvalidQueryParam: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyInvalidQueryParam,
+			Message:        "Invalid query parameter provided",
+		},
+		ErrKeyPageOutOfRange: {
+			HttpStatusCode: http.StatusBadRequest,
+			ErrCode:        ErrKeyPageOutOfRange,
+			Message:        "Page number out of range",
+		},
+	}
+}

--- a/external/group/examples/basic_usage.go
+++ b/external/group/examples/basic_usage.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	group "github.com/ooaklee/ghatd/external/group"
+)
+
+// Example 1: Creating a Simple Team
+func CreateSimpleTeam() {
+	// Set up dependencies
+	config := group.DefaultGroupConfig()
+	idGen := group.NewDefaultIDGenerator()
+	timeProvider := group.NewDefaultTimeProvider()
+	stringUtils := group.NewDefaultStringUtils()
+
+	// Create a new team
+	team := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	team.Name = "Frontend Engineering Team"
+	team.Type = group.GroupTypeTeam
+	team.DisplayInfo.Description = "Responsible for all user-facing web applications"
+	team.DisplayInfo.Email = "frontend@company.com"
+	team.DisplayInfo.Icon = "🎨"
+
+	// Set initial state (generates IDs, timestamps, default status)
+	team.SetInitialState()
+
+	// Add members
+	team.AddMember("user-alice", group.MemberTypeUser, group.MemberRoleHead)
+	team.AddMember("user-bob", group.MemberTypeUser, group.MemberRoleAdmin)
+	team.AddMember("user-charlie", group.MemberTypeUser, group.MemberRoleMember)
+	team.AddMember("user-diana", group.MemberTypeUser, group.MemberRoleMember)
+
+	// Set leadership
+	team.Leadership.HeadID = "user-alice"
+	team.Leadership.AdminIDs = []string{"user-bob"}
+
+	// Add custom extensions
+	team.SetExtension("github_team", "frontend-eng")
+	team.SetExtension("jira_project", "FE")
+	team.SetExtension("cost_center", "ENG-001")
+
+	// Validate
+	if err := team.Validate(); err != nil {
+		log.Fatalf("Validation failed: %v", err)
+	}
+
+	fmt.Printf("Created team: %s (ID: %s)\n", team.Name, team.ID)
+	fmt.Printf("Members: %d users\n", len(team.GetUserMemberIDs()))
+	fmt.Printf("Status: %s\n", team.Status)
+}
+
+// Example 2: Creating a Hierarchical Organization
+func CreateHierarchicalOrganization() {
+	config := group.DefaultGroupConfig()
+	idGen := group.NewDefaultIDGenerator()
+	timeProvider := group.NewDefaultTimeProvider()
+	stringUtils := group.NewDefaultStringUtils()
+
+	// Create company (top level)
+	company := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	company.Name = "Acme Corporation"
+	company.Type = group.GroupTypeCompany
+	company.DisplayInfo.Description = "A leading technology company"
+	company.DisplayInfo.Website = "https://acme.com"
+	company.SetInitialState()
+
+	// Create engineering department
+	engineering := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	engineering.Name = "Engineering"
+	engineering.Type = group.GroupTypeDepartment
+	engineering.DisplayInfo.Description = "Engineering department"
+	engineering.SetInitialState()
+
+	// Create teams under engineering
+	frontendTeam := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	frontendTeam.Name = "Frontend Team"
+	frontendTeam.Type = group.GroupTypeTeam
+	frontendTeam.SetInitialState()
+
+	backendTeam := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	backendTeam.Name = "Backend Team"
+	backendTeam.Type = group.GroupTypeTeam
+	backendTeam.SetInitialState()
+
+	// Add users to teams
+	frontendTeam.AddMember("user-1", group.MemberTypeUser, group.MemberRoleMember)
+	frontendTeam.AddMember("user-2", group.MemberTypeUser, group.MemberRoleMember)
+	backendTeam.AddMember("user-3", group.MemberTypeUser, group.MemberRoleMember)
+	backendTeam.AddMember("user-4", group.MemberTypeUser, group.MemberRoleMember)
+
+	// Build hierarchy: Company -> Engineering -> Teams
+	company.AddMember(engineering.ID, group.MemberTypeGroup, group.MemberRoleMember)
+	engineering.AddMember(frontendTeam.ID, group.MemberTypeGroup, group.MemberRoleMember)
+	engineering.AddMember(backendTeam.ID, group.MemberTypeGroup, group.MemberRoleMember)
+
+	fmt.Printf("Created organization hierarchy:\n")
+	fmt.Printf("  %s\n", company.Name)
+	fmt.Printf("    └─ %s\n", engineering.Name)
+	fmt.Printf("        ├─ %s (%d members)\n", frontendTeam.Name, frontendTeam.GetMemberCount())
+	fmt.Printf("        └─ %s (%d members)\n", backendTeam.Name, backendTeam.GetMemberCount())
+}
+
+// Example 3: Managing Group Status
+func ManageGroupStatus() {
+	config := group.DefaultGroupConfig()
+	idGen := group.NewDefaultIDGenerator()
+	timeProvider := group.NewDefaultTimeProvider()
+	stringUtils := group.NewDefaultStringUtils()
+
+	uniGroup := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	uniGroup.Name = "Project Alpha"
+	uniGroup.Type = group.GroupTypeProject
+	uniGroup.SetInitialState()
+
+	fmt.Printf("Initial status: %s\n", uniGroup.Status)
+
+	// Update status to inactive
+	if _, err := uniGroup.UpdateStatus(group.GroupStatusInactive); err != nil {
+		log.Printf("Failed to set inactive: %v", err)
+	} else {
+		fmt.Printf("Status after inactive: %s\n", uniGroup.Status)
+	}
+
+	// Archive the group
+	if _, err := uniGroup.UpdateStatus(group.GroupStatusArchived); err != nil {
+		log.Printf("Failed to archive: %v", err)
+	} else {
+		fmt.Printf("Status after archive: %s\n", uniGroup.Status)
+		fmt.Printf("Archived at: %s\n", uniGroup.Metadata.ArchivedAt)
+	}
+
+	// Try invalid transition (should fail)
+	if _, err := uniGroup.UpdateStatus(group.GroupStatusProvisioned); err != nil {
+		fmt.Printf("Invalid transition blocked: %v\n", err)
+	}
+}
+
+// Example 4: Custom Group Type (Family Group)
+func CreateFamilyGroup() {
+	// Custom config for family groups
+	config := group.NewCustomGroupConfig().
+		WithDefaultStatus(group.GroupStatusActive).
+		WithValidTypes(group.GroupTypeFamily).
+		WithValidMemberTypes(group.MemberTypeUser). // Only users, no nested groups
+		WithNestedGroups(false).
+		WithRequiredFields("name")
+
+	idGen := group.NewDefaultIDGenerator()
+	timeProvider := group.NewDefaultTimeProvider()
+	stringUtils := group.NewDefaultStringUtils()
+
+	family := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	family.Name = "The Smith Family"
+	family.Type = group.GroupTypeFamily
+	family.DisplayInfo.Description = "Our wonderful family"
+	family.SetInitialState()
+
+	// Add family members
+	family.AddMember("user-dad", group.MemberTypeUser, "PARENT")
+	family.AddMember("user-mom", group.MemberTypeUser, "PARENT")
+	family.AddMember("user-son", group.MemberTypeUser, "CHILD")
+	family.AddMember("user-daughter", group.MemberTypeUser, "CHILD")
+
+	// Add custom extensions for family-specific data
+	family.SetExtension("home_address", "123 Main St")
+	family.SetExtension("family_motto", "Together we are stronger")
+	family.SetExtension("established_year", 2010)
+
+	fmt.Printf("Created family: %s with %d members\n", family.Name, family.GetMemberCount())
+}
+
+// Example 5: Using Extensions for Integration
+func IntegrateWithSlack() {
+	config := group.DefaultGroupConfig()
+	idGen := group.NewDefaultIDGenerator()
+	timeProvider := group.NewDefaultTimeProvider()
+	stringUtils := group.NewDefaultStringUtils()
+
+	team := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	team.Name = "DevOps Team"
+	team.Type = group.GroupTypeTeam
+	team.SetInitialState()
+
+	// Set Slack integration
+	team.Integrations.Slack = &group.SlackIntegration{
+		DisplayID:         "SLACK-CHANNEL-ID-123",
+		OnDutyDisplayID:   "SLACK-USER-ONCALL",
+		OnDutyDisplayName: "John Doe",
+		Emoji:             ":rocket:",
+		AdditionalRecipients: []string{
+			"SLACK-USER-1",
+			"SLACK-USER-2",
+		},
+	}
+
+	// Add other custom integrations
+	if team.Integrations.Custom == nil {
+		team.Integrations.Custom = make(map[string]interface{})
+	}
+	team.Integrations.Custom["pagerduty"] = map[string]interface{}{
+		"service_id":        "PD-SERVICE-123",
+		"escalation_policy": "POL-456",
+	}
+
+	team.SetExtension("monitoring_dashboard", "https://grafana.company.com/d/team-devops")
+
+	fmt.Printf("Team %s integrated with:\n", team.Name)
+	fmt.Printf("  - Slack: %s\n", team.Integrations.Slack.DisplayID)
+	fmt.Printf("  - PagerDuty: %v\n", team.Integrations.Custom["pagerduty"])
+}
+
+// Example 6: Member Management
+func ManageMembers() {
+	var err error
+
+	config := group.DefaultGroupConfig()
+	idGen := group.NewDefaultIDGenerator()
+	timeProvider := group.NewDefaultTimeProvider()
+	stringUtils := group.NewDefaultStringUtils()
+
+	team := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	team.Name = "Backend Team"
+	team.Type = group.GroupTypeTeam
+	team.SetInitialState()
+
+	// Add members
+	team.AddMember("user-1", group.MemberTypeUser, group.MemberRoleMember)
+	team.AddMember("user-2", group.MemberTypeUser, group.MemberRoleMember)
+	team.AddMember("user-3", group.MemberTypeUser, group.MemberRoleMember)
+
+	fmt.Printf("Total members: %d\n", team.GetMemberCount())
+	fmt.Printf("User members: %v\n", team.GetUserMemberIDs())
+
+	// Update member role
+	if team, err = team.UpdateMemberRole("user-2", group.MemberRoleAdmin); err != nil {
+		log.Printf("Failed to update role: %v", err)
+	} else {
+		fmt.Println("Updated user-2 to admin role")
+	}
+
+	// Check if member exists
+	if team.HasMember("user-1") {
+		fmt.Println("user-1 is a member")
+	}
+
+	// Get specific member
+	if member, err := team.GetMemberByID("user-1"); err == nil {
+		fmt.Printf("Member details: ID=%s, Type=%s, Role=%s\n",
+			member.ID, member.Type, member.Role)
+	}
+
+	// Remove member
+	if team, err = team.RemoveMember("user-3"); err != nil {
+		log.Printf("Failed to remove member: %v", err)
+	} else {
+		fmt.Printf("Removed user-3. New count: %d\n", team.GetMemberCount())
+	}
+}
+
+func main() {
+	fmt.Println("=== Example 1: Simple Team ===")
+	CreateSimpleTeam()
+	fmt.Println()
+
+	fmt.Println("=== Example 2: Hierarchical Organization ===")
+	CreateHierarchicalOrganization()
+	fmt.Println()
+
+	fmt.Println("=== Example 3: Status Management ===")
+	ManageGroupStatus()
+	fmt.Println()
+
+	fmt.Println("=== Example 4: Family Group ===")
+	CreateFamilyGroup()
+	fmt.Println()
+
+	fmt.Println("=== Example 5: Slack Integration ===")
+	IntegrateWithSlack()
+	fmt.Println()
+
+	fmt.Println("=== Example 6: Member Management ===")
+	ManageMembers()
+}

--- a/external/group/fender.go
+++ b/external/group/fender.go
@@ -1,0 +1,338 @@
+package group
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/ooaklee/ghatd/external/toolbox"
+	"github.com/ritwickdey/querydecoder"
+)
+
+// MapRequestToCreateGroupRequest maps incoming CreateGroup request to correct struct
+func MapRequestToCreateGroupRequest(request *http.Request, validator GroupValidator) (*CreateGroupRequest, error) {
+	parsedRequest := &CreateGroupRequest{}
+
+	err := toolbox.DecodeRequestBody(request, parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupBody)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyValidationFailed)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToGetGroupByIDRequest maps incoming GetGroupByID request to correct struct
+func MapRequestToGetGroupByIDRequest(request *http.Request, validator GroupValidator) (*GetGroupByIDRequest, error) {
+	var err error
+	parsedRequest := &GetGroupByIDRequest{}
+
+	// get group id from uri
+	parsedRequest.ID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToGetGroupByNanoIDRequest maps incoming GetGroupByNanoID request to correct struct
+func MapRequestToGetGroupByNanoIDRequest(request *http.Request, validator GroupValidator) (*GetGroupByNanoIDRequest, error) {
+	var err error
+	parsedRequest := &GetGroupByNanoIDRequest{}
+
+	// get nano id from uri
+	parsedRequest.NanoID, err = toolbox.GetVariableValueFromUri(request, "groupNanoID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidNanoID)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidNanoID)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToGetGroupByNameRequest maps incoming GetGroupByName request to correct struct
+func MapRequestToGetGroupByNameRequest(request *http.Request, validator GroupValidator) (*GetGroupByNameRequest, error) {
+	parsedRequest := &GetGroupByNameRequest{}
+
+	// get query parameters
+	query := request.URL.Query()
+	err := querydecoder.New(query).Decode(parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidQueryParam)
+	}
+
+	if parsedRequest.Name == "" {
+		return nil, errors.New(ErrKeyInvalidQueryParam)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidQueryParam)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToUpdateGroupRequest maps incoming UpdateGroup request to correct struct
+func MapRequestToUpdateGroupRequest(request *http.Request, validator GroupValidator) (*UpdateGroupRequest, error) {
+	var err error
+	parsedRequest := &UpdateGroupRequest{}
+
+	// get group id from uri
+	parsedRequest.ID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	err = toolbox.DecodeRequestBody(request, parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupBody)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyValidationFailed)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToDeleteGroupRequest maps incoming DeleteGroup request to correct struct
+func MapRequestToDeleteGroupRequest(request *http.Request, validator GroupValidator) (*DeleteGroupRequest, error) {
+	var err error
+	parsedRequest := &DeleteGroupRequest{}
+
+	// get group id from uri
+	parsedRequest.ID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	// get query parameters
+	query := request.URL.Query()
+	err = querydecoder.New(query).Decode(parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidQueryParam)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToGetGroupsRequest maps incoming GetGroups request to correct struct
+func MapRequestToGetGroupsRequest(request *http.Request, validator GroupValidator) (*GetGroupsRequest, error) {
+	var err error
+	parsedRequest := &GetGroupsRequest{}
+
+	// get request queries
+	query := request.URL.Query()
+	err = querydecoder.New(query).Decode(parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidQueryParam)
+	}
+
+	err = validator.Validate(parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidQueryParam)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToAddMemberRequest maps incoming AddMember request to correct struct
+func MapRequestToAddMemberRequest(request *http.Request, validator GroupValidator) (*AddMemberRequest, error) {
+	var err error
+	parsedRequest := &AddMemberRequest{}
+
+	// get group id from uri
+	parsedRequest.GroupID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	err = toolbox.DecodeRequestBody(request, parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupBody)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyValidationFailed)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToRemoveMemberRequest maps incoming RemoveMember request to correct struct
+func MapRequestToRemoveMemberRequest(request *http.Request, validator GroupValidator) (*RemoveMemberRequest, error) {
+	var err error
+	parsedRequest := &RemoveMemberRequest{}
+
+	// get group id from uri
+	parsedRequest.GroupID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	// get member id from uri
+	parsedRequest.MemberID, err = toolbox.GetVariableValueFromUri(request, "memberID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidMemberID)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidMemberID)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToUpdateMemberRoleRequest maps incoming UpdateMemberRole request to correct struct
+func MapRequestToUpdateMemberRoleRequest(request *http.Request, validator GroupValidator) (*UpdateMemberRoleRequest, error) {
+	var err error
+	parsedRequest := &UpdateMemberRoleRequest{}
+
+	// get group id from uri
+	parsedRequest.GroupID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	// get member id from uri
+	parsedRequest.MemberID, err = toolbox.GetVariableValueFromUri(request, "memberID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidMemberID)
+	}
+
+	err = toolbox.DecodeRequestBody(request, parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupBody)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyValidationFailed)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToGetGroupMembersRequest maps incoming GetGroupMembers request to correct struct
+func MapRequestToGetGroupMembersRequest(request *http.Request, validator GroupValidator) (*GetGroupMembersRequest, error) {
+	var err error
+	parsedRequest := &GetGroupMembersRequest{}
+
+	// get group id from uri
+	parsedRequest.GroupID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	// get query parameters
+	query := request.URL.Query()
+	err = querydecoder.New(query).Decode(parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidQueryParam)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidQueryParam)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToUpdateLeadershipRequest maps incoming UpdateLeadership request to correct struct
+func MapRequestToUpdateLeadershipRequest(request *http.Request, validator GroupValidator) (*UpdateLeadershipRequest, error) {
+	var err error
+	parsedRequest := &UpdateLeadershipRequest{}
+
+	// get group id from uri
+	parsedRequest.GroupID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	err = toolbox.DecodeRequestBody(request, parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupBody)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyValidationFailed)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToArchiveGroupRequest maps incoming ArchiveGroup request to correct struct
+func MapRequestToArchiveGroupRequest(request *http.Request, validator GroupValidator) (*ArchiveGroupRequest, error) {
+	var err error
+	parsedRequest := &ArchiveGroupRequest{}
+
+	// get group id from uri
+	parsedRequest.ID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToRestoreGroupRequest maps incoming RestoreGroup request to correct struct
+func MapRequestToRestoreGroupRequest(request *http.Request, validator GroupValidator) (*RestoreGroupRequest, error) {
+	var err error
+	parsedRequest := &RestoreGroupRequest{}
+
+	// get group id from uri
+	parsedRequest.ID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	return parsedRequest, nil
+}
+
+// MapRequestToGetGroupStatsRequest maps incoming GetGroupStats request to correct struct
+func MapRequestToGetGroupStatsRequest(request *http.Request, validator GroupValidator) (*GetGroupStatsRequest, error) {
+	var err error
+	parsedRequest := &GetGroupStatsRequest{}
+
+	// get group id from uri
+	parsedRequest.ID, err = toolbox.GetVariableValueFromUri(request, "groupID")
+	if err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyInvalidGroupID)
+	}
+
+	return parsedRequest, nil
+}
+
+// validateParsedRequest validates the parsed request using the validator
+func validateParsedRequest(request interface{}, validator GroupValidator) error {
+	if validator == nil {
+		return nil
+	}
+
+	return validator.Validate(request)
+}

--- a/external/group/handler.go
+++ b/external/group/handler.go
@@ -1,0 +1,386 @@
+package group
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ooaklee/reply"
+)
+
+// GroupService interface defines expected methods of a valid group service
+type GroupService interface {
+	CreateGroup(ctx context.Context, r *CreateGroupRequest) (*CreateGroupResponse, error)
+	GetGroupByID(ctx context.Context, r *GetGroupByIDRequest) (*GetGroupByIDResponse, error)
+	GetGroupByNanoID(ctx context.Context, r *GetGroupByNanoIDRequest) (*GetGroupByNanoIDResponse, error)
+	GetGroupByName(ctx context.Context, r *GetGroupByNameRequest) (*GetGroupByNameResponse, error)
+	UpdateGroup(ctx context.Context, r *UpdateGroupRequest) (*UpdateGroupResponse, error)
+	DeleteGroup(ctx context.Context, r *DeleteGroupRequest) error
+	GetGroups(ctx context.Context, r *GetGroupsRequest) (*GetGroupsResponse, error)
+	GetGroupsByMemberID(ctx context.Context, r *GetGroupsRequest) (*GetGroupsResponse, error)
+	GetGroupsByLeaderID(ctx context.Context, r *GetGroupsRequest) (*GetGroupsResponse, error)
+	SearchGroupsByExtension(ctx context.Context, r *GetGroupsRequest) (*GetGroupsResponse, error)
+	AddMember(ctx context.Context, r *AddMemberRequest) (*AddMemberResponse, error)
+	RemoveMember(ctx context.Context, r *RemoveMemberRequest) (*RemoveMemberResponse, error)
+	UpdateMemberRole(ctx context.Context, r *UpdateMemberRoleRequest) (*UpdateMemberRoleResponse, error)
+	GetGroupMembers(ctx context.Context, r *GetGroupMembersRequest) (*GetGroupMembersResponse, error)
+	UpdateLeadership(ctx context.Context, r *UpdateLeadershipRequest) (*UpdateLeadershipResponse, error)
+	ArchiveGroup(ctx context.Context, r *ArchiveGroupRequest) (*ArchiveGroupResponse, error)
+	RestoreGroup(ctx context.Context, r *RestoreGroupRequest) (*RestoreGroupResponse, error)
+	GetGroupStats(ctx context.Context, groupID string) (*GetGroupStatsResponse, error)
+}
+
+// GroupValidator interface defines expected methods of a valid validator
+type GroupValidator interface {
+	Validate(s interface{}) error
+}
+
+// Handler manages group requests
+type Handler struct {
+	Service   GroupService
+	Validator GroupValidator
+	ErrorMaps []reply.ErrorManifest
+}
+
+// NewHandler returns a new group handler
+func NewHandler(service GroupService, validator GroupValidator, errorMaps ...reply.ErrorManifest) *Handler {
+	return &Handler{
+		Service:   service,
+		Validator: validator,
+		ErrorMaps: errorMaps,
+	}
+}
+
+// CreateGroup handles group creation
+func (h *Handler) CreateGroup(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToCreateGroupRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.CreateGroup(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusCreated, response.Group)
+}
+
+// GetGroupByID handles getting a group by ID
+func (h *Handler) GetGroupByID(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupByIDRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroupByID(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// GetGroupByNanoID handles getting a group by nano ID
+func (h *Handler) GetGroupByNanoID(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupByNanoIDRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroupByNanoID(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// GetGroupByName handles getting a group by name
+func (h *Handler) GetGroupByName(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupByNameRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroupByName(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// GetGroups handles getting groups with filters and pagination
+func (h *Handler) GetGroups(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupsRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroups(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	// Return with pagination metadata if requested
+	if request.Meta {
+		h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups, reply.WithMeta(response.GetMetaData()))
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups)
+}
+
+// GetGroupsByMemberID handles getting groups by member ID with pagination
+func (h *Handler) GetGroupsByMemberID(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupsRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroupsByMemberID(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	// Return with pagination metadata if requested
+	if request.Meta {
+		h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups, reply.WithMeta(response.GetMetaData()))
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups)
+}
+
+// GetGroupsByLeaderID handles getting groups by leader ID with pagination
+func (h *Handler) GetGroupsByLeaderID(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupsRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroupsByLeaderID(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	// Return with pagination metadata if requested
+	if request.Meta {
+		h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups, reply.WithMeta(response.GetMetaData()))
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups)
+}
+
+// SearchGroupsByExtension handles searching groups by extension field with pagination
+func (h *Handler) SearchGroupsByExtension(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupsRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.SearchGroupsByExtension(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	// Return with pagination metadata if requested
+	if request.Meta {
+		h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups, reply.WithMeta(response.GetMetaData()))
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups)
+}
+
+// UpdateGroup handles group updates
+func (h *Handler) UpdateGroup(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToUpdateGroupRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.UpdateGroup(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// DeleteGroup handles group deletion
+func (h *Handler) DeleteGroup(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToDeleteGroupRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	err = h.Service.DeleteGroup(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusNoContent, nil)
+}
+
+// AddMember handles adding a member to a group
+func (h *Handler) AddMember(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToAddMemberRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.AddMember(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// RemoveMember handles removing a member from a group
+func (h *Handler) RemoveMember(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToRemoveMemberRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.RemoveMember(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// UpdateMemberRole handles updating a member's role
+func (h *Handler) UpdateMemberRole(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToUpdateMemberRoleRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.UpdateMemberRole(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// GetGroupMembers handles getting group members
+func (h *Handler) GetGroupMembers(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupMembersRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroupMembers(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Members)
+}
+
+// UpdateLeadership handles updating group leadership
+func (h *Handler) UpdateLeadership(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToUpdateLeadershipRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.UpdateLeadership(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// ArchiveGroup handles archiving a group
+func (h *Handler) ArchiveGroup(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToArchiveGroupRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.ArchiveGroup(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// RestoreGroup handles restoring an archived group
+func (h *Handler) RestoreGroup(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToRestoreGroupRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.RestoreGroup(r.Context(), request)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Group)
+}
+
+// GetGroupStats handles getting group statistics
+func (h *Handler) GetGroupStats(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupStatsRequest(r, h.Validator)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroupStats(r.Context(), request.ID)
+	if err != nil {
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response)
+}
+
+// getBaseResponseHandler returns response handler configured with group error maps
+func (h *Handler) getBaseResponseHandler() *reply.Replier {
+	return reply.NewReplier(h.ErrorMaps)
+}

--- a/external/group/migrations/indexes_groups.go
+++ b/external/group/migrations/indexes_groups.go
@@ -1,0 +1,233 @@
+package migrations
+
+import (
+	"context"
+	"log"
+
+	"github.com/ooaklee/ghatd/external/group"
+	"github.com/ooaklee/ghatd/external/toolbox"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// InitGroupsIndexesUp initializes indexes for the groups collection
+func InitGroupsIndexesUp(db *mongo.Database) error { //Up
+	log.SetFlags(0)
+	const mongoCollectionName = group.GroupCollection
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "starting-task-to-add-groups-indexes"))
+
+	// Unique compound index on name and type for fast lookups and uniqueness
+	nameTypeIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "name", Value: 1},
+			{Key: "type", Value: 1},
+		},
+		Options: options.Index().
+			SetName("idx_groups_name_type").
+			SetUnique(true),
+	}
+
+	// Unique index on nano_id for alternative identifier lookups
+	nanoIDIndexModel := mongo.IndexModel{
+		Keys: bson.D{{Key: "_nano_id", Value: 1}},
+		Options: options.Index().
+			SetName("idx_groups_nano_id").
+			SetUnique(true).
+			SetSparse(true), // Sparse because nano_id is optional
+	}
+
+	// Index on type for filtering groups by type
+	typeIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "type", Value: 1}},
+		Options: options.Index().SetName("idx_groups_type"),
+	}
+
+	// Index on status for filtering groups by status
+	statusIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "status", Value: 1}},
+		Options: options.Index().SetName("idx_groups_status"),
+	}
+
+	// Compound index on status and created_at for efficient filtered sorting
+	statusCreatedAtIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "status", Value: 1},
+			{Key: "metadata.created_at", Value: -1},
+		},
+		Options: options.Index().SetName("idx_groups_status_created_at"),
+	}
+
+	// Index on members.id for finding groups by member (supports $elemMatch)
+	membersIdIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "members.id", Value: 1}},
+		Options: options.Index().SetName("idx_groups_members_id"),
+	}
+
+	// Compound index on members.id and members.type for filtered member queries
+	membersIdTypeIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "members.id", Value: 1},
+			{Key: "members.type", Value: 1},
+		},
+		Options: options.Index().SetName("idx_groups_members_id_type"),
+	}
+
+	// Index on leadership.owner_id for finding groups by owner
+	ownerIdIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "leadership.owner_id", Value: 1}},
+		Options: options.Index().SetName("idx_groups_owner_id"),
+	}
+
+	// Index on leadership.head_id for finding groups by head
+	headIdIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "leadership.head_id", Value: 1}},
+		Options: options.Index().SetName("idx_groups_head_id"),
+	}
+
+	// Index on leadership.lead_id for finding groups by lead
+	leadIdIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "leadership.lead_id", Value: 1}},
+		Options: options.Index().SetName("idx_groups_lead_id"),
+	}
+
+	// Index on leadership.admin_ids for finding groups by admin
+	adminIdsIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "leadership.admin_ids", Value: 1}},
+		Options: options.Index().SetName("idx_groups_admin_ids"),
+	}
+
+	// Index on settings.visibility for filtering by visibility
+	visibilityIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "settings.visibility", Value: 1}},
+		Options: options.Index().SetName("idx_groups_visibility"),
+	}
+
+	// Text index on name for text search capabilities
+	nameTextIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "name", Value: "text"}},
+		Options: options.Index().SetName("idx_groups_name_text"),
+	}
+
+	// Index on created_at for sorting/filtering by creation date
+	createdAtIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "metadata.created_at", Value: -1}},
+		Options: options.Index().SetName("idx_groups_created_at"),
+	}
+
+	// Index on updated_at for sorting by last update
+	updatedAtIndexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "metadata.updated_at", Value: -1}},
+		Options: options.Index().SetName("idx_groups_updated_at"),
+	}
+
+	// Index on archived_at for filtering archived groups
+	archivedAtIndexModel := mongo.IndexModel{
+		Keys: bson.D{{Key: "metadata.archived_at", Value: -1}},
+		Options: options.Index().
+			SetName("idx_groups_archived_at").
+			SetSparse(true), // Sparse since most groups won't be archived
+	}
+
+	// Index on deleted_at for soft-delete filtering
+	deletedAtIndexModel := mongo.IndexModel{
+		Keys: bson.D{{Key: "metadata.deleted_at", Value: -1}},
+		Options: options.Index().
+			SetName("idx_groups_deleted_at").
+			SetSparse(true), // Sparse since most groups won't be deleted
+	}
+
+	// Compound index on type and status for common filtered queries
+	typeStatusIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "type", Value: 1},
+			{Key: "status", Value: 1},
+		},
+		Options: options.Index().SetName("idx_groups_type_status"),
+	}
+
+	// Compound index on visibility and status for access control queries
+	visibilityStatusIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "settings.visibility", Value: 1},
+			{Key: "status", Value: 1},
+		},
+		Options: options.Index().SetName("idx_groups_visibility_status"),
+	}
+
+	// Create all indexes
+	_, err := db.Collection(mongoCollectionName).Indexes().CreateMany(
+		context.Background(),
+		[]mongo.IndexModel{
+			nameTypeIndexModel,
+			nanoIDIndexModel,
+			typeIndexModel,
+			statusIndexModel,
+			statusCreatedAtIndexModel,
+			membersIdIndexModel,
+			membersIdTypeIndexModel,
+			ownerIdIndexModel,
+			headIdIndexModel,
+			leadIdIndexModel,
+			adminIdsIndexModel,
+			visibilityIndexModel,
+			nameTextIndexModel,
+			createdAtIndexModel,
+			updatedAtIndexModel,
+			archivedAtIndexModel,
+			deletedAtIndexModel,
+			typeStatusIndexModel,
+			visibilityStatusIndexModel,
+		},
+	)
+	if err != nil {
+		log.Default().Println(toolbox.OutputBasicLogString("error", "failed-task-to-add-groups-indexes"))
+		return err
+	}
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "completed-task-to-add-groups-indexes"))
+	return nil
+}
+
+// InitGroupsIndexesDown rolls back the groups indexes
+func InitGroupsIndexesDown(db *mongo.Database) error { //Down
+	log.SetFlags(0)
+	const mongoCollectionName = group.GroupCollection
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "rolling-back-task-to-add-groups-indexes"))
+
+	// Drop all indexes by name
+	indexNames := []string{
+		"idx_groups_name_type",
+		"idx_groups_nano_id",
+		"idx_groups_type",
+		"idx_groups_status",
+		"idx_groups_status_created_at",
+		"idx_groups_members_id",
+		"idx_groups_members_id_type",
+		"idx_groups_owner_id",
+		"idx_groups_head_id",
+		"idx_groups_lead_id",
+		"idx_groups_admin_ids",
+		"idx_groups_visibility",
+		"idx_groups_name_text",
+		"idx_groups_created_at",
+		"idx_groups_updated_at",
+		"idx_groups_archived_at",
+		"idx_groups_deleted_at",
+		"idx_groups_type_status",
+		"idx_groups_visibility_status",
+	}
+
+	for _, indexName := range indexNames {
+		_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
+		if err != nil {
+			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
+			return err
+		}
+	}
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "completed-rolling-back-task-to-add-groups-indexes"))
+	return nil
+}

--- a/external/group/model.go
+++ b/external/group/model.go
@@ -1,0 +1,620 @@
+package group
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/ooaklee/ghatd/external/toolbox"
+)
+
+// IDGenerator generates unique identifiers
+type IDGenerator interface {
+	GenerateUUID() string
+	GenerateNanoID() string
+}
+
+// TimeProvider provides current time (useful for testing)
+type TimeProvider interface {
+	Now() time.Time
+	NowUTC() string
+}
+
+// StringUtils provides string manipulation utilities
+type StringUtils interface {
+	ToTitleCase(s string) string
+	ToLowerCase(s string) string
+	ToUpperCase(s string) string
+	InSlice(item string, slice []string) bool
+}
+
+// GroupConfig holds configuration for group behavior
+type GroupConfig struct {
+	DefaultStatus       string
+	StatusTransitions   map[string][]string
+	RequiredFields      []string
+	ValidTypes          []string
+	ValidMemberTypes    []string
+	AllowNestedGroups   bool
+	MaxNestingDepth     int
+	MultipleIdentifiers bool // Support both UUID and NanoID
+}
+
+// UniversalGroup represents a flexible group/collection model
+type UniversalGroup struct {
+	// Core required fields
+	ID     string `json:"id" bson:"_id" db:"id"`
+	Name   string `json:"name" bson:"name" db:"name"`
+	Type   string `json:"type" bson:"type" db:"type"`
+	Status string `json:"status" bson:"status" db:"status"`
+
+	// Version field for tracking model version
+	Version int `json:"-" bson:"version" db:"version"`
+
+	// Optional identifier (for systems that need multiple ID types)
+	NanoID string `json:"nano_id,omitempty" bson:"_nano_id,omitempty" db:"nano_id"`
+
+	// Display information
+	DisplayInfo *DisplayInfo `json:"display_info,omitempty" bson:"display_info,omitempty" db:"display_info"`
+
+	// Members collection - supports both users and nested groups
+	Members []Member `json:"members,omitempty" bson:"members,omitempty" db:"members"`
+
+	// Leadership/hierarchy
+	Leadership *Leadership `json:"leadership,omitempty" bson:"leadership,omitempty" db:"leadership"`
+
+	// Settings and permissions
+	Settings *GroupSettings `json:"settings,omitempty" bson:"settings,omitempty" db:"settings"`
+
+	// Integration points
+	Integrations *Integrations `json:"integrations,omitempty" bson:"integrations,omitempty" db:"integrations"`
+
+	// Metadata with flexible timestamps
+	Metadata *GroupMetadata `json:"metadata" bson:"metadata" db:"metadata"`
+
+	// Extension point for project-specific fields
+	Extensions map[string]interface{} `json:"extensions,omitempty" bson:"extensions,omitempty" db:"extensions"`
+
+	// Injected dependencies
+	config       *GroupConfig `json:"-" bson:"-" db:"-"`
+	idGenerator  IDGenerator  `json:"-" bson:"-" db:"-"`
+	timeProvider TimeProvider `json:"-" bson:"-" db:"-"`
+	stringUtils  StringUtils  `json:"-" bson:"-" db:"-"`
+}
+
+// DisplayInfo holds display-related information
+type DisplayInfo struct {
+	Description string   `json:"description,omitempty" bson:"description,omitempty" db:"description"`
+	NameAliases []string `json:"name_aliases,omitempty" bson:"name_aliases,omitempty" db:"name_aliases"`
+	Icon        string   `json:"icon,omitempty" bson:"icon,omitempty" db:"icon"`
+	Avatar      string   `json:"avatar,omitempty" bson:"avatar,omitempty" db:"avatar"`
+	Color       string   `json:"color,omitempty" bson:"color,omitempty" db:"color"`
+	Email       string   `json:"email,omitempty" bson:"email,omitempty" db:"email"`
+	Website     string   `json:"website,omitempty" bson:"website,omitempty" db:"website"`
+}
+
+// Member represents a member (user or group) of the group
+type Member struct {
+	ID       string                 `json:"id" bson:"id" db:"id"`
+	Type     string                 `json:"type" bson:"type" db:"type"` // USER or GROUP
+	Role     string                 `json:"role,omitempty" bson:"role,omitempty" db:"role"`
+	JoinedAt string                 `json:"joined_at,omitempty" bson:"joined_at,omitempty" db:"joined_at"`
+	Metadata map[string]interface{} `json:"metadata,omitempty" bson:"metadata,omitempty" db:"metadata"`
+}
+
+// Leadership holds leadership structure
+type Leadership struct {
+	OwnerID      string   `json:"owner_id,omitempty" bson:"owner_id,omitempty" db:"owner_id"`
+	HeadID       string   `json:"head_id,omitempty" bson:"head_id,omitempty" db:"head_id"`
+	LeadID       string   `json:"lead_id,omitempty" bson:"lead_id,omitempty" db:"lead_id"`
+	AdminIDs     []string `json:"admin_ids,omitempty" bson:"admin_ids,omitempty" db:"admin_ids"`
+	ModeratorIDs []string `json:"moderator_ids,omitempty" bson:"moderator_ids,omitempty" db:"moderator_ids"`
+}
+
+// GroupSettings holds group configuration
+type GroupSettings struct {
+	Visibility         string   `json:"visibility,omitempty" bson:"visibility,omitempty" db:"visibility"` // PUBLIC, PRIVATE, INTERNAL
+	AllowMemberInvites bool     `json:"allow_member_invites,omitempty" bson:"allow_member_invites,omitempty" db:"allow_member_invites"`
+	RequireApproval    bool     `json:"require_approval,omitempty" bson:"require_approval,omitempty" db:"require_approval"`
+	MaxMembers         int      `json:"max_members,omitempty" bson:"max_members,omitempty" db:"max_members"`
+	AllowedMemberTypes []string `json:"allowed_member_types,omitempty" bson:"allowed_member_types,omitempty" db:"allowed_member_types"`
+}
+
+// Integrations holds external integration data
+type Integrations struct {
+	Slack  *SlackIntegration      `json:"slack,omitempty" bson:"slack,omitempty" db:"slack"`
+	Custom map[string]interface{} `json:"custom,omitempty" bson:"custom,omitempty" db:"custom"`
+}
+
+// SlackIntegration holds Slack-specific data
+type SlackIntegration struct {
+	DisplayID            string   `json:"display_id,omitempty" bson:"display_id,omitempty" db:"display_id"`
+	OnDutyDisplayID      string   `json:"on_duty_display_id,omitempty" bson:"on_duty_display_id,omitempty" db:"on_duty_display_id"`
+	OnDutyDisplayName    string   `json:"on_duty_display_name,omitempty" bson:"on_duty_display_name,omitempty" db:"on_duty_display_name"`
+	Emoji                string   `json:"emoji,omitempty" bson:"emoji,omitempty" db:"emoji"`
+	AdditionalRecipients []string `json:"additional_recipients,omitempty" bson:"additional_recipients,omitempty" db:"additional_recipients"`
+}
+
+// GroupMetadata holds timestamp and audit information
+type GroupMetadata struct {
+	CreatedAt   string `json:"created_at" bson:"created_at" db:"created_at"`
+	UpdatedAt   string `json:"updated_at,omitempty" bson:"updated_at,omitempty" db:"updated_at"`
+	ArchivedAt  string `json:"archived_at,omitempty" bson:"archived_at,omitempty" db:"archived_at"`
+	DeletedAt   string `json:"deleted_at,omitempty" bson:"deleted_at,omitempty" db:"deleted_at"`
+	DeletedByID string `json:"deleted_by_id,omitempty" bson:"deleted_by_id,omitempty" db:"deleted_by_id"`
+
+	// Extensible metadata
+	CustomTimestamps map[string]string `json:"custom_timestamps,omitempty" bson:"custom_timestamps,omitempty" db:"custom_timestamps"`
+}
+
+// NewUniversalGroup creates a new group with injected dependencies
+func NewUniversalGroup(
+	config *GroupConfig,
+	idGenerator IDGenerator,
+	timeProvider TimeProvider,
+	stringUtils StringUtils,
+) *UniversalGroup {
+	if config == nil {
+		config = DefaultGroupConfig()
+	}
+
+	return &UniversalGroup{
+		Members:      []Member{},
+		Extensions:   make(map[string]interface{}),
+		DisplayInfo:  &DisplayInfo{},
+		Leadership:   &Leadership{},
+		Settings:     &GroupSettings{},
+		Integrations: &Integrations{},
+		Metadata: &GroupMetadata{
+			CustomTimestamps: make(map[string]string),
+		},
+		config:       config,
+		idGenerator:  idGenerator,
+		timeProvider: timeProvider,
+		stringUtils:  stringUtils,
+	}
+}
+
+// SetDependencies allows setting dependencies after creation (useful for existing records)
+func (g *UniversalGroup) SetDependencies(
+	config *GroupConfig,
+	idGenerator IDGenerator,
+	timeProvider TimeProvider,
+	stringUtils StringUtils,
+) *UniversalGroup {
+	if config == nil {
+		config = DefaultGroupConfig()
+	}
+
+	g.config = config
+	g.idGenerator = idGenerator
+	g.timeProvider = timeProvider
+	g.stringUtils = stringUtils
+
+	// Initialize nil fields if needed
+	if g.Extensions == nil {
+		g.Extensions = make(map[string]interface{})
+	}
+	if g.DisplayInfo == nil {
+		g.DisplayInfo = &DisplayInfo{}
+	}
+	if g.Leadership == nil {
+		g.Leadership = &Leadership{}
+	}
+	if g.Settings == nil {
+		g.Settings = &GroupSettings{}
+	}
+	if g.Integrations == nil {
+		g.Integrations = &Integrations{}
+	}
+	if g.Metadata == nil {
+		g.Metadata = &GroupMetadata{
+			CustomTimestamps: make(map[string]string),
+		}
+	}
+	if g.Metadata.CustomTimestamps == nil {
+		g.Metadata.CustomTimestamps = make(map[string]string)
+	}
+
+	return g
+}
+
+// Core ID Methods
+
+// GenerateNewUUID creates a new UUID for the group
+func (g *UniversalGroup) GenerateNewUUID() *UniversalGroup {
+	if g.idGenerator != nil {
+		g.ID = g.idGenerator.GenerateUUID()
+	}
+	return g
+}
+
+// GenerateNewNanoID creates a new nano ID for the group
+func (g *UniversalGroup) GenerateNewNanoID() *UniversalGroup {
+	if g.idGenerator != nil && g.config.MultipleIdentifiers {
+		g.NanoID = g.idGenerator.GenerateNanoID()
+	}
+	return g
+}
+
+// SetInitialState sets up a new group with default values
+func (g *UniversalGroup) SetInitialState() *UniversalGroup {
+	g.Status = g.config.DefaultStatus
+	g.Version = 1 // Mark as v1 model
+	g.SetCreatedAtNow()
+	return g
+}
+
+// SetVersion sets the model version
+func (g *UniversalGroup) SetVersion(version int) *UniversalGroup {
+	g.Version = version
+	return g
+}
+
+// EnsureVersion ensures the group has version 1 set
+func (g *UniversalGroup) EnsureVersion() *UniversalGroup {
+	if g.Version != 1 {
+		g.Version = 1
+	}
+	return g
+}
+
+// Timestamp Management
+
+// SetCreatedAtNow sets created timestamp to current time
+func (g *UniversalGroup) SetCreatedAtNow() *UniversalGroup {
+	if g.timeProvider != nil {
+		g.Metadata.CreatedAt = g.timeProvider.NowUTC()
+	}
+	return g
+}
+
+// SetUpdatedAtNow sets updated timestamp to current time
+func (g *UniversalGroup) SetUpdatedAtNow() *UniversalGroup {
+	if g.timeProvider != nil {
+		g.Metadata.UpdatedAt = g.timeProvider.NowUTC()
+	}
+	return g
+}
+
+// SetArchivedAtNow sets archived timestamp to current time
+func (g *UniversalGroup) SetArchivedAtNow() *UniversalGroup {
+	if g.timeProvider != nil {
+		g.Metadata.ArchivedAt = g.timeProvider.NowUTC()
+	}
+	return g
+}
+
+// SetDeletedAtNow sets deleted timestamp to current time
+func (g *UniversalGroup) SetDeletedAtNow(deletedByID string) *UniversalGroup {
+	if g.timeProvider != nil {
+		g.Metadata.DeletedAt = g.timeProvider.NowUTC()
+		g.Metadata.DeletedByID = deletedByID
+	}
+	return g
+}
+
+// SetCustomTimestamp sets a custom timestamp field
+func (g *UniversalGroup) SetCustomTimestamp(key string) *UniversalGroup {
+	if g.timeProvider != nil {
+		g.Metadata.CustomTimestamps[key] = g.timeProvider.NowUTC()
+	}
+	return g
+}
+
+// Status Management
+
+// UpdateStatus updates group status with validation
+func (g *UniversalGroup) UpdateStatus(desiredStatus string) (*UniversalGroup, error) {
+	if g.config == nil {
+		return g, errors.New(ErrKeyGroupConfigNotSet)
+	}
+
+	// Check if transition is valid
+	validSources, exists := g.config.StatusTransitions[desiredStatus]
+	if !exists {
+		return g, errors.New(ErrKeyInvalidGroupStatus)
+	}
+
+	// Check if current status allows transition
+	if g.stringUtils != nil && !g.stringUtils.InSlice(g.Status, validSources) {
+		return g, errors.New(ErrKeyInvalidStatusTransition)
+	}
+
+	// Update status
+	g.Status = desiredStatus
+	g.SetUpdatedAtNow()
+
+	// Handle special status logic
+	if desiredStatus == GroupStatusArchived {
+		g.SetArchivedAtNow()
+	}
+
+	return g, nil
+}
+
+// IsValidStatus checks if a status is valid
+func (g *UniversalGroup) IsValidStatus(status string) bool {
+	if g.config == nil {
+		return false
+	}
+	_, exists := g.config.StatusTransitions[status]
+	return exists || status == g.config.DefaultStatus
+}
+
+// Member Management
+
+// AddMember adds a member to the group
+func (g *UniversalGroup) AddMember(memberID, memberType, role string) (*UniversalGroup, error) {
+	// Validate member type
+	if !g.isValidMemberType(memberType) {
+		return g, errors.New(ErrKeyInvalidMemberType)
+	}
+
+	// Check if member already exists
+	if g.HasMember(memberID) {
+		return g, errors.New(ErrKeyMemberAlreadyExists)
+	}
+
+	// Check max members limit
+	if g.Settings != nil && g.Settings.MaxMembers > 0 && len(g.Members) >= g.Settings.MaxMembers {
+		return g, errors.New("MaxMembersReached")
+	}
+
+	member := Member{
+		ID:   memberID,
+		Type: memberType,
+		Role: role,
+	}
+
+	if g.timeProvider != nil {
+		member.JoinedAt = g.timeProvider.NowUTC()
+	}
+
+	g.Members = append(g.Members, member)
+	g.SetUpdatedAtNow()
+
+	return g, nil
+}
+
+// RemoveMember removes a member from the group
+func (g *UniversalGroup) RemoveMember(memberID string) (*UniversalGroup, error) {
+	for i, member := range g.Members {
+		if member.ID == memberID {
+			g.Members = append(g.Members[:i], g.Members[i+1:]...)
+			g.SetUpdatedAtNow()
+			return g, nil
+		}
+	}
+	return g, errors.New(ErrKeyMemberNotFound)
+}
+
+// HasMember checks if a member exists in the group
+func (g *UniversalGroup) HasMember(memberID string) bool {
+	for _, member := range g.Members {
+		if member.ID == memberID {
+			return true
+		}
+	}
+	return false
+}
+
+// GetMemberByID retrieves a member by ID
+func (g *UniversalGroup) GetMemberByID(memberID string) (*Member, error) {
+	for _, member := range g.Members {
+		if member.ID == memberID {
+			return &member, nil
+		}
+	}
+	return nil, errors.New(ErrKeyMemberNotFound)
+}
+
+// GetMembersByType retrieves all members of a specific type
+func (g *UniversalGroup) GetMembersByType(memberType string) []Member {
+	var members []Member
+	for _, member := range g.Members {
+		if member.Type == memberType {
+			members = append(members, member)
+		}
+	}
+	return members
+}
+
+// GetMemberIDsByType retrieves all member IDs of a specific type
+func (g *UniversalGroup) GetMemberIDsByType(memberType string) []string {
+	var ids []string
+	for _, member := range g.Members {
+		if member.Type == memberType {
+			ids = append(ids, member.ID)
+		}
+	}
+	return ids
+}
+
+// GetUserMemberIDs retrieves all user member IDs
+func (g *UniversalGroup) GetUserMemberIDs() []string {
+	return g.GetMemberIDsByType(MemberTypeUser)
+}
+
+// GetGroupMemberIDs retrieves all group member IDs (nested groups)
+func (g *UniversalGroup) GetGroupMemberIDs() []string {
+	return g.GetMemberIDsByType(MemberTypeGroup)
+}
+
+// UpdateMemberRole updates a member's role
+func (g *UniversalGroup) UpdateMemberRole(memberID, newRole string) (*UniversalGroup, error) {
+	for i, member := range g.Members {
+		if member.ID == memberID {
+			g.Members[i].Role = newRole
+			g.SetUpdatedAtNow()
+			return g, nil
+		}
+	}
+	return g, errors.New(ErrKeyMemberNotFound)
+}
+
+// GetMemberCount returns the total number of members
+func (g *UniversalGroup) GetMemberCount() int {
+	return len(g.Members)
+}
+
+// isValidMemberType checks if member type is valid
+func (g *UniversalGroup) isValidMemberType(memberType string) bool {
+	if g.config == nil || len(g.config.ValidMemberTypes) == 0 {
+		return true // Allow any if not configured
+	}
+
+	if g.stringUtils != nil {
+		return g.stringUtils.InSlice(memberType, g.config.ValidMemberTypes)
+	}
+
+	for _, validType := range g.config.ValidMemberTypes {
+		if validType == memberType {
+			return true
+		}
+	}
+	return false
+}
+
+// Extension Management
+
+// SetExtension sets a custom extension field
+func (g *UniversalGroup) SetExtension(key string, value interface{}) *UniversalGroup {
+	g.Extensions[key] = value
+	g.SetUpdatedAtNow()
+	return g
+}
+
+// GetExtension retrieves a custom extension field
+func (g *UniversalGroup) GetExtension(key string) (interface{}, bool) {
+	value, exists := g.Extensions[key]
+	return value, exists
+}
+
+// Validation
+
+// Validate checks if group meets configured requirements
+func (g *UniversalGroup) Validate() error {
+	if g.config == nil {
+		return errors.New(ErrKeyGroupConfigNotSet)
+	}
+
+	// Check required fields
+	for _, field := range g.config.RequiredFields {
+		switch field {
+		case "name":
+			if g.Name == "" {
+				return errors.New(ErrKeyRequiredFieldMissingName)
+			}
+		case "type":
+			if g.Type == "" {
+				return errors.New(ErrKeyRequiredFieldMissingType)
+			}
+		}
+	}
+
+	// Validate type
+	if !g.isValidType(g.Type) {
+		return errors.New(ErrKeyInvalidGroupType)
+	}
+
+	// Validate status
+	if !g.IsValidStatus(g.Status) {
+		return errors.New(ErrKeyInvalidGroupStatus)
+	}
+
+	return nil
+}
+
+// isValidType checks if group type is valid
+func (g *UniversalGroup) isValidType(groupType string) bool {
+	if g.config == nil || len(g.config.ValidTypes) == 0 {
+		return true // Allow any if not configured
+	}
+
+	if g.stringUtils != nil {
+		return g.stringUtils.InSlice(groupType, g.config.ValidTypes)
+	}
+
+	for _, validType := range g.config.ValidTypes {
+		if validType == groupType {
+			return true
+		}
+	}
+	return false
+}
+
+// Utility Methods
+
+// GetAttributeByJSONPath retrieves nested field values using JSON path
+func (g *UniversalGroup) GetAttributeByJSONPath(jsonPath string) (interface{}, error) {
+	jsonData, err := json.Marshal(g)
+	if err != nil {
+		return nil, err
+	}
+
+	var dataMap map[string]interface{}
+	if err := json.Unmarshal(jsonData, &dataMap); err != nil {
+		return nil, err
+	}
+
+	result, err := jsonpath.Get(jsonPath, dataMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// Legacy method aliases for backward compatibility
+
+func (g *UniversalGroup) GetId() string {
+	return g.ID
+}
+
+func (g *UniversalGroup) GetFullName() string {
+	return g.Name
+}
+
+func (g *UniversalGroup) GetType() string {
+	return g.Type
+}
+
+func (g *UniversalGroup) GetHeadId() string {
+	if g.Leadership != nil {
+		return g.Leadership.HeadID
+	}
+	return ""
+}
+
+func (g *UniversalGroup) GetLeadId() string {
+	if g.Leadership != nil {
+		return g.Leadership.LeadID
+	}
+	return ""
+}
+
+func (g *UniversalGroup) GetMemberIdsByKind(kind string) []string {
+	return g.GetMemberIDsByType(toolbox.StringStandardisedToUpper(kind))
+}
+
+func (g *UniversalGroup) GetUserMembersIds() []string {
+	return g.GetUserMemberIDs()
+}
+
+func (g *UniversalGroup) SetCreatedAtTimeToNow() *UniversalGroup {
+	return g.SetCreatedAtNow()
+}
+
+func (g *UniversalGroup) SetUpdatedAtTimeToNow() *UniversalGroup {
+	return g.SetUpdatedAtNow()
+}
+
+func (g *UniversalGroup) GenerateNewUuid() *UniversalGroup {
+	return g.GenerateNewUUID()
+}
+
+func (g *UniversalGroup) GetAttributeByJsonPath(jsonPath string) (interface{}, error) {
+	return g.GetAttributeByJSONPath(jsonPath)
+}

--- a/external/group/repository.go
+++ b/external/group/repository.go
@@ -1,0 +1,618 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// GroupCollection collection name for groups
+const GroupCollection string = "groups"
+
+// MongoDbStore represents the datastore to hold group data
+type MongoDbStore interface {
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
+	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
+	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
+	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
+	ExecuteAggregateCommand(ctx context.Context, collection *mongo.Collection, mongoPipeline []bson.D) (*mongo.Cursor, error)
+	ExecuteReplaceOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, replacementObject interface{}, resultObjectName string) error
+	ExecuteUpdateManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
+	ExecuteInsertManyCommand(ctx context.Context, collection *mongo.Collection, documents []interface{}, resultObjectName string) (*mongo.InsertManyResult, error)
+
+	GetDatabase(ctx context.Context, dbName string) (*mongo.Database, error)
+	InitialiseClient(ctx context.Context) (*mongo.Client, error)
+	MapAllInCursorToResult(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error
+	MapOneInCursorToResult(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error
+}
+
+// Repository handles group data persistence
+type Repository struct {
+	Store MongoDbStore
+}
+
+// NewRepository creates a new group repository
+func NewRepository(store MongoDbStore) *Repository {
+	return &Repository{
+		Store: store,
+	}
+}
+
+// GetGroupCollection returns collection used for groups domain
+func (r *Repository) GetGroupCollection(ctx context.Context) (*mongo.Collection, error) {
+	_, err := r.Store.InitialiseClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := r.Store.GetDatabase(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	collection := db.Collection(GroupCollection)
+
+	return collection, nil
+}
+
+// CreateGroup creates a new group in the repository
+func (r *Repository) CreateGroup(ctx context.Context, group *UniversalGroup) (*UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = r.Store.ExecuteInsertOneCommand(ctx, collection, group, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return group, nil
+}
+
+// GetGroupByID retrieves a group by ID
+func (r *Repository) GetGroupByID(ctx context.Context, id string) (*UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"_id": id,
+	}
+
+	var result UniversalGroup
+	err = r.Store.ExecuteFindOneCommandDecodeResult(ctx, collection, queryFilter, &result, "group", true, errors.New(ErrKeyResourceNotFound))
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetGroupByNanoID retrieves a group by nano ID
+func (r *Repository) GetGroupByNanoID(ctx context.Context, nanoID string) (*UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"_nano_id": nanoID,
+	}
+
+	var result UniversalGroup
+	err = r.Store.ExecuteFindOneCommandDecodeResult(ctx, collection, queryFilter, &result, "group", true, errors.New(ErrKeyResourceNotFound))
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetGroupByName retrieves a group by name and optional type
+func (r *Repository) GetGroupByName(ctx context.Context, name, groupType string, logError bool) (*UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"name": normaliseGroupName(name),
+	}
+
+	if groupType != "" {
+		queryFilter["type"] = groupType
+	}
+
+	var result UniversalGroup
+	err = r.Store.ExecuteFindOneCommandDecodeResult(ctx, collection, queryFilter, &result, "group", logError, errors.New(ErrKeyUnableToFindGroupWithName))
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// UpdateGroup updates an existing group
+func (r *Repository) UpdateGroup(ctx context.Context, group *UniversalGroup) (*UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"_id": group.ID,
+	}
+
+	update := bson.M{
+		"$set": group,
+	}
+
+	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, queryFilter, update, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return group, nil
+}
+
+// DeleteGroupByID deletes a group by ID
+func (r *Repository) DeleteGroupByID(ctx context.Context, id string) error {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return err
+	}
+
+	queryFilter := bson.M{
+		"_id": id,
+	}
+
+	err = r.Store.ExecuteDeleteOneCommand(ctx, collection, queryFilter, "group")
+	return err
+}
+
+// SoftDeleteGroup soft deletes a group by setting deleted timestamp
+func (r *Repository) SoftDeleteGroup(ctx context.Context, id, deletedByID string, deletedAt string) error {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return err
+	}
+
+	queryFilter := bson.M{
+		"_id": id,
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"metadata.deleted_at":    deletedAt,
+			"metadata.deleted_by_id": deletedByID,
+			"status":                 GroupStatusArchived,
+		},
+	}
+
+	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, queryFilter, update, "group")
+	return err
+}
+
+// GetGroups retrieves groups with filters and pagination
+func (r *Repository) GetGroups(ctx context.Context, req *GetGroupsRequest) ([]UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build query filter
+	queryFilter := r.buildGroupQueryFilter(req)
+
+	// Build sort options
+	sortOptions := r.buildSortOptions(req.OrderBy)
+
+	// Calculate skip
+	skip := int64((req.Page - 1) * req.PageSize)
+	limit := int64(req.PageSize)
+
+	options := options.Find().
+		SetSort(sortOptions).
+		SetSkip(skip).
+		SetLimit(limit)
+
+	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []UniversalGroup
+	err = r.Store.MapAllInCursorToResult(ctx, cursor, &results, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetTotalGroups retrieves the total count of groups matching filters
+func (r *Repository) GetTotalGroups(ctx context.Context, req *GetGroupsRequest) (int64, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	queryFilter := r.buildGroupQueryFilter(req)
+
+	count, err := r.Store.ExecuteCountDocuments(ctx, collection, queryFilter)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// GetGroupsByType retrieves groups by type with pagination
+func (r *Repository) GetGroupsByType(ctx context.Context, groupType string, page, pageSize int, order string) ([]UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"type": groupType,
+	}
+
+	sortOptions := r.buildSortOptions(order)
+	skip := int64((page - 1) * pageSize)
+	limit := int64(pageSize)
+
+	options := options.Find().
+		SetSort(sortOptions).
+		SetSkip(skip).
+		SetLimit(limit)
+
+	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []UniversalGroup
+	err = r.Store.MapAllInCursorToResult(ctx, cursor, &results, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetGroupsByStatus retrieves groups by status with pagination
+func (r *Repository) GetGroupsByStatus(ctx context.Context, status string, page, pageSize int, order string) ([]UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"status": status,
+	}
+
+	sortOptions := r.buildSortOptions(order)
+	skip := int64((page - 1) * pageSize)
+	limit := int64(pageSize)
+
+	options := options.Find().
+		SetSort(sortOptions).
+		SetSkip(skip).
+		SetLimit(limit)
+
+	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []UniversalGroup
+	err = r.Store.MapAllInCursorToResult(ctx, cursor, &results, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetGroupsByMemberID retrieves groups that contain a specific member
+func (r *Repository) GetGroupsByMemberID(ctx context.Context, memberID string, memberType string, page, pageSize int) ([]UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"members": bson.M{
+			"$elemMatch": bson.M{
+				"id": memberID,
+			},
+		},
+	}
+
+	if memberType != "" {
+		queryFilter["members"].(bson.M)["$elemMatch"].(bson.M)["type"] = memberType
+	}
+
+	skip := int64((page - 1) * pageSize)
+	limit := int64(pageSize)
+
+	options := options.Find().
+		SetSkip(skip).
+		SetLimit(limit).
+		SetSort(bson.D{{Key: "metadata.created_at", Value: -1}})
+
+	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []UniversalGroup
+	err = r.Store.MapAllInCursorToResult(ctx, cursor, &results, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetGroupsByLeaderID retrieves groups where user is a leader (owner, head, or lead)
+func (r *Repository) GetGroupsByLeaderID(ctx context.Context, leaderID string, page, pageSize int) ([]UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"$or": []bson.M{
+			{"leadership.owner_id": leaderID},
+			{"leadership.head_id": leaderID},
+			{"leadership.lead_id": leaderID},
+			{"leadership.admin_ids": leaderID},
+		},
+	}
+
+	skip := int64((page - 1) * pageSize)
+	limit := int64(pageSize)
+
+	options := options.Find().
+		SetSkip(skip).
+		SetLimit(limit).
+		SetSort(bson.D{{Key: "metadata.created_at", Value: -1}})
+
+	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []UniversalGroup
+	err = r.Store.MapAllInCursorToResult(ctx, cursor, &results, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// SearchGroupsByExtension searches groups by extension field
+func (r *Repository) SearchGroupsByExtension(ctx context.Context, key string, value interface{}, page, pageSize int) ([]UniversalGroup, error) {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := bson.M{
+		"extensions." + key: value,
+	}
+
+	skip := int64((page - 1) * pageSize)
+	limit := int64(pageSize)
+
+	options := options.Find().
+		SetSkip(skip).
+		SetLimit(limit)
+
+	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []UniversalGroup
+	err = r.Store.MapAllInCursorToResult(ctx, cursor, &results, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// AddMemberToGroup adds a member to a group
+func (r *Repository) AddMemberToGroup(ctx context.Context, groupID string, member Member) error {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return err
+	}
+
+	queryFilter := bson.M{
+		"_id": groupID,
+	}
+
+	update := bson.M{
+		"$push": bson.M{
+			"members": member,
+		},
+	}
+
+	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, queryFilter, update, "group")
+	return err
+}
+
+// RemoveMemberFromGroup removes a member from a group
+func (r *Repository) RemoveMemberFromGroup(ctx context.Context, groupID, memberID string) error {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return err
+	}
+
+	queryFilter := bson.M{
+		"_id": groupID,
+	}
+
+	update := bson.M{
+		"$pull": bson.M{
+			"members": bson.M{
+				"id": memberID,
+			},
+		},
+	}
+
+	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, queryFilter, update, "group")
+	return err
+}
+
+// BulkUpdateGroupsStatus updates status for multiple groups
+func (r *Repository) BulkUpdateGroupsStatus(ctx context.Context, groupIDs []string, status string) error {
+	collection, err := r.GetGroupCollection(ctx)
+	if err != nil {
+		return err
+	}
+
+	queryFilter := bson.M{
+		"_id": bson.M{"$in": groupIDs},
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"status": status,
+		},
+	}
+
+	err = r.Store.ExecuteUpdateManyCommand(ctx, collection, queryFilter, update, "groups")
+	return err
+}
+
+// Helper methods
+
+// buildGroupQueryFilter builds a query filter for group searches
+func (r *Repository) buildGroupQueryFilter(req *GetGroupsRequest) bson.M {
+	queryFilter := bson.M{}
+
+	// Type filters
+	if len(req.Types) > 0 {
+		queryFilter["type"] = bson.M{"$in": req.Types}
+	}
+
+	// Status filters
+	if len(req.Statuses) > 0 {
+		queryFilter["status"] = bson.M{"$in": req.Statuses}
+	}
+
+	// Member filters
+	if req.MemberID != "" {
+		memberFilter := bson.M{
+			"members": bson.M{
+				"$elemMatch": bson.M{
+					"id": req.MemberID,
+				},
+			},
+		}
+		if req.MemberType != "" {
+			memberFilter["members"].(bson.M)["$elemMatch"].(bson.M)["type"] = req.MemberType
+		}
+		for key, value := range memberFilter {
+			queryFilter[key] = value
+		}
+	}
+
+	// Members with specific IDs and types
+	if len(req.MembersWithIDs) > 0 {
+		memberConditions := []bson.M{}
+		for memberType, ids := range req.MembersWithIDs {
+			for _, id := range ids {
+				memberConditions = append(memberConditions, bson.M{
+					"members": bson.M{
+						"$elemMatch": bson.M{
+							"id":   id,
+							"type": memberType,
+						},
+					},
+				})
+			}
+		}
+		if len(memberConditions) > 0 {
+			queryFilter["$and"] = memberConditions
+		}
+	}
+
+	// Leadership filters
+	if req.OwnerID != "" {
+		queryFilter["leadership.owner_id"] = req.OwnerID
+	}
+	if req.HeadID != "" {
+		queryFilter["leadership.head_id"] = req.HeadID
+	}
+	if req.LeadID != "" {
+		queryFilter["leadership.lead_id"] = req.LeadID
+	}
+
+	// Settings filters
+	if req.Visibility != "" {
+		queryFilter["settings.visibility"] = req.Visibility
+	}
+
+	// Name search (case-insensitive regex)
+	if req.NameSearch != "" {
+		queryFilter["name"] = bson.M{
+			"$regex":   req.NameSearch,
+			"$options": "i",
+		}
+	}
+
+	// Extension filters
+	for key, value := range req.ExtensionFilters {
+		queryFilter["extensions."+key] = value
+	}
+
+	// Exclude soft-deleted groups by default
+	if queryFilter["metadata.deleted_at"] == nil {
+		queryFilter["metadata.deleted_at"] = bson.M{"$exists": false}
+	}
+
+	return queryFilter
+}
+
+// buildSortOptions builds sort options based on order string
+func (r *Repository) buildSortOptions(order string) bson.D {
+	switch order {
+	case GetGroupOrderCreatedAtDesc:
+		return bson.D{{Key: "metadata.created_at", Value: -1}}
+	case GetGroupOrderCreatedAtAsc:
+		return bson.D{{Key: "metadata.created_at", Value: 1}}
+	case GetGroupOrderUpdatedAtDesc:
+		return bson.D{{Key: "metadata.updated_at", Value: -1}}
+	case GetGroupOrderUpdatedAtAsc:
+		return bson.D{{Key: "metadata.updated_at", Value: 1}}
+	case GetGroupOrderNameAsc:
+		return bson.D{{Key: "name", Value: 1}}
+	case GetGroupOrderNameDesc:
+		return bson.D{{Key: "name", Value: -1}}
+	case GetGroupOrderMemberCountDesc:
+		return bson.D{{Key: "members", Value: -1}}
+	case GetGroupOrderMemberCountAsc:
+		return bson.D{{Key: "members", Value: 1}}
+	default:
+		return bson.D{{Key: "metadata.created_at", Value: -1}}
+	}
+}
+
+// normaliseGroupName standardises group name
+func normaliseGroupName(name string) string {
+	return strings.TrimSpace(name)
+}

--- a/external/group/request.go
+++ b/external/group/request.go
@@ -1,0 +1,151 @@
+package group
+
+// GetGroupsRequest defines the request structure for getting groups
+type GetGroupsRequest struct {
+	// Type filters (flexible - any type string)
+	Types []string `json:"types,omitempty" query:"types"`
+
+	// Status filters
+	Statuses []string `query:"statuses"`
+
+	// Member filters
+	MemberID       string              ` query:"member_id"`
+	MemberType     string              ` query:"member_type"`
+	MembersWithIDs map[string][]string ` query:"members_with_ids"`
+
+	// Leadership filters
+	OwnerID string ` query:"owner_id"`
+	HeadID  string ` query:"head_id"`
+	LeadID  string ` query:"lead_id"`
+
+	// Settings filters
+	Visibility string `query:"visibility"`
+
+	// Search
+	NameSearch string `query:"name_search"`
+
+	// Pagination
+	Page       int    ` query:"page"`
+	PageSize   int    ` query:"page_size"`
+	PerPage    int    ` query:"per_page"` // Alias for PageSize
+	OrderBy    string ` query:"order_by"`
+	Meta       bool   ` query:"meta"`
+	TotalCount int    ` query:"total_count"`
+
+	// Extension filters (for custom queries)
+	ExtensionFilters map[string]interface{} `json:"extension_filters,omitempty" query:"extension_filters"`
+}
+
+// GetGroupByIDRequest defines the request for getting a single group
+type GetGroupByIDRequest struct {
+	ID string `path:"groupID"`
+}
+
+// GetGroupByNanoIDRequest defines the request for getting a single group by nano ID
+type GetGroupByNanoIDRequest struct {
+	NanoID string `path:"groupNanoID"`
+}
+
+// GetGroupByNameRequest defines the request for getting a group by name
+type GetGroupByNameRequest struct {
+	Name string `query:"name"`
+	Type string `query:"type"` // Optional type filter
+}
+
+// CreateGroupRequest defines the request for creating a new group
+type CreateGroupRequest struct {
+	Name        string                 `json:"name" validate:"required"`
+	Type        string                 `json:"type" validate:"required"`
+	Description string                 `json:"description,omitempty"`
+	Email       string                 `json:"email,omitempty"`
+	Icon        string                 `json:"icon,omitempty"`
+	Visibility  string                 `json:"visibility,omitempty"`
+	Extensions  map[string]interface{} `json:"extensions,omitempty"`
+
+	// Initial members
+	InitialMembers []CreateMemberRequest `json:"initial_members,omitempty"`
+
+	// Initial leadership
+	OwnerID string `json:"owner_id,omitempty"`
+	HeadID  string `json:"head_id,omitempty"`
+	LeadID  string `json:"lead_id,omitempty"`
+}
+
+// CreateMemberRequest defines member data for creation
+type CreateMemberRequest struct {
+	ID   string `json:"id" validate:"required"`
+	Type string `json:"type" validate:"required"`
+	Role string `json:"role,omitempty"`
+}
+
+// UpdateGroupRequest defines the request for updating a group
+type UpdateGroupRequest struct {
+	ID          string                 `path:"groupID"`
+	Name        *string                `json:"name,omitempty"`
+	Description *string                `json:"description,omitempty"`
+	Email       *string                `json:"email,omitempty"`
+	Icon        *string                `json:"icon,omitempty"`
+	Visibility  *string                `json:"visibility,omitempty"`
+	Status      *string                `json:"status,omitempty"`
+	Extensions  map[string]interface{} `json:"extensions,omitempty"`
+	// Group if specified updates entire group object
+	Group *UniversalGroup `json:"group,omitempty"`
+}
+
+// AddMemberRequest defines the request for adding a member
+type AddMemberRequest struct {
+	GroupID  string `path:"groupID"`
+	MemberID string `json:"member_id" validate:"required"`
+	Type     string `json:"type" validate:"required"`
+	Role     string `json:"role,omitempty"`
+}
+
+// RemoveMemberRequest defines the request for removing a member
+type RemoveMemberRequest struct {
+	GroupID  string `path:"groupID"`
+	MemberID string `path:"memberID"`
+}
+
+// UpdateMemberRoleRequest defines the request for updating a member's role
+type UpdateMemberRoleRequest struct {
+	GroupID  string `path:"groupID"`
+	MemberID string `path:"memberID"`
+	NewRole  string `json:"new_role" validate:"required"`
+}
+
+// GetGroupMembersRequest defines the request for getting group members
+type GetGroupMembersRequest struct {
+	GroupID    string `path:"groupID"`
+	MemberType string `query:"member_type"`
+	Role       string `query:"role"`
+}
+
+// UpdateLeadershipRequest defines the request for updating leadership
+type UpdateLeadershipRequest struct {
+	GroupID string  `path:"groupID"`
+	OwnerID *string `json:"owner_id,omitempty"`
+	HeadID  *string `json:"head_id,omitempty"`
+	LeadID  *string `json:"lead_id,omitempty"`
+}
+
+// DeleteGroupRequest defines the request for deleting a group
+type DeleteGroupRequest struct {
+	ID          string `path:"groupID"`
+	DeletedByID string `query:"deleted_by_id"`
+	HardDelete  bool   `query:"hard_delete"`
+}
+
+// ArchiveGroupRequest defines the request for archiving a group
+type ArchiveGroupRequest struct {
+	ID string `path:"groupID"`
+}
+
+// RestoreGroupRequest defines the request for restoring a group
+type RestoreGroupRequest struct {
+	ID string `path:"groupID"`
+}
+
+// GetGroupStatsRequest defines the request for getting group statistics
+type GetGroupStatsRequest struct {
+	ID string `path:"groupID"`
+}

--- a/external/group/response.go
+++ b/external/group/response.go
@@ -1,0 +1,96 @@
+package group
+
+// GetGroupsResponse defines the response structure for getting groups
+type GetGroupsResponse struct {
+	Total      int               `json:"total"`
+	TotalPages int               `json:"total_pages"`
+	Groups     []*UniversalGroup `json:"groups"`
+	Page       int               `json:"page"`
+	PerPage    int               `json:"per_page"`
+}
+
+// GetMetaData returns metadata in reply.WithMeta format
+func (r *GetGroupsResponse) GetMetaData() map[string]interface{} {
+	return map[string]interface{}{
+		"page":            r.Page,
+		"per_page":        r.PerPage,
+		"total_resources": r.Total,
+		"total_pages":     r.TotalPages,
+	}
+}
+
+// GetGroupByIDResponse defines the response for getting a single group
+type GetGroupByIDResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// GetGroupByNanoIDResponse defines the response for getting a single group by nano ID
+type GetGroupByNanoIDResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// GetGroupByNameResponse defines the response for getting a group by name
+type GetGroupByNameResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// CreateGroupResponse defines the response for creating a group
+type CreateGroupResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// UpdateGroupResponse defines the response for updating a group
+type UpdateGroupResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// DeleteGroupResponse defines the response for deleting a group
+type DeleteGroupResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}
+
+// GetGroupMembersResponse defines the response for getting group members
+type GetGroupMembersResponse struct {
+	Members []Member `json:"members"`
+	Count   int      `json:"count"`
+}
+
+// AddMemberResponse defines the response for adding a member
+type AddMemberResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// RemoveMemberResponse defines the response for removing a member
+type RemoveMemberResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// UpdateMemberRoleResponse defines the response for updating a member role
+type UpdateMemberRoleResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// UpdateLeadershipResponse defines the response for updating leadership
+type UpdateLeadershipResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// ArchiveGroupResponse defines the response for archiving a group
+type ArchiveGroupResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// RestoreGroupResponse defines the response for restoring a group
+type RestoreGroupResponse struct {
+	Group *UniversalGroup `json:"group"`
+}
+
+// GetGroupStatsResponse defines the response for group statistics
+type GetGroupStatsResponse struct {
+	GroupID          string `json:"group_id"`
+	MemberCount      int    `json:"member_count"`
+	UserMemberCount  int    `json:"user_member_count"`
+	GroupMemberCount int    `json:"group_member_count"`
+	SubgroupCount    int    `json:"subgroup_count,omitempty"`
+}

--- a/external/group/routes.go
+++ b/external/group/routes.go
@@ -1,0 +1,84 @@
+package group
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/ooaklee/ghatd/external/router"
+)
+
+// GroupHandler interface defines expected methods for valid group handler
+type GroupHandler interface {
+	CreateGroup(w http.ResponseWriter, r *http.Request)
+	GetGroupByID(w http.ResponseWriter, r *http.Request)
+	GetGroupByNanoID(w http.ResponseWriter, r *http.Request)
+	GetGroupByName(w http.ResponseWriter, r *http.Request)
+	UpdateGroup(w http.ResponseWriter, r *http.Request)
+	DeleteGroup(w http.ResponseWriter, r *http.Request)
+	GetGroups(w http.ResponseWriter, r *http.Request)
+	AddMember(w http.ResponseWriter, r *http.Request)
+	RemoveMember(w http.ResponseWriter, r *http.Request)
+	UpdateMemberRole(w http.ResponseWriter, r *http.Request)
+	GetGroupMembers(w http.ResponseWriter, r *http.Request)
+	UpdateLeadership(w http.ResponseWriter, r *http.Request)
+	ArchiveGroup(w http.ResponseWriter, r *http.Request)
+	RestoreGroup(w http.ResponseWriter, r *http.Request)
+	GetGroupStats(w http.ResponseWriter, r *http.Request)
+}
+
+// APIGroupsV1Prefix base URI prefix for all v1 groups routes
+const APIGroupsV1Prefix = "/api/v1/groups"
+
+// AttachRoutesRequest holds everything needed to attach group routes to router
+type AttachRoutesRequest struct {
+	// Router main router being served by API
+	Router *router.Router
+
+	// Handler valid group handler
+	Handler GroupHandler
+
+	// AdminOnlyMiddleware middleware used to lock endpoints down to admin only
+	AdminOnlyMiddleware mux.MiddlewareFunc
+
+	// AuthenticatedMiddleware middleware used for authenticated users
+	AuthenticatedMiddleware mux.MiddlewareFunc
+}
+
+// AttachRoutes attaches group handler to corresponding routes on router
+func AttachRoutes(request *AttachRoutesRequest) {
+	httpRouter := request.Router.GetRouter()
+
+	// Admin-only routes for full group management
+	groupsAdminOnlyRoutes := httpRouter.PathPrefix(APIGroupsV1Prefix).Subrouter()
+	groupsAdminOnlyRoutes.HandleFunc("", request.Handler.CreateGroup).Methods(http.MethodPost, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("", request.Handler.GetGroups).Methods(http.MethodGet, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}", request.Handler.GetGroupByID).Methods(http.MethodGet, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}", request.Handler.UpdateGroup).Methods(http.MethodPatch, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}", request.Handler.DeleteGroup).Methods(http.MethodDelete, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/nano/{groupNanoID}", request.Handler.GetGroupByNanoID).Methods(http.MethodGet, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/search", request.Handler.GetGroupByName).Methods(http.MethodGet, http.MethodOptions)
+
+	// Group status operations
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}/archive", request.Handler.ArchiveGroup).Methods(http.MethodPost, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}/restore", request.Handler.RestoreGroup).Methods(http.MethodPost, http.MethodOptions)
+
+	// Member management
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}/members", request.Handler.GetGroupMembers).Methods(http.MethodGet, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}/members", request.Handler.AddMember).Methods(http.MethodPost, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}/members/{memberID}", request.Handler.RemoveMember).Methods(http.MethodDelete, http.MethodOptions)
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}/members/{memberID}/role", request.Handler.UpdateMemberRole).Methods(http.MethodPut, http.MethodOptions)
+
+	// Leadership management
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}/leadership", request.Handler.UpdateLeadership).Methods(http.MethodPut, http.MethodOptions)
+
+	// Statistics
+	groupsAdminOnlyRoutes.HandleFunc("/{groupID}/stats", request.Handler.GetGroupStats).Methods(http.MethodGet, http.MethodOptions)
+
+	groupsAdminOnlyRoutes.Use(request.AdminOnlyMiddleware)
+
+	// Authenticated routes (if needed for self-service operations)
+	// Uncomment and customise as needed:
+	// groupsAuthenticatedRoutes := httpRouter.PathPrefix(APIGroupsV1Prefix).Subrouter()
+	// groupsAuthenticatedRoutes.HandleFunc("/my-groups", request.Handler.GetMyGroups).Methods(http.MethodGet, http.MethodOptions)
+	// groupsAuthenticatedRoutes.Use(request.AuthenticatedMiddleware)
+}

--- a/external/group/service.go
+++ b/external/group/service.go
@@ -1,0 +1,1027 @@
+package group
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ooaklee/ghatd/external/audit"
+	"github.com/ooaklee/ghatd/external/logger"
+	"github.com/ooaklee/ghatd/external/toolbox"
+	"go.uber.org/zap"
+)
+
+// AuditService expected methods of a valid audit service
+type AuditService interface {
+	LogAuditEvent(ctx context.Context, r *audit.LogAuditEventRequest) error
+}
+
+// GroupRepository expected methods of a valid group repository
+type GroupRepository interface {
+	CreateGroup(ctx context.Context, group *UniversalGroup) (*UniversalGroup, error)
+	GetGroupByID(ctx context.Context, id string) (*UniversalGroup, error)
+	GetGroupByNanoID(ctx context.Context, nanoID string) (*UniversalGroup, error)
+	GetGroupByName(ctx context.Context, name, groupType string, logError bool) (*UniversalGroup, error)
+	UpdateGroup(ctx context.Context, group *UniversalGroup) (*UniversalGroup, error)
+	DeleteGroupByID(ctx context.Context, id string) error
+	SoftDeleteGroup(ctx context.Context, id, deletedByID string, deletedAt string) error
+	GetGroups(ctx context.Context, req *GetGroupsRequest) ([]UniversalGroup, error)
+	GetTotalGroups(ctx context.Context, req *GetGroupsRequest) (int64, error)
+	GetGroupsByType(ctx context.Context, groupType string, page, pageSize int, order string) ([]UniversalGroup, error)
+	GetGroupsByStatus(ctx context.Context, status string, page, pageSize int, order string) ([]UniversalGroup, error)
+	GetGroupsByMemberID(ctx context.Context, memberID string, memberType string, page, pageSize int) ([]UniversalGroup, error)
+	GetGroupsByLeaderID(ctx context.Context, leaderID string, page, pageSize int) ([]UniversalGroup, error)
+	SearchGroupsByExtension(ctx context.Context, key string, value interface{}, page, pageSize int) ([]UniversalGroup, error)
+	AddMemberToGroup(ctx context.Context, groupID string, member Member) error
+	RemoveMemberFromGroup(ctx context.Context, groupID, memberID string) error
+	BulkUpdateGroupsStatus(ctx context.Context, groupIDs []string, status string) error
+}
+
+// Service holds and manages group business logic
+type Service struct {
+	GroupRepository GroupRepository
+	AuditService    AuditService
+	Config          *GroupConfig
+	IDGenerator     IDGenerator
+	TimeProvider    TimeProvider
+	StringUtils     StringUtils
+}
+
+// NewService creates a new group service
+func NewService(
+	groupRepository GroupRepository,
+	auditService AuditService,
+	config *GroupConfig,
+	idGenerator IDGenerator,
+	timeProvider TimeProvider,
+	stringUtils StringUtils,
+) *Service {
+	if config == nil {
+		config = DefaultGroupConfig()
+	}
+
+	return &Service{
+		GroupRepository: groupRepository,
+		AuditService:    auditService,
+		Config:          config,
+		IDGenerator:     idGenerator,
+		TimeProvider:    timeProvider,
+		StringUtils:     stringUtils,
+	}
+}
+
+// CreateGroup creates a new group
+func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*CreateGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "create-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("creating-group", zap.String("name", req.Name), zap.String("type", req.Type))
+
+	// Check if group with same name already exists
+	existingGroup, err := s.GroupRepository.GetGroupByName(ctx, req.Name, req.Type, false)
+	if err == nil && existingGroup != nil {
+		log.Debug("group-with-name-already-exists", zap.String("name", req.Name))
+		return nil, errors.New(ErrKeyNameAlreadyExists)
+	}
+
+	// Create new group with dependencies
+	group := NewUniversalGroup(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Set basic fields
+	group.Name = req.Name
+	group.Type = req.Type
+
+	// Set display info if provided
+	if req.Description != "" || req.Email != "" || req.Icon != "" {
+		group.DisplayInfo.Description = req.Description
+		group.DisplayInfo.Email = req.Email
+		group.DisplayInfo.Icon = req.Icon
+	}
+
+	// Set visibility
+	if req.Visibility != "" {
+		group.Settings.Visibility = req.Visibility
+	} else {
+		group.Settings.Visibility = VisibilityPrivate // Default
+	}
+
+	// Set extensions
+	if len(req.Extensions) > 0 {
+		group.Extensions = req.Extensions
+	}
+
+	// Set leadership
+	if req.OwnerID != "" || req.HeadID != "" || req.LeadID != "" {
+		group.Leadership.OwnerID = req.OwnerID
+		group.Leadership.HeadID = req.HeadID
+		group.Leadership.LeadID = req.LeadID
+	}
+
+	// Generate IDs
+	group.GenerateNewUUID()
+	if s.Config.MultipleIdentifiers {
+		group.GenerateNewNanoID()
+	}
+
+	// Set initial timestamps and state
+	group.SetInitialState()
+
+	// Add initial members if provided
+	for _, memberReq := range req.InitialMembers {
+		if _, err := group.AddMember(memberReq.ID, memberReq.Type, memberReq.Role); err != nil {
+			log.Error("failed-to-add-initial-member", zap.Error(err), zap.String("member_id", memberReq.ID))
+			return nil, err
+		}
+	}
+
+	// Validate group
+	if err := group.Validate(); err != nil {
+		log.Error("group-validation-failed", zap.Error(err))
+		return nil, err
+	}
+
+	// Create group in repository
+	createdGroup, err := s.GroupRepository.CreateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-create-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.created",
+			TargetId: createdGroup.ID,
+			Details: map[string]interface{}{
+				"group_name": createdGroup.Name,
+				"group_type": createdGroup.Type,
+			},
+		})
+	}
+
+	return &CreateGroupResponse{Group: createdGroup}, nil
+}
+
+// GetGroupByID retrieves a group by ID
+func (s *Service) GetGroupByID(ctx context.Context, req *GetGroupByIDRequest) (*GetGroupByIDResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-by-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("getting-group-by-id", zap.String("id", req.ID))
+
+	group, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
+	if err != nil {
+		log.Error("failed-to-get-group-by-id", zap.Error(err), zap.String("id", req.ID))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	return &GetGroupByIDResponse{Group: group}, nil
+}
+
+// GetGroupByName retrieves a group by its name
+func (s *Service) GetGroupByNanoID(ctx context.Context, req *GetGroupByNanoIDRequest) (*GetGroupByNanoIDResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-by-nano-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("getting-group-by-nano-id", zap.String("nano_id", req.NanoID))
+
+	group, err := s.GroupRepository.GetGroupByNanoID(ctx, req.NanoID)
+	if err != nil {
+		log.Error("failed-to-get-group-by-nano-id", zap.Error(err), zap.String("nano_id", req.NanoID))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	return &GetGroupByNanoIDResponse{Group: group}, nil
+}
+
+// GetGroupByName retrieves a group by name and optional type
+func (s *Service) GetGroupByName(ctx context.Context, req *GetGroupByNameRequest) (*GetGroupByNameResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-by-name")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("getting-group-by-name", zap.String("name", req.Name), zap.String("type", req.Type))
+
+	group, err := s.GroupRepository.GetGroupByName(ctx, req.Name, req.Type, true)
+	if err != nil {
+		log.Error("failed-to-get-group-by-name", zap.Error(err), zap.String("name", req.Name))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	return &GetGroupByNameResponse{Group: group}, nil
+}
+
+// UpdateGroup updates an existing group
+func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*UpdateGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("updating-group", zap.String("id", req.ID))
+
+	targetGroupID := req.ID
+	if req.Group != nil && req.Group.ID != "" {
+		targetGroupID = req.Group.ID
+	}
+
+	// Get existing group
+	group, err := s.GroupRepository.GetGroupByID(ctx, targetGroupID)
+	if err != nil {
+		log.Error("failed-to-get-group-for-update", zap.Error(err), zap.String("id", targetGroupID))
+		return nil, err
+	}
+
+	if req.Group != nil {
+		groupWithProvidedData := req.Group
+
+		groupWithProvidedData.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+		if groupWithProvidedData.Name != "" && groupWithProvidedData.Name != group.Name {
+			// Check if new name already exists
+			existingGroup, _ := s.GroupRepository.GetGroupByName(ctx, groupWithProvidedData.Name, groupWithProvidedData.Type, false)
+			if existingGroup != nil && existingGroup.ID != group.ID {
+				return nil, errors.New(ErrKeyNameAlreadyExists)
+			}
+			group.Name = groupWithProvidedData.Name
+		}
+
+		group = groupWithProvidedData
+	}
+
+	if req.Group == nil {
+		group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+		// Track if any changes were made
+		hasChanges := false
+
+		// Update fields if provided
+		if req.Name != nil && *req.Name != group.Name {
+			group.Name = *req.Name
+			hasChanges = true
+		}
+
+		if req.Description != nil && *req.Description != group.DisplayInfo.Description {
+			group.DisplayInfo.Description = *req.Description
+			hasChanges = true
+		}
+
+		if req.Email != nil && *req.Email != group.DisplayInfo.Email {
+			group.DisplayInfo.Email = *req.Email
+			hasChanges = true
+		}
+
+		if req.Icon != nil && *req.Icon != group.DisplayInfo.Icon {
+			group.DisplayInfo.Icon = *req.Icon
+			hasChanges = true
+		}
+
+		if req.Visibility != nil && *req.Visibility != group.Settings.Visibility {
+			group.Settings.Visibility = *req.Visibility
+			hasChanges = true
+		}
+
+		if req.Status != nil && *req.Status != group.Status {
+			_, err := group.UpdateStatus(*req.Status)
+			if err != nil {
+				log.Error("failed-to-update-group-status", zap.Error(err))
+				return nil, err
+			}
+			hasChanges = true
+		}
+
+		// Update extensions
+		if len(req.Extensions) > 0 {
+			for key, value := range req.Extensions {
+				group.SetExtension(key, value)
+			}
+			hasChanges = true
+		}
+
+		if !hasChanges {
+			log.Debug("no-changes-detected-for-group-update", zap.String("id", req.ID))
+			return &UpdateGroupResponse{Group: group}, nil
+		}
+	}
+
+	// Update timestamps
+	group.SetUpdatedAtNow()
+
+	// Validate group
+	if err := group.Validate(); err != nil {
+		log.Error("group-validation-failed", zap.Error(err))
+		return nil, err
+	}
+
+	// Ensure version is set to 1
+	group.EnsureVersion()
+
+	// Update in repository
+	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.updated",
+			TargetId: updatedGroup.ID,
+			Details: map[string]interface{}{
+				"group_name": updatedGroup.Name,
+			},
+		})
+	}
+
+	log.Info("group-updated-successfully", zap.String("group-id", updatedGroup.ID))
+
+	return &UpdateGroupResponse{Group: updatedGroup}, nil
+}
+
+// DeleteGroup deletes a group
+func (s *Service) DeleteGroup(ctx context.Context, req *DeleteGroupRequest) (*DeleteGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "delete-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("deleting-group", zap.String("id", req.ID), zap.Bool("hard_delete", req.HardDelete))
+
+	// Verify group exists
+	_, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
+	if err != nil {
+		log.Error("group-not-found-for-deletion", zap.Error(err), zap.String("id", req.ID))
+		return nil, err
+	}
+
+	if req.HardDelete {
+		// Hard delete - permanently remove
+		err = s.GroupRepository.DeleteGroupByID(ctx, req.ID)
+	} else {
+		// Soft delete - mark as deleted
+		deletedAt := s.TimeProvider.NowUTC()
+		err = s.GroupRepository.SoftDeleteGroup(ctx, req.ID, req.DeletedByID, deletedAt)
+	}
+
+	if err != nil {
+		log.Error("failed-to-delete-group", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.deleted",
+			TargetId: req.ID,
+			Details: map[string]interface{}{
+				"hard_delete":   req.HardDelete,
+				"deleted_by_id": req.DeletedByID,
+			},
+		})
+	}
+
+	return &DeleteGroupResponse{
+		Success: true,
+		Message: "Group deleted successfully",
+	}, nil
+}
+
+// GetGroups retrieves groups with filters and pagination
+func (s *Service) GetGroups(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("getting-groups", zap.Int("page", req.Page), zap.Int("page_size", req.PageSize))
+
+	// Normalize PerPage to PageSize
+	if req.PerPage > 0 {
+		req.PageSize = req.PerPage
+	}
+
+	// Set defaults
+	if req.PageSize == 0 {
+		req.PageSize = 20
+	}
+	if req.Page == 0 {
+		req.Page = 1
+	}
+
+	// Get total count
+	totalGroups, err := s.GroupRepository.GetTotalGroups(ctx, req)
+	if err != nil {
+		log.Error("failed-to-get-total-groups-count", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	req.TotalCount = int(totalGroups)
+	log.Debug("handling-get-groups-request-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", req))
+
+	// Get groups
+	groups, err := s.GroupRepository.GetGroups(ctx, req)
+	if err != nil {
+		log.Error("failed-to-get-groups", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Reinject dependencies for all groups
+	groupPointers := make([]*UniversalGroup, len(groups))
+	for i := range groups {
+		groups[i].SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+		groupPointers[i] = &groups[i]
+	}
+
+	paginatedResponse, err := toolbox.Paginate(ctx, &toolbox.PaginationRequest{
+		PerPage: req.PageSize,
+		Page:    req.Page,
+	}, groupPointers, req.TotalCount)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetGroupsResponse{
+		Total:      paginatedResponse.Total,
+		TotalPages: paginatedResponse.TotalPages,
+		Groups:     paginatedResponse.Resources,
+		Page:       paginatedResponse.Page,
+		PerPage:    paginatedResponse.ResourcePerPage,
+	}, nil
+}
+
+// AddMember adds a member to a group
+func (s *Service) AddMember(ctx context.Context, req *AddMemberRequest) (*AddMemberResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "add-member")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("adding-member-to-group", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err), zap.String("group_id", req.GroupID))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Add member
+	if _, err := group.AddMember(req.MemberID, req.Type, req.Role); err != nil {
+		log.Error("failed-to-add-member", zap.Error(err))
+		return nil, err
+	}
+
+	// Save to repository
+	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Get the added member
+	addedMember, _ := group.GetMemberByID(req.MemberID)
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.member.added",
+			TargetId: req.GroupID,
+			Details: map[string]interface{}{
+				"member": addedMember,
+			},
+		})
+	}
+
+	return &AddMemberResponse{
+		Group: updatedGroup,
+	}, nil
+}
+
+// RemoveMember removes a member from a group
+func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*RemoveMemberResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "remove-member")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("removing-member-from-group", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err), zap.String("group_id", req.GroupID))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Remove member
+	if group, err = group.RemoveMember(req.MemberID); err != nil {
+		log.Error("failed-to-remove-member", zap.Error(err))
+		return nil, err
+	}
+
+	// Save to repository
+	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.member.removed",
+			TargetId: req.GroupID,
+			Details: map[string]interface{}{
+				"member": map[string]string{
+					"id": req.MemberID,
+				},
+			},
+		})
+	}
+
+	return &RemoveMemberResponse{
+		Group: updatedGroup,
+	}, nil
+}
+
+// UpdateMemberRole updates a member's role in a group
+func (s *Service) UpdateMemberRole(ctx context.Context, req *UpdateMemberRoleRequest) (*UpdateGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-member-role")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("updating-member-role", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Update role
+	if group, err = group.UpdateMemberRole(req.MemberID, req.NewRole); err != nil {
+		log.Error("failed-to-update-member-role", zap.Error(err))
+		return nil, err
+	}
+
+	// Save to repository
+	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	memberInfo, _ := group.GetMemberByID(req.MemberID)
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.member.role_updated",
+			TargetId: req.GroupID,
+			Details: map[string]interface{}{
+				"member": memberInfo,
+			},
+		})
+	}
+
+	return &UpdateGroupResponse{Group: updatedGroup}, nil
+}
+
+// GetGroupMembers retrieves members of a group with optional filters
+func (s *Service) GetGroupMembers(ctx context.Context, req *GetGroupMembersRequest) (*GetGroupMembersResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-members")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("getting-group-members", zap.String("group_id", req.GroupID))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Filter members
+	var members []Member
+	if req.MemberType != "" {
+		members = group.GetMembersByType(req.MemberType)
+	} else {
+		members = group.Members
+	}
+
+	// Further filter by role if specified
+	if req.Role != "" {
+		filteredMembers := []Member{}
+		for _, member := range members {
+			if member.Role == req.Role {
+				filteredMembers = append(filteredMembers, member)
+			}
+		}
+		members = filteredMembers
+	}
+
+	return &GetGroupMembersResponse{
+		Members: members,
+		Count:   len(members),
+	}, nil
+}
+
+// UpdateLeadership updates group leadership
+func (s *Service) UpdateLeadership(ctx context.Context, req *UpdateLeadershipRequest) (*UpdateGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-leadership")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("updating-group-leadership", zap.String("group_id", req.GroupID))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Update leadership fields
+	hasChanges := false
+	if req.OwnerID != nil && *req.OwnerID != group.Leadership.OwnerID {
+		group.Leadership.OwnerID = *req.OwnerID
+		hasChanges = true
+	}
+	if req.HeadID != nil && *req.HeadID != group.Leadership.HeadID {
+		group.Leadership.HeadID = *req.HeadID
+		hasChanges = true
+	}
+	if req.LeadID != nil && *req.LeadID != group.Leadership.LeadID {
+		group.Leadership.LeadID = *req.LeadID
+		hasChanges = true
+	}
+
+	if !hasChanges {
+		return nil, errors.New(ErrKeyNoChangesDetected)
+	}
+
+	// Update timestamps
+	group.SetUpdatedAtNow()
+
+	// Save to repository
+	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.leadership.updated",
+			TargetId: req.GroupID,
+		})
+	}
+
+	return &UpdateGroupResponse{Group: updatedGroup}, nil
+}
+
+// ArchiveGroup archives a group
+func (s *Service) ArchiveGroup(ctx context.Context, req *ArchiveGroupRequest) (*UpdateGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "archive-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("archiving-group", zap.String("id", req.ID))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Update status to archived
+	_, err = group.UpdateStatus(GroupStatusArchived)
+	if err != nil {
+		log.Error("failed-to-archive-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Save to repository
+	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.archived",
+			TargetId: req.ID,
+		})
+	}
+
+	return &UpdateGroupResponse{Group: updatedGroup}, nil
+}
+
+// RestoreGroup restores an archived group
+func (s *Service) RestoreGroup(ctx context.Context, req *RestoreGroupRequest) (*UpdateGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "restore-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("restoring-group", zap.String("id", req.ID))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Update status to active
+	_, err = group.UpdateStatus(GroupStatusActive)
+	if err != nil {
+		log.Error("failed-to-restore-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Save to repository
+	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action:   "group.restored",
+			TargetId: req.ID,
+		})
+	}
+
+	return &UpdateGroupResponse{Group: updatedGroup}, nil
+}
+
+// GetGroupsByMemberID retrieves groups that contain a specific member
+func (s *Service) GetGroupsByMemberID(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups-by-member-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("getting-groups-by-member-id", zap.String("member_id", req.MemberID))
+
+	// Normalize PerPage to PageSize
+	if req.PerPage > 0 {
+		req.PageSize = req.PerPage
+	}
+
+	// Set defaults
+	if req.PageSize == 0 {
+		req.PageSize = 20
+	}
+	if req.Page == 0 {
+		req.Page = 1
+	}
+
+	// Get total count using GetTotalGroups
+	totalGroups, err := s.GroupRepository.GetTotalGroups(ctx, req)
+	if err != nil {
+		log.Error("failed-to-get-total-groups-count-by-member-id", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	req.TotalCount = int(totalGroups)
+	log.Debug("handling-get-groups-by-member-id-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", req))
+
+	groups, err := s.GroupRepository.GetGroupsByMemberID(ctx, req.MemberID, req.MemberType, req.Page, req.PageSize)
+	if err != nil {
+		log.Error("failed-to-get-groups-by-member-id", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Reinject dependencies
+	groupPointers := make([]*UniversalGroup, len(groups))
+	for i := range groups {
+		groups[i].SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+		groupPointers[i] = &groups[i]
+	}
+
+	paginatedResponse, err := toolbox.Paginate(ctx, &toolbox.PaginationRequest{
+		PerPage: req.PageSize,
+		Page:    req.Page,
+	}, groupPointers, req.TotalCount)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetGroupsResponse{
+		Total:      paginatedResponse.Total,
+		TotalPages: paginatedResponse.TotalPages,
+		Groups:     paginatedResponse.Resources,
+		Page:       paginatedResponse.Page,
+		PerPage:    paginatedResponse.ResourcePerPage,
+	}, nil
+}
+
+// GetGroupsByLeaderID retrieves groups where user is a leader
+func (s *Service) GetGroupsByLeaderID(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups-by-leader-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("getting-groups-by-leader-id", zap.String("owner_id", req.OwnerID), zap.String("head_id", req.HeadID), zap.String("lead_id", req.LeadID))
+
+	// Normalize PerPage to PageSize
+	if req.PerPage > 0 {
+		req.PageSize = req.PerPage
+	}
+
+	// Set defaults
+	if req.PageSize == 0 {
+		req.PageSize = 20
+	}
+	if req.Page == 0 {
+		req.Page = 1
+	}
+
+	// Get total count using GetTotalGroups
+	totalGroups, err := s.GroupRepository.GetTotalGroups(ctx, req)
+	if err != nil {
+		log.Error("failed-to-get-total-groups-count-by-leader-id", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	req.TotalCount = int(totalGroups)
+	log.Debug("handling-get-groups-by-leader-id-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", req))
+
+	// Determine which leader field to use
+	leaderID := req.OwnerID
+	if leaderID == "" {
+		leaderID = req.HeadID
+	}
+	if leaderID == "" {
+		leaderID = req.LeadID
+	}
+
+	groups, err := s.GroupRepository.GetGroupsByLeaderID(ctx, leaderID, req.Page, req.PageSize)
+	if err != nil {
+		log.Error("failed-to-get-groups-by-leader-id", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Reinject dependencies
+	groupPointers := make([]*UniversalGroup, len(groups))
+	for i := range groups {
+		groups[i].SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+		groupPointers[i] = &groups[i]
+	}
+
+	paginatedResponse, err := toolbox.Paginate(ctx, &toolbox.PaginationRequest{
+		PerPage: req.PageSize,
+		Page:    req.Page,
+	}, groupPointers, req.TotalCount)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetGroupsResponse{
+		Total:      paginatedResponse.Total,
+		TotalPages: paginatedResponse.TotalPages,
+		Groups:     paginatedResponse.Resources,
+		Page:       paginatedResponse.Page,
+		PerPage:    paginatedResponse.ResourcePerPage,
+	}, nil
+}
+
+// GetGroupStats retrieves statistics for a group
+func (s *Service) GetGroupStats(ctx context.Context, groupID string) (*GetGroupStatsResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-stats")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("getting-group-stats", zap.String("group_id", groupID))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Calculate stats
+	userCount := len(group.GetUserMemberIDs())
+	groupCount := len(group.GetGroupMemberIDs())
+
+	return &GetGroupStatsResponse{
+		GroupID:          group.ID,
+		MemberCount:      group.GetMemberCount(),
+		UserMemberCount:  userCount,
+		GroupMemberCount: groupCount,
+		SubgroupCount:    groupCount,
+	}, nil
+}
+
+// SetGroupExtension sets an extension field value
+func (s *Service) SetGroupExtension(ctx context.Context, groupID, key string, value interface{}) (*UpdateGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "set-group-extension")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("setting-group-extension", zap.String("group_id", groupID), zap.String("key", key))
+
+	// Get group
+	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
+	if err != nil {
+		log.Error("failed-to-get-group", zap.Error(err))
+		return nil, err
+	}
+
+	// Reinject dependencies
+	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+
+	// Set extension
+	group.SetExtension(key, value)
+
+	// Save to repository
+	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
+	if err != nil {
+		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	return &UpdateGroupResponse{Group: updatedGroup}, nil
+}
+
+// SearchGroupsByExtension searches for groups by extension field value
+func (s *Service) SearchGroupsByExtension(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "search-groups-by-extension")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("searching-groups-by-extension", zap.Any("extension_filters", req.ExtensionFilters))
+
+	// Normalize PerPage to PageSize
+	if req.PerPage > 0 {
+		req.PageSize = req.PerPage
+	}
+
+	// Set defaults
+	if req.PageSize == 0 {
+		req.PageSize = 20
+	}
+	if req.Page == 0 {
+		req.Page = 1
+	}
+
+	// Get total count using GetTotalGroups
+	totalGroups, err := s.GroupRepository.GetTotalGroups(ctx, req)
+	if err != nil {
+		log.Error("failed-to-get-total-groups-count-by-extension", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	req.TotalCount = int(totalGroups)
+	log.Debug("handling-search-groups-by-extension-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", req))
+
+	// Extract first extension filter for backward compatibility with repository method
+	var key string
+	var value interface{}
+	for k, v := range req.ExtensionFilters {
+		key = k
+		value = v
+		break
+	}
+
+	groups, err := s.GroupRepository.SearchGroupsByExtension(ctx, key, value, req.Page, req.PageSize)
+	if err != nil {
+		log.Error("failed-to-search-groups-by-extension", zap.Error(err))
+		return nil, errors.New(ErrKeyDatabaseError)
+	}
+
+	// Reinject dependencies
+	groupPointers := make([]*UniversalGroup, len(groups))
+	for i := range groups {
+		groups[i].SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
+		groupPointers[i] = &groups[i]
+	}
+
+	paginatedResponse, err := toolbox.Paginate(ctx, &toolbox.PaginationRequest{
+		PerPage: req.PageSize,
+		Page:    req.Page,
+	}, groupPointers, req.TotalCount)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetGroupsResponse{
+		Total:      paginatedResponse.Total,
+		TotalPages: paginatedResponse.TotalPages,
+		Groups:     paginatedResponse.Resources,
+		Page:       paginatedResponse.Page,
+		PerPage:    paginatedResponse.ResourcePerPage,
+	}, nil
+}
+
+// BulkUpdateGroupsStatus updates status for multiple groups
+func (s *Service) BulkUpdateGroupsStatus(ctx context.Context, groupIDs []string, status string) error {
+	log := logger.AcquireFrom(ctx).With(zap.String("method", "bulk-update-groups-status")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("bulk-updating-group-status", zap.Int("count", len(groupIDs)), zap.String("status", status))
+
+	err := s.GroupRepository.BulkUpdateGroupsStatus(ctx, groupIDs, status)
+	if err != nil {
+		log.Error("failed-to-bulk-update-groups-status", zap.Error(err))
+		return errors.New(ErrKeyDatabaseError)
+	}
+
+	// Audit log
+	if s.AuditService != nil {
+		s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
+			Action: "groups.bulk_status_updated",
+			Details: map[string]interface{}{
+				"group_ids": groupIDs,
+				"status":    status,
+			},
+		})
+	}
+
+	return nil
+}

--- a/external/group/utils.groupfactory.go
+++ b/external/group/utils.groupfactory.go
@@ -1,0 +1,109 @@
+package group
+
+// GroupFactory provides convenient methods for creating groups
+type GroupFactory struct {
+	Config       *GroupConfig
+	IDGenerator  IDGenerator
+	TimeProvider TimeProvider
+	StringUtils  StringUtils
+}
+
+// NewGroupFactory creates a new group factory
+func NewGroupFactory(
+	config *GroupConfig,
+	idGenerator IDGenerator,
+	timeProvider TimeProvider,
+	stringUtils StringUtils,
+) *GroupFactory {
+	if config == nil {
+		config = DefaultGroupConfig()
+	}
+	if idGenerator == nil {
+		idGenerator = NewDefaultIDGenerator()
+	}
+	if timeProvider == nil {
+		timeProvider = NewDefaultTimeProvider()
+	}
+	if stringUtils == nil {
+		stringUtils = NewDefaultStringUtils()
+	}
+
+	return &GroupFactory{
+		Config:       config,
+		IDGenerator:  idGenerator,
+		TimeProvider: timeProvider,
+		StringUtils:  stringUtils,
+	}
+}
+
+// CreateGroup creates a new group with basic information
+func (f *GroupFactory) CreateGroup(name, groupType string) *UniversalGroup {
+	group := NewUniversalGroup(f.Config, f.IDGenerator, f.TimeProvider, f.StringUtils)
+	group.Name = name
+	group.Type = groupType
+	group.SetInitialState()
+	return group
+}
+
+// CreateTeam creates a new team group
+func (f *GroupFactory) CreateTeam(name string) *UniversalGroup {
+	return f.CreateGroup(name, GroupTypeTeam)
+}
+
+// CreateDepartment creates a new department group
+func (f *GroupFactory) CreateDepartment(name string) *UniversalGroup {
+	return f.CreateGroup(name, GroupTypeDepartment)
+}
+
+// CreateOrganization creates a new organization group
+func (f *GroupFactory) CreateOrganization(name string) *UniversalGroup {
+	return f.CreateGroup(name, GroupTypeOrganisation)
+}
+
+// CreateProject creates a new project group
+func (f *GroupFactory) CreateProject(name string) *UniversalGroup {
+	return f.CreateGroup(name, GroupTypeProject)
+}
+
+// CreateCommunity creates a new community group
+func (f *GroupFactory) CreateCommunity(name string) *UniversalGroup {
+	return f.CreateGroup(name, GroupTypeCommunity)
+}
+
+// CreateGroupWithMembers creates a group and adds initial members
+func (f *GroupFactory) CreateGroupWithMembers(name, groupType string, memberIDs []string, memberType string) *UniversalGroup {
+	group := f.CreateGroup(name, groupType)
+	for _, memberID := range memberIDs {
+		group.AddMember(memberID, memberType, MemberRoleMember)
+	}
+	return group
+}
+
+// CreateGroupWithOwner creates a group with an owner
+func (f *GroupFactory) CreateGroupWithOwner(name, groupType, ownerID string) *UniversalGroup {
+	group := f.CreateGroup(name, groupType)
+	group.Leadership.OwnerID = ownerID
+	group.AddMember(ownerID, MemberTypeUser, MemberRoleOwner)
+	return group
+}
+
+// CreateHierarchicalGroup creates a parent-child group relationship
+func (f *GroupFactory) CreateHierarchicalGroup(parentName, parentType, childName, childType string) (*UniversalGroup, *UniversalGroup) {
+	parent := f.CreateGroup(parentName, parentType)
+	child := f.CreateGroup(childName, childType)
+	parent.AddMember(child.ID, MemberTypeGroup, MemberRoleMember)
+	return parent, child
+}
+
+// ReinjectDependencies reinjects dependencies into an existing group
+func (f *GroupFactory) ReinjectDependencies(group *UniversalGroup) *UniversalGroup {
+	return group.SetDependencies(f.Config, f.IDGenerator, f.TimeProvider, f.StringUtils)
+}
+
+// ReinjectDependenciesMultiple reinjects dependencies into multiple groups
+func (f *GroupFactory) ReinjectDependenciesMultiple(groups []*UniversalGroup) []*UniversalGroup {
+	for _, group := range groups {
+		group.SetDependencies(f.Config, f.IDGenerator, f.TimeProvider, f.StringUtils)
+	}
+	return groups
+}

--- a/external/group/utils.toolbox.go
+++ b/external/group/utils.toolbox.go
@@ -1,0 +1,68 @@
+package group
+
+import (
+	"time"
+
+	"github.com/ooaklee/ghatd/external/toolbox"
+)
+
+// DefaultIDGenerator implementation using toolbox
+type DefaultIDGenerator struct{}
+
+func (d *DefaultIDGenerator) GenerateUUID() string {
+	return toolbox.GenerateUuidV4()
+}
+
+func (d *DefaultIDGenerator) GenerateNanoID() string {
+	return toolbox.GenerateNanoId()
+}
+
+// NewDefaultIDGenerator creates a new default ID generator
+func NewDefaultIDGenerator() IDGenerator {
+	return &DefaultIDGenerator{}
+}
+
+// DefaultTimeProvider implementation
+type DefaultTimeProvider struct{}
+
+func (d *DefaultTimeProvider) Now() time.Time {
+	return time.Now()
+}
+
+func (d *DefaultTimeProvider) NowUTC() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// NewDefaultTimeProvider creates a new default time provider
+func NewDefaultTimeProvider() TimeProvider {
+	return &DefaultTimeProvider{}
+}
+
+// DefaultStringUtils implementation using toolbox
+type DefaultStringUtils struct{}
+
+func (d *DefaultStringUtils) ToTitleCase(s string) string {
+	return toolbox.StringConvertToTitleCase(s)
+}
+
+func (d *DefaultStringUtils) ToLowerCase(s string) string {
+	return toolbox.StringStandardisedToLower(s)
+}
+
+func (d *DefaultStringUtils) ToUpperCase(s string) string {
+	return toolbox.StringStandardisedToUpper(s)
+}
+
+func (d *DefaultStringUtils) InSlice(item string, slice []string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// NewDefaultStringUtils creates a new default string utils
+func NewDefaultStringUtils() StringUtils {
+	return &DefaultStringUtils{}
+}

--- a/external/user/v2/model.go
+++ b/external/user/v2/model.go
@@ -172,6 +172,11 @@ func (u *UniversalUser) SetDependencies(
 
 // Core Methods
 
+// GetType handles return the resource type
+func (u *UniversalUser) GetType() string {
+	return "USER"
+}
+
 // Standardise handles common user tasks like making sure email is lowercase
 func (u *UniversalUser) Standardise() *UniversalUser {
 	if u.stringUtils != nil {

--- a/external/usermanager/const.go
+++ b/external/usermanager/const.go
@@ -1,6 +1,15 @@
 package usermanager
 
-const UserManagerURIVariableID = "blankpackagID"
+const (
+	// UserManagerURIVariableID placeholder for URI variable ID
+	UserManagerURIVariableID = "blankpackagID"
+
+	// UserManagerURIVariableGroupID is the URI variable for group ID
+	UserManagerURIVariableGroupID = "groupID"
+
+	// UserManagerURIVariableGroupType is the URI variable for group type
+	UserManagerURIVariableGroupType = "groupType"
+)
 
 const (
 
@@ -16,4 +25,33 @@ const (
 	// ErrKeyInvalidUserBody returned when a request that is request body dependent fails
 	// validation
 	ErrKeyInvalidUserBody = "UserManagerInvalidUserBody"
+
+	// Group/Team related errors
+
+	// ErrKeyGroupNotFound returned when the requested group cannot be found
+	ErrKeyGroupNotFound = "GroupNotFound"
+
+	// ErrKeyUserNotFound returned when the requested user cannot be found
+	ErrKeyUserNotFound = "UserNotFound"
+
+	// ErrKeyUserAlreadyMemberOfGroup returned when user is already a member of the group
+	ErrKeyUserAlreadyMemberOfGroup = "UserAlreadyMemberOfGroup"
+
+	// ErrKeyFailedToAddUserToGroup returned when adding user to group fails
+	ErrKeyFailedToAddUserToGroup = "FailedToAddUserToGroup"
+
+	// ErrKeyFailedToRemoveUserFromGroup returned when removing user from group fails
+	ErrKeyFailedToRemoveUserFromGroup = "FailedToRemoveUserFromGroup"
+
+	// ErrKeyInvalidGroupType returned when an invalid group type is provided
+	ErrKeyInvalidGroupType = "InvalidGroupType"
+
+	// ErrKeyNoGroupsFound returned when no groups match the search criteria
+	ErrKeyNoGroupsFound = "NoGroupsFound"
+
+	// ErrKeyBulkOperationPartialFailure returned when bulk operation has some failures
+	ErrKeyBulkOperationPartialFailure = "BulkOperationPartialFailure"
+
+	// ErrKeyGroupServiceNotEnabled is returned when group features are requested but GroupService is not configured
+	ErrKeyGroupServiceNotEnabled = "GroupServiceNotEnabled"
 )

--- a/external/usermanager/errormap.go
+++ b/external/usermanager/errormap.go
@@ -5,11 +5,21 @@ import (
 )
 
 // UsermanagerErrorMap holds Error keys, their corresponding human-friendly message, and response status code
-// TODO: remove nolint
-// nolint will be used later
 var UsermanagerErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
+	// General errors
 	ErrKeyUserManagerError:        {Title: "Bad Request", Detail: "Some user manager related error.", StatusCode: 400, Code: "USM00-001"},
-	ErrKeyUnableToIdentifyUser:    {Title: "Unauthorized", Detail: "Please contact support.", StatusCode: 401, Code: "USM00-002"},
+	ErrKeyUnableToIdentifyUser:    {Title: "Unauthorised", Detail: "Please contact support.", StatusCode: 401, Code: "USM00-002"},
 	ErrKeyInvalidUserBody:         {Title: "Bad Request", Detail: "Check your submitted user information.", StatusCode: 400, Code: "USM00-003"},
-	ErrKeyRequestFailedValidation: {Title: "Bad Request", Detail: "Request failed validation, please check provided data", StatusCode: 400, Code: "USM00-004"},
+	ErrKeyRequestFailedValidation: {Title: "Bad Request", Detail: "Request failed validation, please check provided data.", StatusCode: 400, Code: "USM00-004"},
+
+	// Group/Team related errors
+	ErrKeyGroupNotFound:               {Title: "Not Found", Detail: "The requested group could not be found.", StatusCode: 404, Code: "USM00-005"},
+	ErrKeyUserNotFound:                {Title: "Not Found", Detail: "The requested user could not be found.", StatusCode: 404, Code: "USM00-006"},
+	ErrKeyUserAlreadyMemberOfGroup:    {Title: "Conflict", Detail: "User is already a member of this group.", StatusCode: 409, Code: "USM00-007"},
+	ErrKeyFailedToAddUserToGroup:      {Title: "Internal Error", Detail: "Failed to add user to the group. Please try again.", StatusCode: 500, Code: "USM00-008"},
+	ErrKeyFailedToRemoveUserFromGroup: {Title: "Internal Error", Detail: "Failed to remove user from the group. Please try again.", StatusCode: 500, Code: "USM00-009"},
+	ErrKeyInvalidGroupType:            {Title: "Bad Request", Detail: "The provided group type is invalid.", StatusCode: 400, Code: "USM00-010"},
+	ErrKeyNoGroupsFound:               {Title: "Not Found", Detail: "No groups match the search criteria.", StatusCode: 404, Code: "USM00-011"},
+	ErrKeyBulkOperationPartialFailure: {Title: "Partial Success", Detail: "Some operations in the bulk update failed. Check response details.", StatusCode: 207, Code: "USM00-012"},
+	ErrKeyGroupServiceNotEnabled:      {Title: "Service Unavailable", Detail: "Group management features have not been enabled for this service.", StatusCode: 503, Code: "USM00-013"},
 }

--- a/external/usermanager/examples/examples.go
+++ b/external/usermanager/examples/examples.go
@@ -1,0 +1,788 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ooaklee/ghatd/external/apitoken"
+	"github.com/ooaklee/ghatd/external/audit"
+	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/contacter"
+	"github.com/ooaklee/ghatd/external/group"
+	user "github.com/ooaklee/ghatd/external/user/v2"
+	"github.com/ooaklee/ghatd/external/usermanager"
+)
+
+// Example1_GetEnrichedUserProfile demonstrates fetching a user profile with group memberships
+func Example1_GetEnrichedUserProfile() {
+	service := setupService()
+
+	ctx := context.Background()
+	resp, err := service.GetEnrichedUserProfile(ctx, &usermanager.GetEnrichedUserProfileRequest{
+		UserId:             "user-123",
+		IncludeTeams:       true,
+		IncludeDepartments: true,
+		IncludeAllGroups:   true,
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	profile := resp.Profile
+	fmt.Printf("User: %s (%s)\n", profile.FullName, profile.Email)
+	fmt.Printf("Teams: %d\n", len(profile.Teams))
+	fmt.Printf("Departments: %d\n", len(profile.Departments))
+
+	for _, team := range profile.Teams {
+		fmt.Printf("  - %s (%s)\n", team.Group.Name, team.Role)
+	}
+}
+
+// Example2_GetUserTeamMemberships demonstrates getting detailed team membership information
+func Example2_GetUserTeamMemberships() {
+	service := setupService()
+
+	ctx := context.Background()
+	resp, err := service.GetUserTeamMemberships(ctx, &usermanager.GetUserTeamMembershipsRequest{
+		UserId:          "user-123",
+		IncludeInactive: false,
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Printf("User %s team memberships:\n", resp.UserID)
+	for teamName, membership := range resp.Memberships {
+		if membership.IsMember {
+			fmt.Printf("  - %s: %s", teamName, membership.Role)
+			if membership.IsOwner {
+				fmt.Print(" (Owner)")
+			}
+			if membership.IsLead {
+				fmt.Print(" (Lead)")
+			}
+			fmt.Println()
+		}
+	}
+}
+
+// Example3_UpdateUserTeamMembership demonstrates adding a user to a team
+func Example3_UpdateUserTeamMembership() {
+	service := setupService()
+
+	ctx := context.Background()
+	resp, err := service.UpdateUserTeamMembership(ctx, &usermanager.UpdateUserTeamMembershipRequest{
+		UserId:               "user-456",
+		GroupID:              "team-frontend",
+		Role:                 group.MemberRoleMember,
+		RemoveFromOtherTeams: false,
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	if resp.Success {
+		fmt.Printf("Successfully added user to team: %s\n", resp.Membership.Group.Name)
+		fmt.Printf("Role: %s\n", resp.Membership.Role)
+		if len(resp.PreviousMemberships) > 0 {
+			fmt.Printf("Removed from %d previous teams\n", len(resp.PreviousMemberships))
+		}
+	}
+}
+
+// Example4_RemoveUserFromGroup demonstrates removing a user from a group
+func Example4_RemoveUserFromGroup() {
+	service := setupService()
+
+	ctx := context.Background()
+	resp, err := service.RemoveUserFromGroup(ctx, &usermanager.RemoveUserFromGroupRequest{
+		UserId:  "user-456",
+		GroupID: "team-frontend",
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	if resp.Success {
+		fmt.Printf("Successfully removed user from group: %s\n", resp.GroupID)
+	}
+}
+
+// Example5_GetUserGroups demonstrates fetching groups for a user with filtering
+func Example5_GetUserGroups() {
+	service := setupService()
+
+	ctx := context.Background()
+	resp, err := service.GetUserGroups(ctx, &usermanager.GetUserGroupsRequest{
+		UserId:    "user-123",
+		GroupType: group.GroupTypeTeam,
+		Status:    group.GroupStatusActive,
+		Page:      1,
+		PerPage:   10,
+		Meta:      true,
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Printf("Found %d teams:\n", len(resp.Groups))
+	for _, g := range resp.Groups {
+		fmt.Printf("  - %s (%s) - %d members\n", g.Name, g.Type, g.MemberCount)
+	}
+
+	if resp.Meta != nil {
+		fmt.Printf("Total: %d, Page: %d\n", resp.Total, resp.Meta["page"])
+	}
+}
+
+// Example6_GetGroupsByType demonstrates fetching groups filtered by type
+func Example6_GetGroupsByType() {
+	service := setupService()
+
+	ctx := context.Background()
+	resp, err := service.GetGroupsByType(ctx, &usermanager.GetGroupsByTypeRequest{
+		UserId:              "user-123",
+		GroupType:           group.GroupTypeDepartment,
+		Status:              group.GroupStatusActive,
+		OnlyUserMemberships: true,
+		Page:                1,
+		PerPage:             20,
+		Meta:                true,
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Printf("Found %d departments:\n", len(resp.Groups))
+	for _, g := range resp.Groups {
+		fmt.Printf("  - %s (%d members)\n", g.Name, g.MemberCount)
+	}
+}
+
+// Example7_FindUserInfo demonstrates finding user information with group memberships
+func Example7_FindUserInfo() {
+	service := setupService()
+
+	ctx := context.Background()
+	resp, err := service.FindUserInfo(ctx, &usermanager.FindUserInfoRequest{
+		Email:                   "john.doe@company.com",
+		IncludeTeamMemberships:  true,
+		IncludeGroupMemberships: true,
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Printf("Found user: %s (%s)\n", resp.User.FirstName+" "+resp.User.LastName, resp.User.Email)
+	if resp.MembershipDataFetched {
+		fmt.Printf("Team memberships: %d\n", len(resp.TeamMemberships))
+		fmt.Printf("All group memberships: %d\n", len(resp.GroupMemberships))
+	}
+}
+
+// Example8_BulkUpdateUserGroupMemberships demonstrates bulk membership operations
+func Example8_BulkUpdateUserGroupMemberships() {
+	service := setupService()
+
+	ctx := context.Background()
+	resp, err := service.BulkUpdateUserGroupMemberships(ctx, &usermanager.BulkUpdateUserGroupMembershipsRequest{
+		UserId:       "admin-user",
+		TargetUserId: "user-789",
+		Actions: []usermanager.GroupMembershipAction{
+			{
+				Action:  "ADD",
+				GroupID: "team-backend",
+				Role:    group.MemberRoleMember,
+			},
+			{
+				Action:  "ADD",
+				GroupID: "dept-engineering",
+				Role:    group.MemberRoleMember,
+			},
+			{
+				Action:  "REMOVE",
+				GroupID: "team-frontend",
+			},
+		},
+	})
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Printf("Bulk update completed: %d success, %d failures\n",
+		resp.SuccessCount, resp.FailureCount)
+
+	for _, result := range resp.Results {
+		status := "SUCCESS"
+		if !result.Success {
+			status = "FAILED: " + result.Error
+		}
+		fmt.Printf("  %s %s: %s\n", result.Action, result.GroupID, status)
+	}
+}
+
+// Example9_UserProfileManagement demonstrates basic user profile operations
+func Example9_UserProfileManagement() {
+	service := setupService()
+
+	ctx := context.Background()
+
+	// Get user profile
+	profileResp, err := service.GetUserProfile(ctx, &usermanager.GetUserProfileRequest{
+		UserId: "user-123",
+	})
+	if err != nil {
+		fmt.Println("Error getting profile:", err)
+		return
+	}
+
+	fmt.Printf("User profile: %s %s\n", profileResp.Profile.FirstName, profileResp.Profile.LastName)
+
+	// Update user profile
+	updateResp, err := service.UpdateUserProfile(ctx, &usermanager.UpdateUserProfileRequest{
+		UserId: "user-123",
+		UpdateUserRequest: &user.UpdateUserRequest{
+			FirstName: "John",
+			LastName:  "Smith",
+		},
+	})
+	if err != nil {
+		fmt.Println("Error updating profile:", err)
+		return
+	}
+
+	fmt.Printf("Updated user: %s %s\n",
+		updateResp.UpdateUserResponse.User.PersonalInfo.FirstName,
+		updateResp.UpdateUserResponse.User.PersonalInfo.LastName)
+}
+
+// Example10_CommunicationManagement demonstrates creating and retrieving communications
+func Example10_CommunicationManagement() {
+	service := setupService()
+
+	ctx := context.Background()
+
+	// Create a communication
+	createResp, err := service.CreateComms(ctx, &usermanager.CreateCommsRequest{
+		CreateCommsRequest: &contacter.CreateCommsRequest{
+			UserId:   "user-123",
+			FullName: "John Doe",
+			Email:    "john.doe@company.com",
+			Type:     contacter.CommsTypeFeedback,
+			Message:  "Welcome to our engineering team...",
+			Meta: map[string]interface{}{
+				"subject": "Welcome to the team!",
+			},
+		},
+	})
+	if err != nil {
+		fmt.Println("Error creating comms:", err)
+		return
+	}
+
+	fmt.Printf("Created communication: %s\n", createResp.Comms.Id)
+
+	// Get communications
+	getResp, err := service.GetComms(ctx, &usermanager.GetCommsRequest{
+		UserId: "user-123",
+		GetCommsRequest: &contacter.GetCommsRequest{
+			Page:    1,
+			PerPage: 10,
+		},
+	})
+	if err != nil {
+		fmt.Println("Error getting comms:", err)
+		return
+	}
+
+	fmt.Printf("Found %d communications\n", len(getResp.Comms))
+}
+
+// Example11_GroupManagementWorkflow demonstrates a complete group management workflow
+func Example11_GroupManagementWorkflow() {
+	service := setupService()
+
+	ctx := context.Background()
+	userID := "user-new-hire"
+
+	fmt.Println("=== Group Management Workflow ===")
+
+	// 1. Get user's current memberships
+	fmt.Println("1. Checking current memberships...")
+	currentResp, err := service.GetUserGroups(ctx, &usermanager.GetUserGroupsRequest{
+		UserId:  userID,
+		Page:    1,
+		PerPage: 50,
+	})
+	if err != nil {
+		fmt.Printf("Error getting current memberships: %v\n", err)
+		return
+	}
+	fmt.Printf("   Current groups: %d\n", len(currentResp.Groups))
+
+	// 2. Add to engineering department
+	fmt.Println("2. Adding to Engineering department...")
+	deptResp, err := service.UpdateUserTeamMembership(ctx, &usermanager.UpdateUserTeamMembershipRequest{
+		UserId:  userID,
+		GroupID: "dept-engineering",
+		Role:    group.MemberRoleMember,
+	})
+	if err != nil {
+		fmt.Printf("Error adding to department: %v\n", err)
+		return
+	}
+	fmt.Printf("   Added to: %s\n", deptResp.Membership.Group.Name)
+
+	// 3. Add to frontend team
+	fmt.Println("3. Adding to Frontend team...")
+	teamResp, err := service.UpdateUserTeamMembership(ctx, &usermanager.UpdateUserTeamMembershipRequest{
+		UserId:               userID,
+		GroupID:              "team-frontend",
+		Role:                 group.MemberRoleMember,
+		RemoveFromOtherTeams: true, // Remove from other teams
+	})
+	if err != nil {
+		fmt.Printf("Error adding to team: %v\n", err)
+		return
+	}
+	fmt.Printf("   Added to: %s\n", teamResp.Membership.Group.Name)
+	if len(teamResp.PreviousMemberships) > 0 {
+		fmt.Printf("   Removed from %d other teams\n", len(teamResp.PreviousMemberships))
+	}
+
+	// 4. Verify final memberships
+	fmt.Println("4. Verifying final memberships...")
+	finalResp, err := service.GetEnrichedUserProfile(ctx, &usermanager.GetEnrichedUserProfileRequest{
+		UserId:           userID,
+		IncludeAllGroups: true,
+	})
+	if err != nil {
+		fmt.Printf("Error verifying memberships: %v\n", err)
+		return
+	}
+
+	fmt.Printf("   Final teams: %d\n", len(finalResp.Profile.Teams))
+	fmt.Printf("   Final departments: %d\n", len(finalResp.Profile.Departments))
+	fmt.Printf("   Total groups: %d\n", len(finalResp.Profile.Groups))
+
+	fmt.Println("=== Workflow completed successfully ===")
+}
+
+// Example12_AdminCreateGroup demonstrates admin creating a new group
+func Example12_AdminCreateGroup() {
+	service := setupService()
+
+	ctx := context.Background()
+
+	fmt.Println("=== Admin Create Group Example ===")
+
+	// Create a new engineering team
+	createResp, err := service.CreateGroup(ctx, &usermanager.CreateGroupRequest{
+		AdminUserId:       "admin-user-123",
+		Name:              "Machine Learning Team",
+		Type:              group.GroupTypeTeam,
+		Description:       "Team focused on ML/AI projects and research",
+		Email:             "ml-team@company.com",
+		Icon:              "🤖",
+		Visibility:        group.VisibilityPrivate,
+		InitialMemberIDs:  []string{"user-123", "user-456", "user-789"},
+		InitialMemberRole: group.MemberRoleMember,
+		HeadID:            "user-123",
+		Extensions: map[string]interface{}{
+			"slack_channel": "#ml-team",
+			"cost_center":   "ENG-ML-001",
+			"budget":        150000,
+		},
+	})
+	if err != nil {
+		fmt.Printf("Error creating group: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Created group: %s (ID: %s)\n", createResp.Group.Name, createResp.Group.ID)
+	fmt.Printf("  Type: %s\n", createResp.Group.Type)
+	fmt.Printf("  Members: %d\n", createResp.Group.MemberCount)
+	fmt.Printf("  Status: %s\n", createResp.Group.Status)
+	fmt.Printf("  Created: %s\n", createResp.Group.CreatedAt)
+
+	fmt.Println("=== Group created successfully ===")
+}
+
+// Helper functions and types
+
+func setupService() *usermanager.Service {
+	// Create mock services
+	userSvc := &MockUserService{}
+	apiTokenSvc := &MockApiTokenService{}
+	auditSvc := &MockAuditService{}
+	contacterSvc := &MockContacterService{}
+	groupSvc := &MockGroupService{}
+
+	// Create usermanager service
+	service := usermanager.NewService(&usermanager.NewServiceRequest{
+		UserService:      userSvc,
+		ApiTokenService:  apiTokenSvc,
+		AuditService:     auditSvc,
+		ContacterService: contacterSvc,
+	})
+
+	// Add group service
+	service.WithGroupService(groupSvc)
+
+	return service
+}
+
+// Mock services for examples
+
+type MockUserService struct{}
+
+func (m *MockUserService) GetUserMicroProfile(ctx context.Context, r *user.GetUserMicroProfileRequest) (*user.GetUserMicroProfileResponse, error) {
+	return &user.GetUserMicroProfileResponse{
+		MicroProfile: &user.UserMicroProfile{
+			ID:     r.ID,
+			Roles:  []string{"USER"},
+			Status: "ACTIVE",
+		},
+	}, nil
+}
+
+func (m *MockUserService) GetUserProfile(ctx context.Context, r *user.GetUserProfileRequest) (*user.GetUserProfileResponse, error) {
+	return &user.GetUserProfileResponse{
+		Profile: &user.UserProfile{
+			ID:            r.ID,
+			Email:         "user@example.com",
+			FirstName:     "John",
+			LastName:      "Doe",
+			Status:        "ACTIVE",
+			Roles:         []string{"USER"},
+			EmailVerified: true,
+			UpdatedAt:     time.Now().Format(time.RFC3339),
+		},
+	}, nil
+}
+
+func (m *MockUserService) GetUserByID(ctx context.Context, r *user.GetUserByIDRequest) (*user.GetUserByIDResponse, error) {
+	return &user.GetUserByIDResponse{
+		User: &user.UniversalUser{
+			ID:    r.ID,
+			Email: "user@example.com",
+			PersonalInfo: &user.PersonalInfo{
+				FullName:  "John Doe",
+				FirstName: "John",
+				LastName:  "Doe",
+			},
+			Status: "ACTIVE",
+			Roles:  []string{"USER"},
+			Metadata: &user.UserMetadata{
+				CreatedAt: time.Now().Add(-30 * 24 * time.Hour).Format(common.RFC3339NanoUTC),
+			},
+		},
+	}, nil
+}
+
+func (m *MockUserService) GetUserByEmail(ctx context.Context, r *user.GetUserByEmailRequest) (*user.GetUserByEmailResponse, error) {
+	return &user.GetUserByEmailResponse{
+		User: &user.UniversalUser{
+			ID:    "user-123",
+			Email: r.Email,
+			PersonalInfo: &user.PersonalInfo{
+				FullName:  "John Doe",
+				FirstName: "John",
+				LastName:  "Doe",
+			},
+			Status: "ACTIVE",
+			Roles:  []string{"USER"},
+		},
+	}, nil
+}
+
+func (m *MockUserService) UpdateUser(ctx context.Context, r *user.UpdateUserRequest) (*user.UpdateUserResponse, error) {
+	return &user.UpdateUserResponse{
+		User: &user.UniversalUser{
+			ID:    "user-123",
+			Email: "user@example.com",
+			PersonalInfo: &user.PersonalInfo{
+				FullName:  r.FirstName + " " + r.LastName,
+				FirstName: r.FirstName,
+				LastName:  r.LastName,
+			},
+		},
+	}, nil
+}
+
+func (m *MockUserService) DeleteUser(ctx context.Context, r *user.DeleteUserRequest) error {
+	return nil
+}
+
+type MockApiTokenService struct{}
+
+func (m *MockApiTokenService) DeleteApiTokensByOwnerId(ctx context.Context, ownerId string) error {
+	return nil
+}
+
+func (m *MockApiTokenService) GetTotalApiTokens(ctx context.Context, r *apitoken.GetTotalApiTokensRequest) (int64, error) {
+	return 5, nil
+}
+
+type MockAuditService struct{}
+
+func (m *MockAuditService) GetTotalAuditLogEvents(ctx context.Context, r *audit.GetTotalAuditLogEventsRequest) (int64, error) {
+	return 25, nil
+}
+
+type MockContacterService struct{}
+
+func (m *MockContacterService) CreateComms(ctx context.Context, req *contacter.CreateCommsRequest) (*contacter.CreateCommsResponse, error) {
+	return &contacter.CreateCommsResponse{
+		Comms: &contacter.Comms{
+			Id:           "comms-123",
+			FullName:     req.FullName,
+			Email:        req.Email,
+			Type:         req.Type,
+			Message:      req.Message,
+			Meta:         req.Meta,
+			UserId:       req.UserId,
+			UserLoggedIn: true,
+			CreatedAt:    time.Now().Format(time.RFC3339),
+		},
+	}, nil
+}
+
+func (m *MockContacterService) GetComms(ctx context.Context, req *contacter.GetCommsRequest) (*contacter.GetCommsResponse, error) {
+	return &contacter.GetCommsResponse{
+		Comms: []contacter.Comms{
+			{
+				Id:           "comms-123",
+				FullName:     "John Doe",
+				Email:        "john.doe@company.com",
+				Type:         contacter.CommsTypeFeedback,
+				Message:      "Welcome!",
+				UserId:       "user-123",
+				UserLoggedIn: true,
+				CreatedAt:    time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+			},
+		},
+		Total: 1,
+	}, nil
+}
+
+type MockGroupService struct{}
+
+func (m *MockGroupService) GetGroups(ctx context.Context, r *group.GetGroupsRequest) (*group.GetGroupsResponse, error) {
+	var groups []*group.UniversalGroup
+
+	// Mock some teams
+	if r.Types == nil || contains(r.Types, group.GroupTypeTeam) {
+		teams := []*group.UniversalGroup{
+			createMockGroup("team-frontend", "Frontend Team", group.GroupTypeTeam, 5),
+			createMockGroup("team-backend", "Backend Team", group.GroupTypeTeam, 8),
+			createMockGroup("team-devops", "DevOps Team", group.GroupTypeTeam, 4),
+		}
+
+		// Add common test users to teams for consistent testing
+		for _, team := range teams {
+			team.AddMember("user-123", group.MemberTypeUser, group.MemberRoleMember)
+			team.AddMember("user-456", group.MemberTypeUser, group.MemberRoleMember)
+			team.AddMember("user-new-hire", group.MemberTypeUser, group.MemberRoleMember)
+		}
+
+		// Filter by member if specified
+		if r.MemberID != "" {
+			for _, team := range teams {
+				if team.HasMember(r.MemberID) {
+					groups = append(groups, team)
+				}
+			}
+		} else {
+			groups = append(groups, teams...)
+		}
+	}
+
+	// Mock departments
+	if r.Types == nil || contains(r.Types, group.GroupTypeDepartment) {
+		depts := []*group.UniversalGroup{
+			createMockGroup("dept-engineering", "Engineering", group.GroupTypeDepartment, 25),
+			createMockGroup("dept-product", "Product", group.GroupTypeDepartment, 15),
+		}
+
+		// Add common test users to departments
+		for _, dept := range depts {
+			dept.AddMember("user-123", group.MemberTypeUser, group.MemberRoleMember)
+			dept.AddMember("user-456", group.MemberTypeUser, group.MemberRoleMember)
+			dept.AddMember("user-new-hire", group.MemberTypeUser, group.MemberRoleMember)
+		}
+
+		if r.MemberID != "" {
+			for _, dept := range depts {
+				if dept.HasMember(r.MemberID) {
+					groups = append(groups, dept)
+				}
+			}
+		} else {
+			groups = append(groups, depts...)
+		}
+	}
+
+	// Apply status filter if specified
+	if len(r.Statuses) > 0 {
+		filteredGroups := []*group.UniversalGroup{}
+		for _, g := range groups {
+			for _, status := range r.Statuses {
+				if g.Status == status {
+					filteredGroups = append(filteredGroups, g)
+					break
+				}
+			}
+		}
+		groups = filteredGroups
+	}
+
+	return &group.GetGroupsResponse{
+		Groups:     groups,
+		Total:      len(groups),
+		TotalPages: 1,
+		Page:       r.Page,
+		PerPage:    r.PerPage,
+	}, nil
+}
+
+func (m *MockGroupService) GetGroupByID(ctx context.Context, r *group.GetGroupByIDRequest) (*group.GetGroupByIDResponse, error) {
+	// Return specific groups based on ID for better example testing
+	var mockGroup *group.UniversalGroup
+
+	switch r.ID {
+	case "team-frontend":
+		mockGroup = createMockGroup("team-frontend", "Frontend Team", group.GroupTypeTeam, 5)
+	case "team-backend":
+		mockGroup = createMockGroup("team-backend", "Backend Team", group.GroupTypeTeam, 8)
+	case "team-devops":
+		mockGroup = createMockGroup("team-devops", "DevOps Team", group.GroupTypeTeam, 4)
+	case "dept-engineering":
+		mockGroup = createMockGroup("dept-engineering", "Engineering", group.GroupTypeDepartment, 25)
+	case "dept-product":
+		mockGroup = createMockGroup("dept-product", "Product", group.GroupTypeDepartment, 15)
+	default:
+		mockGroup = createMockGroup(r.ID, "Mock Group", group.GroupTypeTeam, 3)
+	}
+
+	// Add common test users
+	mockGroup.AddMember("user-123", group.MemberTypeUser, group.MemberRoleMember)
+	mockGroup.AddMember("user-456", group.MemberTypeUser, group.MemberRoleMember)
+	mockGroup.AddMember("user-new-hire", group.MemberTypeUser, group.MemberRoleMember)
+
+	return &group.GetGroupByIDResponse{
+		Group: mockGroup,
+	}, nil
+}
+
+func (m *MockGroupService) AddMember(ctx context.Context, r *group.AddMemberRequest) (*group.AddMemberResponse, error) {
+	// Return a properly populated group
+	mockGroup := createMockGroup(r.GroupID, "Updated Group", group.GroupTypeTeam, 5)
+	mockGroup.AddMember(r.MemberID, r.Type, r.Role)
+
+	return &group.AddMemberResponse{
+		Group: mockGroup,
+	}, nil
+}
+
+func (m *MockGroupService) RemoveMember(ctx context.Context, r *group.RemoveMemberRequest) error {
+	return nil
+}
+
+func (m *MockGroupService) UpdateMemberRole(ctx context.Context, r *group.UpdateMemberRoleRequest) error {
+	return nil
+}
+
+func (m *MockGroupService) CreateGroup(ctx context.Context, req *group.CreateGroupRequest) (*group.CreateGroupResponse, error) {
+	// Create a new mock group based on the request
+	newGroup := createMockGroup(
+		fmt.Sprintf("group-%s", time.Now().Format("20060102150405")),
+		req.Name,
+		req.Type,
+		len(req.InitialMembers),
+	)
+
+	// Set additional fields from request
+	newGroup.DisplayInfo.Description = req.Description
+	newGroup.DisplayInfo.Email = req.Email
+	newGroup.DisplayInfo.Icon = req.Icon
+
+	if req.Visibility != "" {
+		newGroup.Settings.Visibility = req.Visibility
+	}
+
+	if len(req.Extensions) > 0 {
+		newGroup.Extensions = req.Extensions
+	}
+
+	// Set leadership
+	if req.OwnerID != "" || req.HeadID != "" || req.LeadID != "" {
+		if newGroup.Leadership == nil {
+			newGroup.Leadership = &group.Leadership{}
+		}
+		newGroup.Leadership.OwnerID = req.OwnerID
+		newGroup.Leadership.HeadID = req.HeadID
+		newGroup.Leadership.LeadID = req.LeadID
+	}
+
+	// Add initial members
+	for _, member := range req.InitialMembers {
+		newGroup.AddMember(member.ID, member.Type, member.Role)
+	}
+
+	return &group.CreateGroupResponse{
+		Group: newGroup,
+	}, nil
+}
+
+func createMockGroup(id, name, groupType string, memberCount int) *group.UniversalGroup {
+	config := group.DefaultGroupConfig()
+	idGen := group.NewDefaultIDGenerator()
+	timeProvider := group.NewDefaultTimeProvider()
+	stringUtils := group.NewDefaultStringUtils()
+
+	g := group.NewUniversalGroup(config, idGen, timeProvider, stringUtils)
+	g.ID = id
+	g.Name = name
+	g.Type = groupType
+	g.Status = group.GroupStatusActive
+	g.DisplayInfo.Description = fmt.Sprintf("%s - A collaborative group", name)
+	g.Metadata.CreatedAt = time.Now().Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+
+	// Initialize leadership
+	if g.Leadership == nil {
+		g.Leadership = &group.Leadership{}
+	}
+
+	// Add some mock members with varied roles
+	for i := 0; i < memberCount; i++ {
+		role := group.MemberRoleMember
+		if i == 0 {
+			role = group.MemberRoleHead
+			g.Leadership.HeadID = fmt.Sprintf("user-%d", i+1)
+		} else if i == 1 {
+			role = group.MemberRoleAdmin
+		}
+		g.AddMember(fmt.Sprintf("user-%d", i+1), group.MemberTypeUser, role)
+	}
+
+	return g
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/external/usermanager/fender.go
+++ b/external/usermanager/fender.go
@@ -134,3 +134,235 @@ func mapGetCommsRequest(r *http.Request, validator UsermanagerValidator) (*GetCo
 func validateParsedRequest(request interface{}, validator UsermanagerValidator) error {
 	return validator.Validate(request)
 }
+
+// MapRequestToGetEnrichedUserProfileRequest maps incoming GetEnrichedUserProfile request to correct struct
+func MapRequestToGetEnrichedUserProfileRequest(request *http.Request, validator UsermanagerValidator) (*GetEnrichedUserProfileRequest, error) {
+	var parsedRequest GetEnrichedUserProfileRequest
+	log := logger.AcquireFrom(request.Context())
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(request.Context())
+	if parsedRequest.UserId == "" {
+		log.Error("unable-get-user-id")
+		return nil, errors.New(ErrKeyUnableToIdentifyUser)
+	}
+
+	query := request.URL.Query()
+	err := querydecoder.New(query).Decode(&parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToGetUserGroupsRequest maps incoming GetUserGroups request to correct struct
+func MapRequestToGetUserGroupsRequest(request *http.Request, validator UsermanagerValidator) (*GetUserGroupsRequest, error) {
+	var parsedRequest GetUserGroupsRequest
+	log := logger.AcquireFrom(request.Context())
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(request.Context())
+	if parsedRequest.UserId == "" {
+		log.Error("unable-get-user-id")
+		return nil, errors.New(ErrKeyUnableToIdentifyUser)
+	}
+
+	query := request.URL.Query()
+	err := querydecoder.New(query).Decode(&parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToGetUserTeamMembershipsRequest maps incoming GetUserTeamMemberships request to correct struct
+func MapRequestToGetUserTeamMembershipsRequest(request *http.Request, validator UsermanagerValidator) (*GetUserTeamMembershipsRequest, error) {
+	var parsedRequest GetUserTeamMembershipsRequest
+	log := logger.AcquireFrom(request.Context())
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(request.Context())
+	if parsedRequest.UserId == "" {
+		log.Error("unable-get-user-id")
+		return nil, errors.New(ErrKeyUnableToIdentifyUser)
+	}
+
+	query := request.URL.Query()
+	err := querydecoder.New(query).Decode(&parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToUpdateUserTeamMembershipRequest maps incoming UpdateUserTeamMembership request to correct struct
+func MapRequestToUpdateUserTeamMembershipRequest(request *http.Request, validator UsermanagerValidator) (*UpdateUserTeamMembershipRequest, error) {
+	var parsedRequest UpdateUserTeamMembershipRequest
+	log := logger.AcquireFrom(request.Context())
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(request.Context())
+	if parsedRequest.UserId == "" {
+		log.Error("unable-get-user-id")
+		return nil, errors.New(ErrKeyUnableToIdentifyUser)
+	}
+
+	var err error
+	parsedRequest.GroupID, err = toolbox.GetVariableValueFromUri(request, UserManagerURIVariableGroupID)
+	if err != nil {
+		log.Error("unable-get-group-id-from-uri")
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	err = toolbox.DecodeRequestBody(request, &parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToRemoveUserFromGroupRequest maps incoming RemoveUserFromGroup request to correct struct
+func MapRequestToRemoveUserFromGroupRequest(request *http.Request, validator UsermanagerValidator) (*RemoveUserFromGroupRequest, error) {
+	var parsedRequest RemoveUserFromGroupRequest
+	log := logger.AcquireFrom(request.Context())
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(request.Context())
+	if parsedRequest.UserId == "" {
+		log.Error("unable-get-user-id")
+		return nil, errors.New(ErrKeyUnableToIdentifyUser)
+	}
+
+	var err error
+	parsedRequest.GroupID, err = toolbox.GetVariableValueFromUri(request, UserManagerURIVariableGroupID)
+	if err != nil {
+		log.Error("unable-get-group-id-from-uri")
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToFindUserInfoRequest maps incoming FindUserInfo request to correct struct
+func MapRequestToFindUserInfoRequest(request *http.Request, validator UsermanagerValidator) (*FindUserInfoRequest, error) {
+	var parsedRequest FindUserInfoRequest
+	log := logger.AcquireFrom(request.Context())
+
+	// This endpoint doesn't require user ID from context for admin lookups
+	_ = log
+
+	query := request.URL.Query()
+	err := querydecoder.New(query).Decode(&parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToBulkUpdateUserGroupMembershipsRequest maps incoming BulkUpdateUserGroupMemberships request to correct struct
+func MapRequestToBulkUpdateUserGroupMembershipsRequest(request *http.Request, validator UsermanagerValidator) (*BulkUpdateUserGroupMembershipsRequest, error) {
+	var parsedRequest BulkUpdateUserGroupMembershipsRequest
+	log := logger.AcquireFrom(request.Context())
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(request.Context())
+	if parsedRequest.UserId == "" {
+		log.Error("unable-get-user-id")
+		return nil, errors.New(ErrKeyUnableToIdentifyUser)
+	}
+
+	var err error
+	parsedRequest.TargetUserId, err = toolbox.GetVariableValueFromUri(request, userv2.UserURIVariableID)
+	if err != nil {
+		log.Error("unable-get-target-user-id-from-uri")
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	err = toolbox.DecodeRequestBody(request, &parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToGetGroupsByTypeRequest maps incoming GetGroupsByType request to correct struct
+func MapRequestToGetGroupsByTypeRequest(request *http.Request, validator UsermanagerValidator) (*GetGroupsByTypeRequest, error) {
+	var parsedRequest GetGroupsByTypeRequest
+	log := logger.AcquireFrom(request.Context())
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(request.Context())
+	if parsedRequest.UserId == "" {
+		log.Error("unable-get-user-id")
+		return nil, errors.New(ErrKeyUnableToIdentifyUser)
+	}
+
+	var err error
+	parsedRequest.GroupType, err = toolbox.GetVariableValueFromUri(request, UserManagerURIVariableGroupType)
+	if err != nil {
+		log.Error("unable-get-group-type-from-uri")
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	query := request.URL.Query()
+	err = querydecoder.New(query).Decode(&parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToCreateGroupRequest maps incoming CreateGroup request to correct struct
+func MapRequestToCreateGroupRequest(request *http.Request, validator UsermanagerValidator) (*CreateGroupRequest, error) {
+	var parsedRequest CreateGroupRequest
+	log := logger.AcquireFrom(request.Context())
+
+	parsedRequest.AdminUserId = accessmanagerhelpers.AcquireFrom(request.Context())
+	if parsedRequest.AdminUserId == "" {
+		log.Error("unable-get-admin-user-id")
+		return nil, errors.New(ErrKeyUnableToIdentifyUser)
+	}
+
+	err := toolbox.DecodeRequestBody(request, &parsedRequest)
+	if err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, errors.New(ErrKeyRequestFailedValidation)
+	}
+
+	return &parsedRequest, nil
+}

--- a/external/usermanager/handler.go
+++ b/external/usermanager/handler.go
@@ -17,6 +17,16 @@ type UsermanagerService interface {
 	DeleteUserPermanently(ctx context.Context, r *DeleteUserPermanentlyRequest) error
 	CreateComms(ctx context.Context, req *CreateCommsRequest) (*CreateCommsResponse, error)
 	GetComms(ctx context.Context, req *GetCommsRequest) (*GetCommsResponse, error)
+	// Group/Team management methods
+	GetEnrichedUserProfile(ctx context.Context, r *GetEnrichedUserProfileRequest) (*GetEnrichedUserProfileResponse, error)
+	GetUserGroups(ctx context.Context, r *GetUserGroupsRequest) (*GetUserGroupsResponse, error)
+	GetUserTeamMemberships(ctx context.Context, r *GetUserTeamMembershipsRequest) (*GetUserTeamMembershipsResponse, error)
+	UpdateUserTeamMembership(ctx context.Context, r *UpdateUserTeamMembershipRequest) (*UpdateUserTeamMembershipResponse, error)
+	RemoveUserFromGroup(ctx context.Context, r *RemoveUserFromGroupRequest) (*RemoveUserFromGroupResponse, error)
+	FindUserInfo(ctx context.Context, r *FindUserInfoRequest) (*FindUserInfoResponse, error)
+	BulkUpdateUserGroupMemberships(ctx context.Context, r *BulkUpdateUserGroupMembershipsRequest) (*BulkUpdateUserGroupMembershipsResponse, error)
+	GetGroupsByType(ctx context.Context, r *GetGroupsByTypeRequest) (*GetGroupsByTypeResponse, error)
+	CreateGroup(ctx context.Context, r *CreateGroupRequest) (*CreateGroupResponse, error)
 }
 
 // UsermanagerValidator expected methods of a valid
@@ -202,6 +212,204 @@ func (h *Handler) GetComms(w http.ResponseWriter, r *http.Request) {
 
 	//nolint will set up default fallback later
 	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, getCommsResponse.Comms)
+}
+
+// GetEnrichedUserProfile handles the request to get an enriched user profile with group memberships
+func (h *Handler) GetEnrichedUserProfile(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetEnrichedUserProfileRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetEnrichedUserProfile(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Profile)
+}
+
+// GetUserGroups handles the request to get a user's group memberships
+func (h *Handler) GetUserGroups(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetUserGroupsRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetUserGroups(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	if request.Meta {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups, reply.WithMeta(response.Meta))
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups)
+}
+
+// GetUserTeamMemberships handles the request to get team membership status for a user
+func (h *Handler) GetUserTeamMemberships(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetUserTeamMembershipsRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetUserTeamMemberships(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Memberships)
+}
+
+// UpdateUserTeamMembership handles the request to update a user's team membership
+func (h *Handler) UpdateUserTeamMembership(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToUpdateUserTeamMembershipRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.UpdateUserTeamMembership(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Membership)
+}
+
+// RemoveUserFromGroup handles the request to remove a user from a group
+func (h *Handler) RemoveUserFromGroup(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToRemoveUserFromGroupRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.RemoveUserFromGroup(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response)
+}
+
+// FindUserInfo handles the request to find user information with optional group membership data
+func (h *Handler) FindUserInfo(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToFindUserInfoRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.FindUserInfo(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.User)
+}
+
+// BulkUpdateUserGroupMemberships handles the request to perform bulk group membership operations
+func (h *Handler) BulkUpdateUserGroupMemberships(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToBulkUpdateUserGroupMembershipsRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.BulkUpdateUserGroupMemberships(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	// Use 207 Multi-Status if there are failures, otherwise 200 OK
+	statusCode := http.StatusOK
+	if response.FailureCount > 0 {
+		statusCode = http.StatusMultiStatus
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, statusCode, response)
+}
+
+// GetGroupsByType handles the request to get groups filtered by type
+func (h *Handler) GetGroupsByType(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetGroupsByTypeRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetGroupsByType(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	if request.Meta {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups, reply.WithMeta(response.Meta))
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Groups)
+}
+
+// CreateGroup handles the admin request to create a new group
+func (h *Handler) CreateGroup(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToCreateGroupRequest(r, h.Validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.CreateGroup(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusCreated, response.Group)
 }
 
 // GetBaseResponseHandler returns response handler configured with auth error map

--- a/external/usermanager/model.go
+++ b/external/usermanager/model.go
@@ -1,7 +1,164 @@
 package usermanager
 
+import "time"
+
+// UsageInfo represents usage statistics
 type UsageInfo struct {
 	Allowance      string `json:"allowance"`
 	Used           string `json:"used"`
 	UsedPercentage string `json:"used_percentage"`
+}
+
+// GroupMemberInfo represents minimal information about a group member
+// Used for displaying membership details without full user/group data
+type GroupMemberInfo struct {
+	// ID is the unique identifier of the member (user or group)
+	ID string `json:"id"`
+
+	// FullName is the complete name of the member
+	FullName string `json:"full_name"`
+
+	// Type indicates the member type (USER or GROUP)
+	Type string `json:"type"`
+
+	// Email is the email address (for users)
+	Email string `json:"email,omitempty"`
+
+	// Role is the member's role within the group
+	Role string `json:"role,omitempty"`
+
+	// JoinedAt is when the member joined the group
+	JoinedAt string `json:"joined_at,omitempty"`
+}
+
+// GroupSummary represents summary information about a group
+type GroupSummary struct {
+	// ID is the group's unique identifier
+	ID string `json:"id"`
+
+	// NanoID is the group's alternative identifier
+	NanoID string `json:"nano_id,omitempty"`
+
+	// Name is the group's name
+	Name string `json:"name"`
+
+	// Type is the group type (TEAM, DEPARTMENT, etc.)
+	Type string `json:"type"`
+
+	// Description is a brief description of the group
+	Description string `json:"description,omitempty"`
+
+	// MemberCount is the total number of members
+	MemberCount int `json:"member_count"`
+
+	// Status is the group's current status
+	Status string `json:"status"`
+
+	// CreatedAt is when the group was created
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// UserGroupMembership represents a user's membership in a specific group
+type UserGroupMembership struct {
+	// Group contains summary information about the group
+	Group GroupSummary `json:"group"`
+
+	// IsMember indicates if the user is a member
+	IsMember bool `json:"is_member"`
+
+	// Role is the user's role in the group
+	Role string `json:"role,omitempty"`
+
+	// IsOwner indicates if the user owns the group
+	IsOwner bool `json:"is_owner"`
+
+	// IsLead indicates if the user leads the group
+	IsLead bool `json:"is_lead"`
+
+	// IsHead indicates if the user is the head of the group
+	IsHead bool `json:"is_head"`
+
+	// JoinedAt is when the user joined the group
+	JoinedAt string `json:"joined_at,omitempty"`
+}
+
+// EnrichedUserProfile represents a user profile enriched with group membership data
+type EnrichedUserProfile struct {
+	// ID is the user's unique identifier
+	ID string `json:"id"`
+
+	// Email is the user's email address
+	Email string `json:"email"`
+
+	// FullName is the user's full name
+	FullName string `json:"full_name"`
+
+	// FirstName is the user's first name
+	FirstName string `json:"first_name,omitempty"`
+
+	// LastName is the user's last name
+	LastName string `json:"last_name,omitempty"`
+
+	// Status is the user's account status
+	Status string `json:"status"`
+
+	// Roles are the user's platform roles
+	Roles []string `json:"roles,omitempty"`
+
+	// Teams are the teams the user belongs to
+	Teams []UserGroupMembership `json:"teams,omitempty"`
+
+	// Departments are the departments the user belongs to
+	Departments []UserGroupMembership `json:"departments,omitempty"`
+
+	// Groups are all groups the user belongs to
+	Groups []UserGroupMembership `json:"groups,omitempty"`
+
+	// CreatedAt is when the user account was created
+	CreatedAt string `json:"created_at,omitempty"`
+
+	// LastLoginAt is when the user last logged in
+	LastLoginAt string `json:"last_login_at,omitempty"`
+}
+
+// GroupMembershipAction represents an action to be performed on group membership
+type GroupMembershipAction struct {
+	// Action is the type of action (ADD, REMOVE, UPDATE_ROLE)
+	Action string `json:"action"`
+
+	// GroupID is the target group identifier
+	GroupID string `json:"group_id"`
+
+	// Role is the role to assign (for ADD/UPDATE_ROLE actions)
+	Role string `json:"role,omitempty"`
+
+	// RemoveFromOtherGroups indicates whether to remove user from other groups of the same type
+	RemoveFromOtherGroups bool `json:"remove_from_other_groups,omitempty"`
+}
+
+// BulkGroupMembershipUpdate represents a batch update of group memberships
+type BulkGroupMembershipUpdate struct {
+	// UserID is the user whose memberships are being updated
+	UserID string `json:"user_id"`
+
+	// Actions are the membership actions to perform
+	Actions []GroupMembershipAction `json:"actions"`
+}
+
+// GroupMembershipUpdateResult represents the result of a membership update
+type GroupMembershipUpdateResult struct {
+	// Success indicates if the operation succeeded
+	Success bool `json:"success"`
+
+	// GroupID is the affected group
+	GroupID string `json:"group_id"`
+
+	// Action is the action that was performed
+	Action string `json:"action"`
+
+	// Error is any error message (if Success is false)
+	Error string `json:"error,omitempty"`
+
+	// UpdatedAt is when the update occurred
+	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/external/usermanager/request.go
+++ b/external/usermanager/request.go
@@ -13,7 +13,7 @@ type GetUserMicroProfileRequest struct {
 }
 
 // GetUserProfileRequest holds all the data needed to action user
-// profile retrival request
+// profile retrieval request
 type GetUserProfileRequest struct {
 
 	// UserId the ID of the user requesting their profile
@@ -63,4 +63,193 @@ type GetCommsRequest struct {
 	UserId string
 
 	*contacter.GetCommsRequest
+}
+
+// GetEnrichedUserProfileRequest holds the data needed to get an enriched user profile
+type GetEnrichedUserProfileRequest struct {
+
+	// UserId is the ID of the user requesting their enriched profile
+	UserId string
+
+	// IncludeTeams indicates whether to include team memberships
+	IncludeTeams bool
+
+	// IncludeDepartments indicates whether to include department memberships
+	IncludeDepartments bool
+
+	// IncludeAllGroups indicates whether to include all group memberships
+	IncludeAllGroups bool
+}
+
+// GetUserGroupsRequest holds the data needed to get groups for a user
+type GetUserGroupsRequest struct {
+
+	// UserId is the ID of the user
+	UserId string
+
+	// GroupType filters by group type (optional: TEAM, DEPARTMENT, etc.)
+	GroupType string
+
+	// Status filters by group status (optional: ACTIVE, INACTIVE, etc.)
+	Status string
+
+	// Page specifies the page results should be taken from. Default 1.
+	Page int
+
+	// PerPage specifies the number of groups to return per page. Default 25. Max 100.
+	PerPage int `validate:"min=1,max=100"`
+
+	// Meta indicates whether response should contain meta information
+	Meta bool
+}
+
+// GetUserTeamMembershipsRequest holds the data needed to get team memberships for a user
+type GetUserTeamMembershipsRequest struct {
+
+	// UserId is the ID of the user (can be current user or admin checking another user)
+	UserId string
+
+	// TargetUserId is the ID of the user to check memberships for (admin feature)
+	TargetUserId string
+
+	// IncludeInactive indicates whether to include inactive teams
+	IncludeInactive bool
+}
+
+// UpdateUserTeamMembershipRequest holds the data needed to update a user's team membership
+type UpdateUserTeamMembershipRequest struct {
+
+	// UserId is the ID of the user making the request
+	UserId string
+
+	// GroupID is the ID of the group to join/update
+	GroupID string
+
+	// Role is the role to assign (optional, uses default if not specified)
+	Role string
+
+	// RemoveFromOtherTeams indicates whether to leave other teams of the same type
+	RemoveFromOtherTeams bool
+
+	// DisableNotification specifies whether to disable notifications for this action
+	DisableNotification bool
+}
+
+// RemoveUserFromGroupRequest holds the data needed to remove a user from a group
+type RemoveUserFromGroupRequest struct {
+
+	// UserId is the ID of the user making the request
+	UserId string
+
+	// GroupID is the ID of the group to leave
+	GroupID string
+
+	// DisableNotification specifies whether to disable notifications for this action
+	DisableNotification bool
+}
+
+// FindUserInfoRequest holds the data needed to find user information with flexible lookup
+type FindUserInfoRequest struct {
+
+	// UserId is the ID of the user to find (direct lookup)
+	UserId string
+
+	// Email is the email address to search by
+	Email string
+
+	// IncludeTeamMemberships indicates whether to include team membership data
+	IncludeTeamMemberships bool
+
+	// IncludeGroupMemberships indicates whether to include all group membership data
+	IncludeGroupMemberships bool
+}
+
+// BulkUpdateUserGroupMembershipsRequest holds the data for bulk membership updates
+type BulkUpdateUserGroupMembershipsRequest struct {
+
+	// UserId is the ID of the user making the request (must be admin)
+	UserId string
+
+	// TargetUserId is the ID of the user whose memberships are being updated
+	TargetUserId string
+
+	// Actions are the membership actions to perform
+	Actions []GroupMembershipAction
+
+	// DisableNotifications specifies whether to disable notifications for all actions
+	DisableNotifications bool
+}
+
+// GetGroupsByTypeRequest holds the data needed to get groups filtered by type
+type GetGroupsByTypeRequest struct {
+
+	// UserId is the ID of the user making the request
+	UserId string
+
+	// GroupType is the type to filter by (TEAM, DEPARTMENT, ORGANIZATION, etc.)
+	GroupType string
+
+	// Name filters groups by name (optional, partial match)
+	Name string
+
+	// Status filters by status (optional: ACTIVE, INACTIVE, etc.)
+	Status string
+
+	// OnlyUserMemberships returns only groups the user belongs to
+	OnlyUserMemberships bool
+
+	// Page specifies the page results should be taken from. Default 1.
+	Page int
+
+	// PerPage specifies the number of groups to return per page. Default 25. Max 100.
+	PerPage int `validate:"min=1,max=100"`
+
+	// Meta indicates whether response should contain meta information
+	Meta bool
+
+	// Order defines how results should be sorted (e.g., "name_asc", "created_at_desc")
+	Order string
+}
+
+// CreateGroupRequest holds the data needed for an admin to create a new group
+type CreateGroupRequest struct {
+
+	// AdminUserId is the ID of the admin making the request
+	AdminUserId string
+
+	// Name is the name of the group
+	Name string `json:"name" validate:"required"`
+
+	// Type is the type of group (TEAM, DEPARTMENT, etc.)
+	Type string `json:"type" validate:"required"`
+
+	// Description is the group description
+	Description string `json:"description,omitempty"`
+
+	// Email is the group contact email
+	Email string `json:"email,omitempty"`
+
+	// Icon is the group icon/emoji
+	Icon string `json:"icon,omitempty"`
+
+	// Visibility controls group visibility (PUBLIC, PRIVATE, etc.)
+	Visibility string `json:"visibility,omitempty"`
+
+	// Extensions are custom key-value pairs
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+
+	// InitialMemberIDs are user IDs to add as initial members
+	InitialMemberIDs []string `json:"initial_member_ids,omitempty"`
+
+	// InitialMemberRole is the default role for initial members
+	InitialMemberRole string `json:"initial_member_role,omitempty"`
+
+	// OwnerID is the ID of the group owner
+	OwnerID string `json:"owner_id,omitempty"`
+
+	// HeadID is the ID of the group head
+	HeadID string `json:"head_id,omitempty"`
+
+	// LeadID is the ID of the group lead
+	LeadID string `json:"lead_id,omitempty"`
 }

--- a/external/usermanager/response.go
+++ b/external/usermanager/response.go
@@ -30,3 +30,83 @@ type GetCommsResponse struct {
 	Comms []contacter.Comms      `json:"comms"`
 	Meta  map[string]interface{} `json:"-"`
 }
+
+// GetEnrichedUserProfileResponse holds the response for an enriched user profile
+type GetEnrichedUserProfileResponse struct {
+	Profile *EnrichedUserProfile `json:"profile"`
+}
+
+// GetUserGroupsResponse holds the response for user groups
+type GetUserGroupsResponse struct {
+	Groups []GroupSummary         `json:"groups"`
+	Total  int                    `json:"-"`
+	Meta   map[string]interface{} `json:"-"`
+}
+
+// GetMetaData returns formatted metadata for pagination
+func (r *GetUserGroupsResponse) GetMetaData() map[string]interface{} {
+	if r.Meta != nil {
+		return r.Meta
+	}
+	return map[string]interface{}{
+		"total_resources": r.Total,
+	}
+}
+
+// GetUserTeamMembershipsResponse holds the response for team memberships
+type GetUserTeamMembershipsResponse struct {
+	Memberships map[string]UserGroupMembership `json:"memberships"`
+	UserID      string                         `json:"user_id"`
+}
+
+// UpdateUserTeamMembershipResponse holds the response for updating team membership
+type UpdateUserTeamMembershipResponse struct {
+	Success             bool                `json:"success"`
+	Membership          UserGroupMembership `json:"membership"`
+	PreviousMemberships []GroupSummary      `json:"previous_memberships,omitempty"`
+}
+
+// RemoveUserFromGroupResponse holds the response for removing a user from a group
+type RemoveUserFromGroupResponse struct {
+	Success bool   `json:"success"`
+	GroupID string `json:"group_id"`
+	Message string `json:"message,omitempty"`
+}
+
+// FindUserInfoResponse holds the response for finding user information
+type FindUserInfoResponse struct {
+	User                  *userv2.UserProfile   `json:"user"`
+	TeamMemberships       []UserGroupMembership `json:"team_memberships,omitempty"`
+	GroupMemberships      []UserGroupMembership `json:"group_memberships,omitempty"`
+	MembershipDataFetched bool                  `json:"membership_data_fetched"`
+}
+
+// BulkUpdateUserGroupMembershipsResponse holds the response for bulk membership updates
+type BulkUpdateUserGroupMembershipsResponse struct {
+	Results      []GroupMembershipUpdateResult `json:"results"`
+	SuccessCount int                           `json:"success_count"`
+	FailureCount int                           `json:"failure_count"`
+	TotalActions int                           `json:"total_actions"`
+}
+
+// GetGroupsByTypeResponse holds the response for getting groups by type
+type GetGroupsByTypeResponse struct {
+	Groups []GroupSummary         `json:"groups"`
+	Total  int                    `json:"-"`
+	Meta   map[string]interface{} `json:"-"`
+}
+
+// GetMetaData returns formatted metadata for pagination
+func (r *GetGroupsByTypeResponse) GetMetaData() map[string]interface{} {
+	if r.Meta != nil {
+		return r.Meta
+	}
+	return map[string]interface{}{
+		"total_resources": r.Total,
+	}
+}
+
+// CreateGroupResponse holds the response for creating a new group
+type CreateGroupResponse struct {
+	Group *GroupSummary `json:"group"`
+}

--- a/external/usermanager/routes.go
+++ b/external/usermanager/routes.go
@@ -15,6 +15,16 @@ type UsermanagerHandler interface {
 	DeleteUserPermanently(w http.ResponseWriter, r *http.Request)
 	CreateComms(w http.ResponseWriter, r *http.Request)
 	GetComms(w http.ResponseWriter, r *http.Request)
+	// Group/Team management methods
+	GetEnrichedUserProfile(w http.ResponseWriter, r *http.Request)
+	GetUserGroups(w http.ResponseWriter, r *http.Request)
+	GetUserTeamMemberships(w http.ResponseWriter, r *http.Request)
+	UpdateUserTeamMembership(w http.ResponseWriter, r *http.Request)
+	RemoveUserFromGroup(w http.ResponseWriter, r *http.Request)
+	FindUserInfo(w http.ResponseWriter, r *http.Request)
+	BulkUpdateUserGroupMemberships(w http.ResponseWriter, r *http.Request)
+	GetGroupsByType(w http.ResponseWriter, r *http.Request)
+	CreateGroup(w http.ResponseWriter, r *http.Request)
 }
 
 const (
@@ -65,13 +75,26 @@ func AttachRoutes(request *AttachRoutesRequest) {
 	usermanagerAuthenticatedRoutes.HandleFunc("/me", request.Handler.GetUserProfile).Methods(http.MethodGet, http.MethodOptions)
 	usermanagerAuthenticatedRoutes.HandleFunc("/me", request.Handler.DeleteUserPermanently).Methods(http.MethodDelete, http.MethodOptions)
 	usermanagerAuthenticatedRoutes.HandleFunc("/me/micro", request.Handler.GetUserMicroProfile).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/me/enriched", request.Handler.GetEnrichedUserProfile).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/me/groups", request.Handler.GetUserGroups).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/me/teams/memberships", request.Handler.GetUserTeamMemberships).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/groups/{"+UserManagerURIVariableGroupType+"}", request.Handler.GetGroupsByType).Methods(http.MethodGet, http.MethodOptions)
 	usermanagerAuthenticatedRoutes.Use(request.ValidApiTokenOrJWTMiddleware)
 
 	usermanagerAdminRoutes := httpRouter.PathPrefix(APIUserManagerV2Prefix).Subrouter()
 	usermanagerAdminRoutes.HandleFunc("/comms", request.Handler.GetComms).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAdminRoutes.HandleFunc("/admin/users/{id}/groups/bulk", request.Handler.BulkUpdateUserGroupMemberships).Methods(http.MethodPost, http.MethodOptions)
+	usermanagerAdminRoutes.HandleFunc("/admin/groups", request.Handler.CreateGroup).Methods(http.MethodPost, http.MethodOptions)
 	usermanagerAdminRoutes.Use(request.AdminOnlyMiddleware)
 
 	usermanagerActiveOnlyRoutes := httpRouter.PathPrefix(APIUserManagerV2Prefix).Subrouter()
 	usermanagerActiveOnlyRoutes.HandleFunc("/me", request.Handler.UpdateUserProfile).Methods(http.MethodPatch, http.MethodOptions)
+	usermanagerActiveOnlyRoutes.HandleFunc("/me/teams/memberships/{"+UserManagerURIVariableGroupID+"}", request.Handler.UpdateUserTeamMembership).Methods(http.MethodPut, http.MethodOptions)
+	usermanagerActiveOnlyRoutes.HandleFunc("/me/teams/memberships/{"+UserManagerURIVariableGroupID+"}", request.Handler.RemoveUserFromGroup).Methods(http.MethodDelete, http.MethodOptions)
 	usermanagerActiveOnlyRoutes.Use(request.ActiveValidApiTokenOrJWTMiddleware)
+
+	// User info lookup - available to both admin and active users
+	usermanagerUserInfoRoutes := httpRouter.PathPrefix(APIUserManagerV2Prefix).Subrouter()
+	usermanagerUserInfoRoutes.HandleFunc("/users/info", request.Handler.FindUserInfo).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerUserInfoRoutes.Use(request.ValidApiTokenOrJWTMiddleware)
 }

--- a/external/usermanager/service.go
+++ b/external/usermanager/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ooaklee/ghatd/external/apitoken"
 	"github.com/ooaklee/ghatd/external/audit"
 	"github.com/ooaklee/ghatd/external/contacter"
+	"github.com/ooaklee/ghatd/external/group"
 	"github.com/ooaklee/ghatd/external/logger"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 	"go.uber.org/zap"
@@ -15,6 +16,8 @@ import (
 type UserService interface {
 	GetUserMicroProfile(ctx context.Context, r *userv2.GetUserMicroProfileRequest) (*userv2.GetUserMicroProfileResponse, error)
 	GetUserProfile(ctx context.Context, r *userv2.GetUserProfileRequest) (*userv2.GetUserProfileResponse, error)
+	GetUserByID(ctx context.Context, r *userv2.GetUserByIDRequest) (*userv2.GetUserByIDResponse, error)
+	GetUserByEmail(ctx context.Context, r *userv2.GetUserByEmailRequest) (*userv2.GetUserByEmailResponse, error)
 	UpdateUser(ctx context.Context, r *userv2.UpdateUserRequest) (*userv2.UpdateUserResponse, error)
 	DeleteUser(ctx context.Context, r *userv2.DeleteUserRequest) error
 }
@@ -36,12 +39,23 @@ type ContacterService interface {
 	GetComms(ctx context.Context, req *contacter.GetCommsRequest) (*contacter.GetCommsResponse, error)
 }
 
+// GroupService expected methods of a valid group service
+type GroupService interface {
+	GetGroups(ctx context.Context, r *group.GetGroupsRequest) (*group.GetGroupsResponse, error)
+	GetGroupByID(ctx context.Context, r *group.GetGroupByIDRequest) (*group.GetGroupByIDResponse, error)
+	AddMember(ctx context.Context, r *group.AddMemberRequest) (*group.AddMemberResponse, error)
+	RemoveMember(ctx context.Context, r *group.RemoveMemberRequest) error
+	UpdateMemberRole(ctx context.Context, r *group.UpdateMemberRoleRequest) error
+	CreateGroup(ctx context.Context, req *group.CreateGroupRequest) (*group.CreateGroupResponse, error)
+}
+
 // Service holds and manages usermanager business logic
 type Service struct {
 	UserService      UserService
 	ApiTokenService  ApiTokenService
 	AuditService     AuditService
 	ContacterService ContacterService
+	GroupService     GroupService
 }
 
 // NewServiceRequest holds all expected dependencies for an usermanager service
@@ -68,6 +82,12 @@ func NewService(r *NewServiceRequest) *Service {
 		AuditService:     r.AuditService,
 		ContacterService: r.ContacterService,
 	}
+}
+
+// WithGroupService adds group service integration
+func (s *Service) WithGroupService(groupSvc GroupService) *Service {
+	s.GroupService = groupSvc
+	return s
 }
 
 // UpdateUserProfile handles the business logic of updating the requesting user's profile

--- a/external/usermanager/service.group.admin.go
+++ b/external/usermanager/service.group.admin.go
@@ -1,0 +1,76 @@
+package usermanager
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ooaklee/ghatd/external/group"
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
+)
+
+// CreateGroup handles creating a new group (admin only)
+func (s *Service) CreateGroup(ctx context.Context, r *CreateGroupRequest) (*CreateGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled", zap.String("admin-user-id", r.AdminUserId))
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	// Build the group creation request
+	createReq := &group.CreateGroupRequest{
+		Name:        r.Name,
+		Type:        r.Type,
+		Description: r.Description,
+		Email:       r.Email,
+		Icon:        r.Icon,
+		Visibility:  r.Visibility,
+		Extensions:  r.Extensions,
+		OwnerID:     r.OwnerID,
+		HeadID:      r.HeadID,
+		LeadID:      r.LeadID,
+	}
+
+	// Add initial members if provided
+	if len(r.InitialMemberIDs) > 0 {
+		defaultRole := r.InitialMemberRole
+		if defaultRole == "" {
+			defaultRole = group.MemberRoleMember
+		}
+
+		createReq.InitialMembers = make([]group.CreateMemberRequest, len(r.InitialMemberIDs))
+		for i, memberID := range r.InitialMemberIDs {
+			createReq.InitialMembers[i] = group.CreateMemberRequest{
+				ID:   memberID,
+				Type: group.MemberTypeUser,
+				Role: defaultRole,
+			}
+		}
+	}
+
+	// Create the group via group service
+	groupResp, err := s.GroupService.CreateGroup(ctx, createReq)
+	if err != nil {
+		log.Error("failed-to-create-group", zap.String("name", r.Name), zap.String("type", r.Type), zap.Error(err))
+		return nil, err
+	}
+
+	// Convert to group summary
+	groupSummary := &GroupSummary{
+		ID:          groupResp.Group.ID,
+		NanoID:      groupResp.Group.NanoID,
+		Name:        groupResp.Group.Name,
+		Type:        groupResp.Group.Type,
+		Description: groupResp.Group.DisplayInfo.Description,
+		MemberCount: groupResp.Group.GetMemberCount(),
+		Status:      groupResp.Group.Status,
+		CreatedAt:   groupResp.Group.Metadata.CreatedAt,
+	}
+
+	log.Info("group-created-successfully", zap.String("group-id", groupSummary.ID), zap.String("group-name", groupSummary.Name))
+
+	return &CreateGroupResponse{
+		Group: groupSummary,
+	}, nil
+}

--- a/external/usermanager/service.group.go
+++ b/external/usermanager/service.group.go
@@ -1,0 +1,662 @@
+package usermanager
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ooaklee/ghatd/external/group"
+	"github.com/ooaklee/ghatd/external/logger"
+	userv2 "github.com/ooaklee/ghatd/external/user/v2"
+	"go.uber.org/zap"
+)
+
+// GetEnrichedUserProfile handles fetching an enriched user profile with group membership data
+func (s *Service) GetEnrichedUserProfile(ctx context.Context, r *GetEnrichedUserProfileRequest) (*GetEnrichedUserProfileResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	// Get base user profile
+	userResp, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{
+		ID: r.UserId,
+	})
+	if err != nil {
+		log.Error("failed-to-get-user-profile", zap.String("user-id", r.UserId), zap.Error(err))
+		return nil, err
+	}
+
+	enrichedProfile := &EnrichedUserProfile{
+		ID:          userResp.User.ID,
+		Email:       userResp.User.Email,
+		FullName:    userResp.User.PersonalInfo.FullName,
+		FirstName:   userResp.User.PersonalInfo.FirstName,
+		LastName:    userResp.User.PersonalInfo.LastName,
+		Status:      userResp.User.Status,
+		Roles:       userResp.User.Roles,
+		CreatedAt:   userResp.User.Metadata.CreatedAt,
+		LastLoginAt: userResp.User.Metadata.LastLoginAt,
+		Teams:       []UserGroupMembership{},
+		Departments: []UserGroupMembership{},
+		Groups:      []UserGroupMembership{},
+	}
+
+	// Fetch group memberships if requested
+	if r.IncludeTeams || r.IncludeAllGroups {
+		teams, err := s.getUserGroupsByType(ctx, r.UserId, group.GroupTypeTeam)
+		if err != nil {
+			log.Warn("failed-to-fetch-team-memberships", zap.String("user-id", r.UserId), zap.Error(err))
+		} else {
+			enrichedProfile.Teams = teams
+		}
+	}
+
+	if r.IncludeDepartments || r.IncludeAllGroups {
+		departments, err := s.getUserGroupsByType(ctx, r.UserId, group.GroupTypeDepartment)
+		if err != nil {
+			log.Warn("failed-to-fetch-department-memberships", zap.String("user-id", r.UserId), zap.Error(err))
+		} else {
+			enrichedProfile.Departments = departments
+		}
+	}
+
+	if r.IncludeAllGroups {
+		allGroups, err := s.getUserAllGroups(ctx, r.UserId)
+		if err != nil {
+			log.Warn("failed-to-fetch-all-group-memberships", zap.String("user-id", r.UserId), zap.Error(err))
+		} else {
+			enrichedProfile.Groups = allGroups
+		}
+	}
+
+	return &GetEnrichedUserProfileResponse{
+		Profile: enrichedProfile,
+	}, nil
+}
+
+// GetUserGroups handles fetching groups for a user with filtering
+func (s *Service) GetUserGroups(ctx context.Context, r *GetUserGroupsRequest) (*GetUserGroupsResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	groupReq := &group.GetGroupsRequest{
+		MemberID:   r.UserId,
+		MemberType: group.MemberTypeUser,
+		Page:       r.Page,
+		PerPage:    r.PerPage,
+		Meta:       r.Meta,
+	}
+
+	if r.GroupType != "" {
+		groupReq.Types = []string{r.GroupType}
+	}
+
+	if r.Status != "" {
+		groupReq.Statuses = []string{r.Status}
+	}
+
+	groupsResp, err := s.GroupService.GetGroups(ctx, groupReq)
+	if err != nil {
+		log.Error("failed-to-get-user-groups", zap.String("user-id", r.UserId), zap.Error(err))
+		return nil, err
+	}
+
+	groupSummaries := make([]GroupSummary, 0, len(groupsResp.Groups))
+	for _, g := range groupsResp.Groups {
+		groupSummaries = append(groupSummaries, GroupSummary{
+			ID:          g.ID,
+			NanoID:      g.NanoID,
+			Name:        g.Name,
+			Type:        g.Type,
+			Description: g.DisplayInfo.Description,
+			MemberCount: g.GetMemberCount(),
+			Status:      g.Status,
+			CreatedAt:   g.Metadata.CreatedAt,
+		})
+	}
+
+	response := &GetUserGroupsResponse{
+		Groups: groupSummaries,
+		Total:  groupsResp.Total,
+	}
+
+	if r.Meta {
+		response.Meta = map[string]interface{}{
+			"total_resources":    groupsResp.Total,
+			"total_pages":        groupsResp.TotalPages,
+			"resources_per_page": groupsResp.PerPage,
+			"page":               groupsResp.Page,
+		}
+	}
+
+	return response, nil
+}
+
+// GetUserTeamMemberships handles fetching team memberships for a user
+func (s *Service) GetUserTeamMemberships(ctx context.Context, r *GetUserTeamMembershipsRequest) (*GetUserTeamMembershipsResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	targetUserID := r.UserId
+	if r.TargetUserId != "" {
+		targetUserID = r.TargetUserId
+	}
+
+	// Get all teams
+	teamsReq := &group.GetGroupsRequest{
+		Types:   []string{group.GroupTypeTeam},
+		PerPage: 100, // Get all teams
+	}
+
+	if !r.IncludeInactive {
+		teamsReq.Statuses = []string{group.GroupStatusActive}
+	}
+
+	teamsResp, err := s.GroupService.GetGroups(ctx, teamsReq)
+	if err != nil {
+		log.Error("failed-to-get-teams", zap.Error(err))
+		return nil, err
+	}
+
+	memberships := make(map[string]UserGroupMembership)
+
+	for _, team := range teamsResp.Groups {
+		membership := UserGroupMembership{
+			Group: GroupSummary{
+				ID:          team.ID,
+				NanoID:      team.NanoID,
+				Name:        team.Name,
+				Type:        team.Type,
+				Description: team.DisplayInfo.Description,
+				MemberCount: team.GetMemberCount(),
+				Status:      team.Status,
+				CreatedAt:   team.Metadata.CreatedAt,
+			},
+			IsMember: team.HasMember(targetUserID),
+		}
+
+		if membership.IsMember {
+			// Find the member details
+			member, err := team.GetMemberByID(targetUserID)
+			if err == nil {
+				membership.Role = member.Role
+				membership.JoinedAt = member.JoinedAt
+			}
+		}
+
+		// Check leadership roles
+		if team.Leadership != nil {
+			membership.IsOwner = team.Leadership.OwnerID == targetUserID
+			membership.IsLead = team.Leadership.LeadID == targetUserID
+			membership.IsHead = team.Leadership.HeadID == targetUserID
+		}
+
+		memberships[team.Name] = membership
+	}
+
+	return &GetUserTeamMembershipsResponse{
+		Memberships: memberships,
+		UserID:      targetUserID,
+	}, nil
+}
+
+// UpdateUserTeamMembership handles updating a user's team membership
+func (s *Service) UpdateUserTeamMembership(ctx context.Context, r *UpdateUserTeamMembershipRequest) (*UpdateUserTeamMembershipResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	// Get the target group
+	groupResp, err := s.GroupService.GetGroupByID(ctx, &group.GetGroupByIDRequest{
+		ID: r.GroupID,
+	})
+	if err != nil {
+		log.Error("failed-to-get-group", zap.String("group-id", r.GroupID), zap.Error(err))
+		return nil, errors.New(ErrKeyGroupNotFound)
+	}
+
+	targetGroup := groupResp.Group
+
+	// Check if user is already a member
+	isMember := targetGroup.HasMember(r.UserId)
+	if isMember {
+		log.Warn("user-already-member-of-group", zap.String("user-id", r.UserId), zap.String("group-id", r.GroupID))
+		return nil, errors.New(ErrKeyUserAlreadyMemberOfGroup)
+	}
+
+	var previousMemberships []GroupSummary
+
+	// If removing from other teams, fetch and remove
+	if r.RemoveFromOtherTeams {
+		currentTeams, err := s.getUserGroupsByType(ctx, r.UserId, targetGroup.Type)
+		if err != nil {
+			log.Warn("failed-to-fetch-current-memberships", zap.String("user-id", r.UserId), zap.Error(err))
+		} else {
+			for _, membership := range currentTeams {
+				if membership.IsMember && membership.Group.ID != r.GroupID {
+					// Remove from this group
+					err := s.GroupService.RemoveMember(ctx, &group.RemoveMemberRequest{
+						GroupID:  membership.Group.ID,
+						MemberID: r.UserId,
+					})
+					if err != nil {
+						log.Warn("failed-to-remove-from-previous-group", zap.String("group-id", membership.Group.ID), zap.Error(err))
+					} else {
+						previousMemberships = append(previousMemberships, membership.Group)
+					}
+				}
+			}
+		}
+	}
+
+	// Add user to the new group
+	role := r.Role
+	if role == "" {
+		role = group.MemberRoleMember // Default role
+	}
+
+	_, err = s.GroupService.AddMember(ctx, &group.AddMemberRequest{
+		GroupID:  r.GroupID,
+		MemberID: r.UserId,
+		Type:     group.MemberTypeUser,
+		Role:     role,
+	})
+	if err != nil {
+		log.Error("failed-to-add-member-to-group", zap.String("group-id", r.GroupID), zap.String("user-id", r.UserId), zap.Error(err))
+		return nil, errors.New(ErrKeyFailedToAddUserToGroup)
+	}
+
+	// Fetch updated membership
+	updatedGroup, err := s.GroupService.GetGroupByID(ctx, &group.GetGroupByIDRequest{
+		ID: r.GroupID,
+	})
+	if err != nil {
+		log.Warn("failed-to-fetch-updated-group", zap.String("group-id", r.GroupID), zap.Error(err))
+	}
+
+	membership := UserGroupMembership{
+		Group: GroupSummary{
+			ID:          targetGroup.ID,
+			NanoID:      targetGroup.NanoID,
+			Name:        targetGroup.Name,
+			Type:        targetGroup.Type,
+			Description: targetGroup.DisplayInfo.Description,
+			Status:      targetGroup.Status,
+			CreatedAt:   targetGroup.Metadata.CreatedAt,
+		},
+		IsMember: true,
+		Role:     role,
+	}
+
+	if updatedGroup != nil {
+		membership.Group.MemberCount = updatedGroup.Group.GetMemberCount()
+		member, err := updatedGroup.Group.GetMemberByID(r.UserId)
+		if err == nil {
+			membership.JoinedAt = member.JoinedAt
+		}
+	}
+
+	return &UpdateUserTeamMembershipResponse{
+		Success:             true,
+		Membership:          membership,
+		PreviousMemberships: previousMemberships,
+	}, nil
+}
+
+// RemoveUserFromGroup handles removing a user from a group
+func (s *Service) RemoveUserFromGroup(ctx context.Context, r *RemoveUserFromGroupRequest) (*RemoveUserFromGroupResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	err := s.GroupService.RemoveMember(ctx, &group.RemoveMemberRequest{
+		GroupID:  r.GroupID,
+		MemberID: r.UserId,
+	})
+	if err != nil {
+		log.Error("failed-to-remove-user-from-group", zap.String("group-id", r.GroupID), zap.String("user-id", r.UserId), zap.Error(err))
+		return nil, errors.New(ErrKeyFailedToRemoveUserFromGroup)
+	}
+
+	return &RemoveUserFromGroupResponse{
+		Success: true,
+		GroupID: r.GroupID,
+		Message: "Successfully removed from group",
+	}, nil
+}
+
+// FindUserInfo handles finding user information with flexible lookup
+func (s *Service) FindUserInfo(ctx context.Context, r *FindUserInfoRequest) (*FindUserInfoResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled")
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	var userResp *userv2.GetUserProfileResponse
+	var err error
+
+	// Attempt to find user by ID or email
+	if r.UserId != "" {
+		userResp, err = s.UserService.GetUserProfile(ctx, &userv2.GetUserProfileRequest{
+			ID: r.UserId,
+		})
+	} else if r.Email != "" {
+		emailResp, err := s.UserService.GetUserByEmail(ctx, &userv2.GetUserByEmailRequest{
+			Email: r.Email,
+		})
+		if err == nil && emailResp != nil {
+			userResp, err = s.UserService.GetUserProfile(ctx, &userv2.GetUserProfileRequest{
+				ID: emailResp.User.ID,
+			})
+		}
+	}
+
+	if err != nil {
+		log.Error("failed-to-find-user", zap.String("user-id", r.UserId), zap.String("email", r.Email), zap.Error(err))
+		return nil, errors.New(ErrKeyUserNotFound)
+	}
+
+	response := &FindUserInfoResponse{
+		User:                  userResp.Profile,
+		MembershipDataFetched: false,
+	}
+
+	// Fetch team memberships if requested
+	if r.IncludeTeamMemberships {
+		teams, err := s.getUserGroupsByType(ctx, userResp.Profile.ID, group.GroupTypeTeam)
+		if err != nil {
+			log.Warn("failed-to-fetch-team-memberships", zap.String("user-id", userResp.Profile.ID), zap.Error(err))
+		} else {
+			response.TeamMemberships = teams
+			response.MembershipDataFetched = true
+		}
+	}
+
+	// Fetch all group memberships if requested
+	if r.IncludeGroupMemberships {
+		allGroups, err := s.getUserAllGroups(ctx, userResp.Profile.ID)
+		if err != nil {
+			log.Warn("failed-to-fetch-group-memberships", zap.String("user-id", userResp.Profile.ID), zap.Error(err))
+		} else {
+			response.GroupMemberships = allGroups
+			response.MembershipDataFetched = true
+		}
+	}
+
+	return response, nil
+}
+
+// BulkUpdateUserGroupMemberships handles bulk updates of group memberships
+func (s *Service) BulkUpdateUserGroupMemberships(ctx context.Context, r *BulkUpdateUserGroupMembershipsRequest) (*BulkUpdateUserGroupMembershipsResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled", zap.String("requesting-user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	results := make([]GroupMembershipUpdateResult, 0, len(r.Actions))
+	successCount := 0
+	failureCount := 0
+
+	for _, action := range r.Actions {
+		result := GroupMembershipUpdateResult{
+			GroupID:   action.GroupID,
+			Action:    action.Action,
+			UpdatedAt: time.Now().UTC(),
+		}
+
+		switch action.Action {
+		case "ADD":
+			role := action.Role
+			if role == "" {
+				role = group.MemberRoleMember
+			}
+
+			_, err := s.GroupService.AddMember(ctx, &group.AddMemberRequest{
+				GroupID:  action.GroupID,
+				MemberID: r.TargetUserId,
+				Type:     group.MemberTypeUser,
+				Role:     role,
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				failureCount++
+				log.Warn("bulk-add-failed", zap.String("group-id", action.GroupID), zap.Error(err))
+			} else {
+				result.Success = true
+				successCount++
+			}
+
+		case "REMOVE":
+			err := s.GroupService.RemoveMember(ctx, &group.RemoveMemberRequest{
+				GroupID:  action.GroupID,
+				MemberID: r.TargetUserId,
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				failureCount++
+				log.Warn("bulk-remove-failed", zap.String("group-id", action.GroupID), zap.Error(err))
+			} else {
+				result.Success = true
+				successCount++
+			}
+
+		case "UPDATE_ROLE":
+			err := s.GroupService.UpdateMemberRole(ctx, &group.UpdateMemberRoleRequest{
+				GroupID:  action.GroupID,
+				MemberID: r.TargetUserId,
+				NewRole:  action.Role,
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				failureCount++
+				log.Warn("bulk-update-role-failed", zap.String("group-id", action.GroupID), zap.Error(err))
+			} else {
+				result.Success = true
+				successCount++
+			}
+
+		default:
+			result.Success = false
+			result.Error = "unknown action"
+			failureCount++
+		}
+
+		results = append(results, result)
+	}
+
+	return &BulkUpdateUserGroupMembershipsResponse{
+		Results:      results,
+		SuccessCount: successCount,
+		FailureCount: failureCount,
+		TotalActions: len(r.Actions),
+	}, nil
+}
+
+// GetGroupsByType handles fetching groups filtered by type
+func (s *Service) GetGroupsByType(ctx context.Context, r *GetGroupsByTypeRequest) (*GetGroupsByTypeResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	if s.GroupService == nil {
+		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId), zap.String("group-type", r.GroupType))
+		return nil, errors.New(ErrKeyGroupServiceNotEnabled)
+	}
+
+	groupReq := &group.GetGroupsRequest{
+		Types:      []string{r.GroupType},
+		Page:       r.Page,
+		PerPage:    r.PerPage,
+		OrderBy:    r.Order,
+		Meta:       r.Meta,
+		NameSearch: r.Name,
+	}
+
+	if r.Status != "" {
+		groupReq.Statuses = []string{r.Status}
+	}
+
+	if r.OnlyUserMemberships {
+		groupReq.MemberID = r.UserId
+		groupReq.MemberType = group.MemberTypeUser
+	}
+
+	groupsResp, err := s.GroupService.GetGroups(ctx, groupReq)
+	if err != nil {
+		log.Error("failed-to-get-groups-by-type", zap.String("type", r.GroupType), zap.Error(err))
+		return nil, err
+	}
+
+	groupSummaries := make([]GroupSummary, 0, len(groupsResp.Groups))
+	for _, g := range groupsResp.Groups {
+		groupSummaries = append(groupSummaries, GroupSummary{
+			ID:          g.ID,
+			NanoID:      g.NanoID,
+			Name:        g.Name,
+			Type:        g.Type,
+			Description: g.DisplayInfo.Description,
+			MemberCount: g.GetMemberCount(),
+			Status:      g.Status,
+			CreatedAt:   g.Metadata.CreatedAt,
+		})
+	}
+
+	response := &GetGroupsByTypeResponse{
+		Groups: groupSummaries,
+		Total:  groupsResp.Total,
+	}
+
+	if r.Meta {
+		response.Meta = map[string]interface{}{
+			"total_resources":    groupsResp.Total,
+			"total_pages":        groupsResp.TotalPages,
+			"resources_per_page": groupsResp.PerPage,
+			"page":               groupsResp.Page,
+		}
+	}
+
+	return response, nil
+}
+
+// Helper functions
+
+// getUserGroupsByType fetches groups of a specific type for a user
+func (s *Service) getUserGroupsByType(ctx context.Context, userID, groupType string) ([]UserGroupMembership, error) {
+	groupReq := &group.GetGroupsRequest{
+		Types:      []string{groupType},
+		MemberID:   userID,
+		MemberType: group.MemberTypeUser,
+		Statuses:   []string{group.GroupStatusActive},
+		PerPage:    100,
+	}
+
+	groupsResp, err := s.GroupService.GetGroups(ctx, groupReq)
+	if err != nil {
+		return nil, err
+	}
+
+	memberships := make([]UserGroupMembership, 0, len(groupsResp.Groups))
+	for _, g := range groupsResp.Groups {
+		member, err := g.GetMemberByID(userID)
+
+		membership := UserGroupMembership{
+			Group: GroupSummary{
+				ID:          g.ID,
+				NanoID:      g.NanoID,
+				Name:        g.Name,
+				Type:        g.Type,
+				Description: g.DisplayInfo.Description,
+				MemberCount: g.GetMemberCount(),
+				Status:      g.Status,
+				CreatedAt:   g.Metadata.CreatedAt,
+			},
+			IsMember: true,
+		}
+
+		if err == nil {
+			membership.Role = member.Role
+			membership.JoinedAt = member.JoinedAt
+		}
+
+		if g.Leadership != nil {
+			membership.IsOwner = g.Leadership.OwnerID == userID
+			membership.IsLead = g.Leadership.LeadID == userID
+			membership.IsHead = g.Leadership.HeadID == userID
+		}
+
+		memberships = append(memberships, membership)
+	}
+
+	return memberships, nil
+}
+
+// getUserAllGroups fetches all groups for a user
+func (s *Service) getUserAllGroups(ctx context.Context, userID string) ([]UserGroupMembership, error) {
+	groupReq := &group.GetGroupsRequest{
+		MemberID:   userID,
+		MemberType: group.MemberTypeUser,
+		Statuses:   []string{group.GroupStatusActive},
+		PerPage:    100,
+	}
+
+	groupsResp, err := s.GroupService.GetGroups(ctx, groupReq)
+	if err != nil {
+		return nil, err
+	}
+
+	memberships := make([]UserGroupMembership, 0, len(groupsResp.Groups))
+	for _, g := range groupsResp.Groups {
+		member, err := g.GetMemberByID(userID)
+
+		membership := UserGroupMembership{
+			Group: GroupSummary{
+				ID:          g.ID,
+				NanoID:      g.NanoID,
+				Name:        g.Name,
+				Type:        g.Type,
+				Description: g.DisplayInfo.Description,
+				MemberCount: g.GetMemberCount(),
+				Status:      g.Status,
+				CreatedAt:   g.Metadata.CreatedAt,
+			},
+			IsMember: true,
+		}
+
+		if err == nil {
+			membership.Role = member.Role
+			membership.JoinedAt = member.JoinedAt
+		}
+
+		if g.Leadership != nil {
+			membership.IsOwner = g.Leadership.OwnerID == userID
+			membership.IsLead = g.Leadership.LeadID == userID
+			membership.IsHead = g.Leadership.HeadID == userID
+		}
+
+		memberships = append(memberships, membership)
+	}
+
+	return memberships, nil
+}


### PR DESCRIPTION
### Context:

This PR introduces the concept of "groups," which represent a collection of users and/or subgroups. It can be used to represent anything from a family unit to an organisation. Rather than creating an independent `manager` service, it's been integrated into `user manager` and is set as an optional extension of the UMS.


### What has been done:

- **Documentation Updates**:
  - Improved overall docs for better readability/clarity and fixed typos.
  - Added guides to help users understand the router and user manager.

- **User Manager Features**:
  - Added group/team management to the user manager.
    - Integrated `Group Service` into the `usermanager.Service` with a new `WithGroupService` helper (allows group usage to be optional).
  - Provided examples for user manager + group features.

- **New Group Package**:
  - Created a new group package with core features, migrations, examples, and documentation.
  - Introduced an external `group` package with a `UniversalGroup` model and support types.
  - Developed a core model (model.go) that includes validation, member and leadership management, timestamps, etc.
  - Added examples and a getting-started README to explain the overall structure and usage.

