### PR TITLE
[GHATD-X] Introduce `post` & `contentmanager` packages

### DIFF
--- a/docs/getting-started/content-manager/README.md
+++ b/docs/getting-started/content-manager/README.md
@@ -1,0 +1,127 @@
+# Content Manager
+
+The `contentmanager` package is the HTTP orchestration layer for CMS-style content in this project. It sits on top of the `post` package and exposes endpoints for changelog entries, glossary items, FAQ items, articles, and latest-post overviews.
+
+This guide focuses on a practical quick start, based on the current service wiring in this repository.
+
+## Architecture
+
+The package follows the standard route -> handler -> service pattern used across this codebase:
+
+1. **Routes (`routes.go`)**: Defines the `/api/v1/cms` endpoints and middleware requirements.
+2. **Handler (`handler.go`)**: Maps HTTP requests to service requests and writes structured responses.
+3. **Fender (`fender.go`)**: Decodes body/query/path values and injects requestor user ID from access middleware context.
+4. **Service (`service.go`)**: Orchestrates post retrieval/mutation and applies access rules (admin-only write, published-only public read).
+
+## Quick Start
+
+### 1. Wire Dependencies in the Server
+
+Create the `post` and `contentmanager` services, then attach routes.
+
+```go
+import (
+    "github.com/ooaklee/ghatd/external/contentmanager"
+    "github.com/ooaklee/ghatd/external/post"
+    userV2 "github.com/ooaklee/ghatd/external/user/v2"
+)
+
+// repository and user service already initialised earlier
+postRepository := post.NewRepository(coreRepository)
+postService := post.NewService(postRepository, post.DefaultValidPostTags)
+contentManagerService := contentmanager.NewService(postService, userV2Service)
+
+contentManagerHandler := contentmanager.NewHandler(
+    contentManagerService,
+    appValidator,
+    post.PostErrorMap,
+    toolbox.ToolboxErrorMap,
+    userV2.UserErrorMap,
+)
+
+contentmanager.AttachRoutes(&contentmanager.AttachRoutesRequest{
+    Router:                                 httpRouter,
+    Handler:                                contentManagerHandler,
+    MiddlewareAdminApiTokenOrJwtRequired:   middlewareAdminApiTokenOrJwtRequired,
+    RateLimitOrActiveMiddleware:            middlewareRateLimitOrActive,
+    MiddlewareValidApiTokenOrJWTMiddleware: middlewareActiveAValidApiTokenOrJwt,
+})
+```
+
+### 2. Endpoint Groups and Access
+
+- **Admin write endpoints**:
+  - `POST /api/v1/cms/posts`
+  - `PATCH /api/v1/cms/posts/{postId}`
+  - `DELETE /api/v1/cms/posts/{postId}`
+  - `PATCH /api/v1/cms/posts/{postId}/restore`
+- **Open/read endpoints (rate-limited or active user)**:
+  - `GET /api/v1/cms/changelog`
+  - `GET /api/v1/cms/changelog/{urlFriendlyId}`
+  - `GET /api/v1/cms/glossary`
+  - `GET /api/v1/cms/faq`
+  - `GET /api/v1/cms/articles`
+  - `GET /api/v1/cms/articles/{urlFriendlyId}`
+  - `GET /api/v1/cms/latest`
+
+## Request Patterns
+
+### Create a Post (Admin)
+
+```bash
+curl -X POST http://localhost:8080/api/v1/cms/posts \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-token>" \
+  -d '{
+    "title": "Launch of the blog",
+    "type": "article",
+    "text": "# Hello\nThis is our first post",
+    "text_format": "markdown",
+    "header_image": "https://example.com/blog-cover.jpg",
+    "tags": ["announcement"],
+    "publish_now": true
+  }'
+```
+
+### Query Latest by Type
+
+Use the `types` and `limit` query parameters to retrieve a latest mixed feed.
+
+```bash
+curl "http://localhost:8080/api/v1/cms/latest?types=article,changelog&limit=5"
+```
+
+### Paginated Content Queries
+
+The changelog/glossary/faq/articles endpoints support common query params from `post.GetPostsRequest`, for example:
+
+```bash
+curl "http://localhost:8080/api/v1/cms/changelog?per_page=10&page=1&meta=true&with_tags=bug-fix"
+```
+
+## Behaviour Rules to Know
+
+- Non-admin users are blocked from create/update/delete/restore actions.
+- Public readers only receive published items.
+- Single-item endpoints enforce URL prefix intent:
+  - changelog IDs should start with `changelog-`
+  - article IDs should start with `article-`
+- If `published_as` is not explicitly set, the service resolves a fallback author display value.
+
+## Frontend Integration Notes
+
+If you are implementing a web client for this API:
+
+- Use a dedicated CMS client with base URL `/api/v1/cms`.
+- Keep dedicated methods for:
+  - `getLatestPostsByType`
+  - `getChangelogItems` and `getChangelogItemByUrlFriendlyId`
+  - `getGlossaryItems`
+  - `getFaqItems`
+  - `getArticles` and `getArticleItemByUrlFriendlyId`
+- For feed cards/home widgets, use `/latest` and consume post overviews.
+
+## Related Package Docs
+
+- [Post Getting Started](../post/README.md)
+- [Router Getting Started](../router/README.md)

--- a/docs/getting-started/post/README.md
+++ b/docs/getting-started/post/README.md
@@ -1,0 +1,153 @@
+# Post
+
+The `post` package is the core content domain used by the CMS layer. It provides strongly-typed models, business rules, and MongoDB-backed persistence for post types such as changelog entries, glossary items, FAQs, and articles.
+
+This guide covers a quick start for service setup, write/read flows, and migration-based seeding.
+
+## Architecture
+
+1. **Model (`model.go`)**: Defines post types, text formats, header image rules, URL-friendly IDs, and lightweight overviews.
+2. **Service (`service.go`)**: Enforces business rules for creation, retrieval, filtering, publication, and deletion/restore workflows.
+3. **Repository (`repository.go`)**: Handles MongoDB read/write operations for the `posts` collection.
+4. **Contracts (`request.go`, `response.go`)**: Defines request/response shapes used by both direct service calls and higher-level packages.
+
+## Supported Content Types
+
+- `changelog`
+- `article`
+- `faq`
+- `glossary`
+- `other`
+
+## Quick Start
+
+### 1. Initialise Repository and Service
+
+```go
+import (
+    "github.com/ooaklee/ghatd/external/post"
+)
+
+postRepository := post.NewRepository(coreRepository)
+postService := post.NewService(postRepository, post.DefaultValidPostTags)
+```
+
+### 2. Create a Post
+
+```go
+created, err := postService.CreatePost(ctx, &post.CreatePostRequest{
+    UserId:     "00000000-0000-0000-0000-000000000001",
+    Title:      "Performance and reliability improvements",
+    Type:       post.PostTypeChangelog,
+    Text:       "Improved caching and route-level efficiency.",
+    TextFormat: string(post.TextFormatMarkdown),
+    Tags:       []string{"product-news"},
+    PublishNow: true,
+})
+if err != nil {
+    return err
+}
+
+_ = created.Post
+```
+
+### 3. Query Posts by Type
+
+```go
+resp, err := postService.GetPosts(ctx, &post.GetPostsRequest{
+    WithTypes:    "article,changelog",
+    PerPage:      10,
+    Page:         1,
+    IsNotDeleted: true,
+    IsPublished:  true,
+    Order:        "published_at_desc",
+})
+if err != nil {
+    return err
+}
+
+for _, item := range resp.Posts {
+    _ = item.UrlFriendlyId
+}
+```
+
+## Key Business Rules
+
+- `UserId` is required for create/update/delete/restore operations.
+- `Title` and `Text` are required to create a post.
+- `article` posts require `header_image`.
+- non-article posts have `header_image` cleared.
+- changelog posts must use valid tags (`post.DefaultValidPostTags`).
+- URL-friendly ID generation is automatic and must remain unique.
+
+## Mongo Collection
+
+Posts are stored in MongoDB collection:
+
+- `posts`
+
+## Seeding Content with Migrations (Recommended)
+
+If you plan to pre-load changelog/FAQ/glossary/article content, use migration files under `migrations/mongo` so content creation is versioned and repeatable.
+
+### 1. Create a New Migration
+
+```bash
+go run main.go start-migrator new add-initial-faq-items
+```
+
+### 2. Add Up/Down Logic in Generated Migration
+
+Use the generated file to insert or remove seed documents in `posts`. Keep IDs and URL-friendly IDs deterministic where practical.
+
+```go
+package migrations
+
+import (
+    "context"
+
+    migrate "github.com/xakep666/mongo-migrate"
+    "go.mongodb.org/mongo-driver/bson"
+    "go.mongodb.org/mongo-driver/mongo"
+)
+
+func init() {
+    migrate.Register(func(db *mongo.Database) error { // Up
+        _, err := db.Collection("posts").InsertMany(context.Background(), []interface{}{
+            bson.M{
+                "_id":              "post-seed-1",
+                "_nano_id":         "postseed1",
+                "_url_friendly_id": "faq-what-is-ghatd",
+                "type":             "faq",
+                "title":            "What is ghatd?",
+                "text_format":      "markdown",
+                "text":             "A reusable backend framework.",
+                "published_at":     "2026-01-01T00:00:00Z",
+                "created_at":       "2026-01-01T00:00:00Z",
+            },
+        })
+        return err
+    }, func(db *mongo.Database) error { // Down
+        _, err := db.Collection("posts").DeleteMany(context.Background(), bson.M{
+            "_id": bson.M{"$in": []string{"post-seed-1"}},
+        })
+        return err
+    })
+}
+```
+
+### 3. Apply Migrations
+
+```bash
+go run main.go start-migrator up
+```
+
+## Relationship to Content Manager
+
+For most HTTP/API use-cases, call the `contentmanager` package and let it orchestrate post operations plus access control. Use `post` directly for:
+
+- internal tooling
+- migration seeding
+- lower-level service composition
+
+See: [Content Manager Getting Started](../content-manager/README.md)

--- a/external/accessmanager/errormap.go
+++ b/external/accessmanager/errormap.go
@@ -1,6 +1,8 @@
 package accessmanager
 
 import (
+	"net/http"
+
 	"github.com/ooaklee/reply"
 )
 
@@ -8,19 +10,24 @@ import (
 // TODO: remove nolint
 // nolint will be used later
 var AccessmanagerErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
-	ErrKeyBadRequest:                                          {Title: "Bad Request", StatusCode: 400, Code: "AM00-001"},
-	ErrKeyInvalidUserBody:                                     {Title: "Bad Request", Detail: "Check submitted user information", StatusCode: 400, Code: "AM00-002"},
-	ErrKeyInvalidVerificationToken:                            {Title: "Bad Request", Detail: "User token missing or malformatted", StatusCode: 400, Code: "AM00-003"},
-	ErrKeyInvalidRefreshToken:                                 {Title: "Bad Request", Detail: "Refresh token missing or malformatted", StatusCode: 400, Code: "AM00-004"},
-	ErrKeyInvalidUserEmail:                                    {Title: "Bad Request", Detail: "User email address missing or malformatted", StatusCode: 400, Code: "AM00-005"},
-	ErrKeyConflictingUserState:                                {Title: "Conflict", Detail: "User in conflicting state for requested action", StatusCode: 409, Code: "AM00-006"},
-	ErrKeyUserStatusUncaught:                                  {Title: "Conflict", Detail: "Conflict was detected. Please contact support", StatusCode: 409, Code: "AM00-007"},
-	ErrKeyUnauthorizedRefreshTokenCacheDeletionFailure:        {Title: "Unauthorized", StatusCode: 401, Code: "AM00-008"},
-	ErrKeyUnauthorizedAccessTokenCacheDeletionFailure:         {Title: "Unauthorized", StatusCode: 401, Code: "AM00-009"},
-	ErrKeyUnauthorizedAdminAccessAttempted:                    {Title: "Unauthorized", StatusCode: 401, Code: "AM00-010"},
-	ErrKeyUnauthorizedNonActiveStatus:                         {Title: "Unauthorized", StatusCode: 401, Code: "AM00-011"},
-	ErrKeyUnauthorizedTokenNotFoundInStore:                    {Title: "Unauthorized", StatusCode: 401, Code: "AM00-012"},
-	ErrKeyUnauthorizedUnableToAttainRequestorID:               {Title: "Unauthorized", StatusCode: 401, Code: "AM00-013"},
+	ErrKeyBadRequest:                                   {Title: "Bad Request", StatusCode: 400, Code: "AM00-001"},
+	ErrKeyInvalidUserBody:                              {Title: "Bad Request", Detail: "Check submitted user information", StatusCode: 400, Code: "AM00-002"},
+	ErrKeyInvalidVerificationToken:                     {Title: "Bad Request", Detail: "User token missing or malformatted", StatusCode: 400, Code: "AM00-003"},
+	ErrKeyInvalidRefreshToken:                          {Title: "Bad Request", Detail: "Refresh token missing or malformatted", StatusCode: 400, Code: "AM00-004"},
+	ErrKeyInvalidUserEmail:                             {Title: "Bad Request", Detail: "User email address missing or malformatted", StatusCode: 400, Code: "AM00-005"},
+	ErrKeyConflictingUserState:                         {Title: "Conflict", Detail: "User in conflicting state for requested action", StatusCode: 409, Code: "AM00-006"},
+	ErrKeyUserStatusUncaught:                           {Title: "Conflict", Detail: "Conflict was detected. Please contact support", StatusCode: 409, Code: "AM00-007"},
+	ErrKeyUnauthorizedRefreshTokenCacheDeletionFailure: {Title: "Unauthorized", StatusCode: 401, Code: "AM00-008"},
+	ErrKeyUnauthorizedAccessTokenCacheDeletionFailure:  {Title: "Unauthorized", StatusCode: 401, Code: "AM00-009"},
+	ErrKeyUnauthorizedAdminAccessAttempted:             {Title: "Unauthorized", StatusCode: 401, Code: "AM00-010"},
+	ErrKeyUnauthorizedNonActiveStatus:                  {Title: "Unauthorized", StatusCode: 401, Code: "AM00-011"},
+	ErrKeyUnauthorizedTokenNotFoundInStore:             {Title: "Unauthorized", StatusCode: 401, Code: "AM00-012"},
+	// ErrKeyUnauthorizedUnableToAttainRequestorID returns 202 (Accepted) instead of the
+	// default 401 to prevent Google's website inspector from treating unauthenticated
+	// requests as hard errors, which was blocking search engine indexing. Clients SHOULD
+	// treat only 200 as authenticated; any other status include other 2XX indicates the
+	// user is not authenticated.
+	ErrKeyUnauthorizedUnableToAttainRequestorID:               {Title: "Unauthorized", StatusCode: http.StatusAccepted, Code: "AM00-013"},
 	ErrKeyInvalidUserID:                                       {Title: "Bad Request", Detail: "User ID missing or malformatted", StatusCode: 400, Code: "AM00-014"},
 	ErrKeyInvalidAPITokenID:                                   {Title: "Bad Request", Detail: "API token ID missing or malformatted", StatusCode: 400, Code: "AM00-015"},
 	ErrKeyForbiddenUnableToAction:                             {Title: "Forbidden", StatusCode: 403, Code: "AM00-016"},

--- a/external/contentmanager/const.go
+++ b/external/contentmanager/const.go
@@ -1,0 +1,7 @@
+package contentmanager
+
+const (
+	// ErrKeyUnauthorisedCMUser is the error key return when a user id being used for an
+	// operation the user is NOT permitted to car out
+	ErrKeyUnauthorisedCMUser = "UnauthorisedCMUser"
+)

--- a/external/contentmanager/errormap.go
+++ b/external/contentmanager/errormap.go
@@ -1,0 +1,9 @@
+package contentmanager
+
+import "github.com/ooaklee/reply"
+
+// ContentManagerErrorMap holds Error keys, their corresponding human-friendly message, and response status code
+// nolint will be used later
+var ContentManagerErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
+	ErrKeyUnauthorisedCMUser: {Title: "Forbidden", Detail: "User is not authorised to carry out this action", StatusCode: 403, Code: "CM00-01"},
+}

--- a/external/contentmanager/fender.go
+++ b/external/contentmanager/fender.go
@@ -1,0 +1,418 @@
+package contentmanager
+
+import (
+	"errors"
+	"net/http"
+
+	accessmanagerhelpers "github.com/ooaklee/ghatd/external/accessmanager/helpers"
+	"github.com/ooaklee/ghatd/external/logger"
+	"github.com/ooaklee/ghatd/external/post"
+	"github.com/ooaklee/ghatd/external/toolbox"
+	tctcToolbox "github.com/ooaklee/ghatd/external/toolbox"
+	"github.com/ritwickdey/querydecoder"
+	"go.uber.org/zap"
+)
+
+// mapRequestToCreatePostRequest maps the http request to the create post request
+func mapRequestToCreatePostRequest(r *http.Request, validator contentManagerValidator) (*CreatePostRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = &CreatePostRequest{
+			CreatePostRequest: &post.CreatePostRequest{},
+		}
+	)
+
+	baseRequest := post.CreatePostRequest{}
+
+	err = toolbox.DecodeRequestBody(r, &baseRequest)
+	if err != nil {
+		return nil, errors.New(post.ErrKeyInvalidPostPayload)
+	}
+	baseRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	parsedRequest.CreatePostRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-create-post-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return parsedRequest, nil
+}
+
+// mapRequestToUpdatePostByIdRequest maps the http request to the update post by id request
+func mapRequestToUpdatePostByIdRequest(r *http.Request, validator contentManagerValidator) (*UpdatePostByIdRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = &UpdatePostByIdRequest{
+			UpdatePostRequest: &post.UpdatePostRequest{},
+		}
+	)
+
+	baseRequest := post.UpdatePostRequest{}
+
+	err = toolbox.DecodeRequestBody(r, &baseRequest)
+	if err != nil {
+		return nil, errors.New(post.ErrKeyInvalidPostPayload)
+	}
+	baseRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	// Extract postId from URI
+	baseRequest.PostId, err = tctcToolbox.GetVariableValueFromUri(r, "postId")
+	if err != nil {
+		log.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
+		return nil, errors.New(post.ErrKeyIdIsRequired)
+	}
+
+	parsedRequest.UpdatePostRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-update-post-by-id-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return parsedRequest, nil
+}
+
+// mapRequestToRestorePostByIdRequest maps the http request to the restore post by id request
+func mapRequestToRestorePostByIdRequest(r *http.Request, validator contentManagerValidator) (*RestorePostByIdRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = &RestorePostByIdRequest{
+			RestorePostByIdRequest: &post.RestorePostByIdRequest{},
+		}
+	)
+
+	baseRequest := post.RestorePostByIdRequest{}
+	baseRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	// Extract postId from URI
+	baseRequest.Id, err = tctcToolbox.GetVariableValueFromUri(r, "postId")
+	if err != nil {
+		log.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
+		return nil, errors.New(post.ErrKeyIdIsRequired)
+	}
+
+	parsedRequest.RestorePostByIdRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-restore-post-by-id-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return parsedRequest, nil
+}
+
+// mapRequestToDeletePostByIdRequest maps the http request to the delete post by id request
+func mapRequestToDeletePostByIdRequest(r *http.Request, validator contentManagerValidator) (*DeletePostByIdRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = &DeletePostByIdRequest{
+			DeletePostByIdRequest: &post.DeletePostByIdRequest{},
+		}
+	)
+
+	baseRequest := post.DeletePostByIdRequest{}
+	baseRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	// Decode query parameters
+	query := r.URL.Query()
+	err = querydecoder.New(query).Decode(&baseRequest)
+	if err != nil {
+		log.Warn("failed-to-decode-query-for-get-glossary-items-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyInvalidPostQueryParam)
+	}
+
+	// Extract postId from URI
+	baseRequest.Id, err = tctcToolbox.GetVariableValueFromUri(r, "postId")
+	if err != nil {
+		log.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
+		return nil, errors.New(post.ErrKeyIdIsRequired)
+	}
+
+	parsedRequest.DeletePostByIdRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-delete-post-by-id-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return parsedRequest, nil
+}
+
+// mapRequestToGetGlossaryItemsRequest maps the http request to the get glossary items request
+func mapRequestToGetGlossaryItemsRequest(r *http.Request, validator contentManagerValidator) (*GetGlossaryItemsRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = GetGlossaryItemsRequest{
+			GetGlossaryItemsRequest: &post.GetGlossaryItemsRequest{
+				GetPostsRequest: &post.GetPostsRequest{},
+			},
+		}
+	)
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	baseRequest := post.GetPostsRequest{}
+
+	query := r.URL.Query()
+	err = querydecoder.New(query).Decode(&baseRequest)
+	if err != nil {
+		log.Warn("failed-to-decode-query-for-get-glossary-items-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyInvalidPostQueryParam)
+	}
+
+	parsedRequest.GetGlossaryItemsRequest.GetPostsRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-get-glossary-items-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return &parsedRequest, nil
+}
+
+// mapRequestToGetFaqItemsRequest maps the http request to the get faq items request
+func mapRequestToGetFaqItemsRequest(r *http.Request, validator contentManagerValidator) (*GetFaqItemsRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = GetFaqItemsRequest{
+			GetFaqItemsRequest: &post.GetFaqItemsRequest{
+				GetPostsRequest: &post.GetPostsRequest{},
+			},
+		}
+	)
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	baseRequest := post.GetPostsRequest{}
+
+	query := r.URL.Query()
+	err = querydecoder.New(query).Decode(&baseRequest)
+	if err != nil {
+		log.Warn("failed-to-decode-query-for-get-faq-items-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyInvalidPostQueryParam)
+	}
+
+	parsedRequest.GetFaqItemsRequest.GetPostsRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-get-faq-items-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return &parsedRequest, nil
+}
+
+// mapRequestToGetArticlesRequest maps the http request to the get articles request
+func mapRequestToGetArticlesRequest(r *http.Request, validator contentManagerValidator) (*GetArticlesRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = GetArticlesRequest{
+			GetArticlesRequest: &post.GetArticlesRequest{
+				GetPostsRequest: &post.GetPostsRequest{},
+			},
+		}
+	)
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	baseRequest := post.GetPostsRequest{}
+
+	query := r.URL.Query()
+	err = querydecoder.New(query).Decode(&baseRequest)
+	if err != nil {
+		log.Warn("failed-to-decode-query-for-get-articles-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyInvalidPostQueryParam)
+	}
+
+	parsedRequest.GetArticlesRequest.GetPostsRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-get-articles-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return &parsedRequest, nil
+}
+
+// mapRequestToGetChangelogItemsRequest maps the http request to the get changelog items request
+func mapRequestToGetChangelogItemsRequest(r *http.Request, validator contentManagerValidator) (*GetChangelogItemsRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = GetChangelogItemsRequest{
+			GetChangelogItemsRequest: &post.GetChangelogItemsRequest{
+				GetPostsRequest: &post.GetPostsRequest{},
+			},
+		}
+	)
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	baseRequest := post.GetPostsRequest{}
+
+	query := r.URL.Query()
+	err = querydecoder.New(query).Decode(&baseRequest)
+	if err != nil {
+		log.Warn("failed-to-decode-query-for-get-changelog-items-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyInvalidPostQueryParam)
+	}
+
+	parsedRequest.GetChangelogItemsRequest.GetPostsRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-get-changelog-items-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return &parsedRequest, nil
+}
+
+// mapRequestToGetChangelogItemByUrlFriendlyIdRequest maps the http request to the get changelog item by url friendly id request
+func mapRequestToGetChangelogItemByUrlFriendlyIdRequest(r *http.Request, validator contentManagerValidator) (*GetChangelogItemByUrlFriendlyIdRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = GetChangelogItemByUrlFriendlyIdRequest{}
+	)
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	// Add urlFriendlyId from uri
+	parsedRequest.UrlFriendlyId, err = tctcToolbox.GetVariableValueFromUri(r, "urlFriendlyId")
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-get-changelog-item-by-url-friendly-id-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return &parsedRequest, nil
+
+}
+
+// mapRequestToGetArticleItemByUrlFriendlyIdRequest maps the http request to the get article item by url friendly id request
+func mapRequestToGetArticleItemByUrlFriendlyIdRequest(r *http.Request, validator contentManagerValidator) (*GetArticleItemByUrlFriendlyIdRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = GetArticleItemByUrlFriendlyIdRequest{}
+	)
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	// Add urlFriendlyId from uri
+	parsedRequest.UrlFriendlyId, err = tctcToolbox.GetVariableValueFromUri(r, "urlFriendlyId")
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-get-article-item-by-url-friendly-id-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return &parsedRequest, nil
+
+}
+
+// mapRequestToGetLatestPostsByTypeRequest maps the http request to the get latest posts by type request
+func mapRequestToGetLatestPostsByTypeRequest(r *http.Request, validator contentManagerValidator) (*GetLatestPostsByTypeRequest, error) {
+
+	var (
+		err error
+		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		parsedRequest = GetLatestPostsByTypeRequest{
+			GetLatestPostsByTypeRequest: &post.GetLatestPostsByTypeRequest{},
+		}
+	)
+
+	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
+
+	baseRequest := post.GetLatestPostsByTypeRequest{}
+
+	query := r.URL.Query()
+	err = querydecoder.New(query).Decode(&baseRequest)
+	if err != nil {
+		log.Warn("failed-to-decode-query-for-get-latest-posts-by-type-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyInvalidPostQueryParam)
+	}
+
+	parsedRequest.GetLatestPostsByTypeRequest = &baseRequest
+
+	err = validateParsedRequest(parsedRequest, validator)
+	if err != nil {
+		log.Warn("validation-failed-for-get-latest-posts-by-type-request", zap.Error(err))
+		return nil, errors.New(post.ErrKeyPostBadRequest)
+	}
+
+	return &parsedRequest, nil
+}
+
+// validateParsedRequest validates the request
+func validateParsedRequest(request interface{}, validator contentManagerValidator) error {
+	return validator.Validate(request)
+}

--- a/external/contentmanager/handler.go
+++ b/external/contentmanager/handler.go
@@ -1,0 +1,308 @@
+package contentmanager
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ooaklee/ghatd/external/post"
+	"github.com/ooaklee/reply"
+)
+
+// contentManagerService manages business logic for
+// handling content based requests
+type contentManagerService interface {
+	CreatePost(ctx context.Context, req *CreatePostRequest) (*CreatePostResponse, error)
+	UpdatePostById(ctx context.Context, req *UpdatePostByIdRequest) (*UpdatePostByIdResponse, error)
+	DeletePostById(ctx context.Context, req *DeletePostByIdRequest) (*DeletePostByIdResponse, error)
+	RestorePostById(ctx context.Context, req *RestorePostByIdRequest) (*RestorePostByIdResponse, error)
+
+	GetChangelogItems(ctx context.Context, req *GetChangelogItemsRequest) (*GetChangelogItemsResponse, error)
+	GetChangelogItemByUrlFriendlyId(ctx context.Context, req *GetChangelogItemByUrlFriendlyIdRequest) (*post.Post, error)
+
+	GetGlossaryItems(ctx context.Context, req *GetGlossaryItemsRequest) (*GetGlossaryItemsResponse, error)
+	GetFaqItems(ctx context.Context, req *GetFaqItemsRequest) (*GetFaqItemsResponse, error)
+	GetArticles(ctx context.Context, req *GetArticlesRequest) (*GetArticlesResponse, error)
+	GetArticleItemByUrlFriendlyId(ctx context.Context, req *GetArticleItemByUrlFriendlyIdRequest) (*post.Post, error)
+
+	GetLatestPostsByType(ctx context.Context, req *GetLatestPostsByTypeRequest) (*GetLatestPostsByTypeResponse, error)
+}
+
+// contentManagerValidator expected methods of a valid
+// validator
+type contentManagerValidator interface {
+	Validate(s interface{}) error
+}
+
+// Handler manages content manager requests
+type Handler struct {
+	// service represents the content manager service
+	service contentManagerService
+
+	// validator represents the content manager validator
+	validator contentManagerValidator
+
+	// errorMaps holds the error maps for the handler
+	errorMaps []reply.ErrorManifest
+}
+
+// NewHandler returns a new instance of the content manager handler
+func NewHandler(service contentManagerService, validator contentManagerValidator, errorMaps ...reply.ErrorManifest) *Handler {
+	return &Handler{
+		service:   service,
+		validator: validator,
+		errorMaps: errorMaps,
+	}
+}
+
+// CreatePost handles the request for creating a post
+func (h *Handler) CreatePost(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToCreatePostRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	newlyCreated, err := h.service.CreatePost(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusCreated, newlyCreated.Post)
+}
+
+// UpdatePostById handles the request for updating a post by its ID
+func (h *Handler) UpdatePostById(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToUpdatePostByIdRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	updatedPost, err := h.service.UpdatePostById(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, updatedPost.Post)
+}
+
+// DeletePostById handles the request for deleting a post by its ID
+func (h *Handler) DeletePostById(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToDeletePostByIdRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	_, err = h.service.DeletePostById(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusNoContent, nil)
+}
+
+// RestorePostById handles the request for restoring a post by its ID
+func (h *Handler) RestorePostById(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToRestorePostByIdRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	restoredPost, err := h.service.RestorePostById(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, restoredPost.Post)
+}
+
+// GetChangelogItems handles the request for getting changelog posts
+func (h *Handler) GetChangelogItems(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToGetChangelogItemsRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	posts, err := h.service.GetChangelogItems(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	if request.Meta {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Posts, reply.WithMeta(posts.GetMetaData()))
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Posts)
+}
+
+// GetChangelogItemByUrlFriendlyId handles the request for getting changelog item by its
+// url friendly id
+func (h *Handler) GetChangelogItemByUrlFriendlyId(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToGetChangelogItemByUrlFriendlyIdRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	post, err := h.service.GetChangelogItemByUrlFriendlyId(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, post)
+}
+
+// GetGlossaryItems handles the request for getting glossary posts
+func (h *Handler) GetGlossaryItems(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToGetGlossaryItemsRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	posts, err := h.service.GetGlossaryItems(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	if request.Meta {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Posts, reply.WithMeta(posts.GetMetaData()))
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Posts)
+}
+
+// GetFaqItems handles the request for getting faq posts
+func (h *Handler) GetFaqItems(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToGetFaqItemsRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	posts, err := h.service.GetFaqItems(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	if request.Meta {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Posts, reply.WithMeta(posts.GetMetaData()))
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Posts)
+}
+
+// GetArticles handles the request for getting articles posts
+func (h *Handler) GetArticles(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToGetArticlesRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	posts, err := h.service.GetArticles(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	if request.Meta {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Posts, reply.WithMeta(posts.GetMetaData()))
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Posts)
+}
+
+// GetArticleItemByUrlFriendlyId handles the request for getting article item by its
+// url friendly id
+func (h *Handler) GetArticleItemByUrlFriendlyId(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToGetArticleItemByUrlFriendlyIdRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	post, err := h.service.GetArticleItemByUrlFriendlyId(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, post)
+}
+
+// GetLatestPostsByType handles the request for getting the latest posts by type
+func (h *Handler) GetLatestPostsByType(w http.ResponseWriter, r *http.Request) {
+	request, err := mapRequestToGetLatestPostsByTypeRequest(r, h.validator)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	posts, err := h.service.GetLatestPostsByType(r.Context(), request)
+	if err != nil {
+		//nolint will set up default fallback later
+		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	//nolint will set up default fallback later
+	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, posts.Overviews)
+}
+
+// getBaseResponseHandler returns response handler configured with auth error map
+func (h *Handler) getBaseResponseHandler() *reply.Replier {
+	consolidatedErrorMaps := append(h.errorMaps, ContentManagerErrorMap)
+
+	return reply.NewReplier(consolidatedErrorMaps)
+}

--- a/external/contentmanager/model.go
+++ b/external/contentmanager/model.go
@@ -1,0 +1,1 @@
+package contentmanager

--- a/external/contentmanager/request.go
+++ b/external/contentmanager/request.go
@@ -1,0 +1,92 @@
+package contentmanager
+
+import "github.com/ooaklee/ghatd/external/post"
+
+// CreatePostRequest represents the request payload for creating a post
+// with given attributes
+type CreatePostRequest struct {
+	*post.CreatePostRequest
+}
+
+// UpdatePostByIdRequest represents the request payload for updating a post
+// by its ID
+type UpdatePostByIdRequest struct {
+	*post.UpdatePostRequest
+}
+
+// DeletePostByIdRequest represents the request payload for deleting a post
+// by its ID
+type DeletePostByIdRequest struct {
+	*post.DeletePostByIdRequest
+}
+
+// RestorePostByIdRequest represents the request payload for restoring a post
+// by its ID
+type RestorePostByIdRequest struct {
+	*post.RestorePostByIdRequest
+}
+
+// GetChangelogItemsRequest represents the request payload for getting
+// posts of type changelog
+type GetChangelogItemsRequest struct {
+	// UserId is the user making the request
+	UserId string
+
+	*post.GetChangelogItemsRequest
+}
+
+// GetChangelogItemByUrlFriendlyIdRequest reprethe request payload for getting
+// changelog item by its url friendly id
+type GetChangelogItemByUrlFriendlyIdRequest struct {
+	// UserId is the user making the request
+	UserId string
+
+	// UrlFriendlyId is the url friendly id of the changelog item
+	UrlFriendlyId string
+}
+
+// GetGlossaryItemsRequest represents the request payload for getting
+// posts of type glossary
+type GetGlossaryItemsRequest struct {
+	// UserId is the user making the request
+	UserId string
+
+	*post.GetGlossaryItemsRequest
+}
+
+// GetFaqItemsRequest represents the request payload for getting
+// posts of type faq
+type GetFaqItemsRequest struct {
+	// UserId is the user making the request
+	UserId string
+
+	*post.GetFaqItemsRequest
+}
+
+// GetArticlesRequest represents the request payload for getting
+// posts of type article
+type GetArticlesRequest struct {
+	// UserId is the user making the request
+	UserId string
+
+	*post.GetArticlesRequest
+}
+
+// GetArticleItemByUrlFriendlyIdRequest represents the request payload for getting
+// article item by its url friendly id
+type GetArticleItemByUrlFriendlyIdRequest struct {
+	// UserId is the user making the request
+	UserId string
+
+	// UrlFriendlyId is the url friendly id of the article item
+	UrlFriendlyId string
+}
+
+// GetLatestPostsByTypeRequest represents the request payload for getting
+// the latest posts by type
+type GetLatestPostsByTypeRequest struct {
+	// UserId is the user making the request
+	UserId string
+
+	*post.GetLatestPostsByTypeRequest
+}

--- a/external/contentmanager/response.go
+++ b/external/contentmanager/response.go
@@ -1,0 +1,53 @@
+package contentmanager
+
+import "github.com/ooaklee/ghatd/external/post"
+
+// CreatePostResponse represents the response payload for the CreatePost method
+type CreatePostResponse struct {
+	*post.CreatePostResponse
+}
+
+// UpdatePostByIdResponse represents the response payload for the UpdatePostById method
+type UpdatePostByIdResponse struct {
+	*post.UpdatePostResponse
+}
+
+// DeletePostByIdResponse represents the response payload for the DeletePostById method
+type DeletePostByIdResponse struct {
+	*post.DeletePostByIdResponse
+}
+
+// RestorePostByIdResponse represents the response payload for the RestorePostById method
+type RestorePostByIdResponse struct {
+	*post.RestorePostByIdResponse
+}
+
+// GetChangelogItemsResponse represents the response payload for changelog items
+// that match respecive queries
+type GetChangelogItemsResponse struct {
+	*post.GetChangelogItemsResponse
+}
+
+// GetGlossaryItemsResponse represents the response payload for glossary items
+// that match respecive queries
+type GetGlossaryItemsResponse struct {
+	*post.GetGlossaryItemsResponse
+}
+
+// GetFaqItemsResponse represents the response payload for faq items
+// that match respecive queries
+type GetFaqItemsResponse struct {
+	*post.GetFaqItemsResponse
+}
+
+// GetArticlesResponse represents the response payload for articles
+// that match respecive queries
+type GetArticlesResponse struct {
+	*post.GetArticlesResponse
+}
+
+// GetLatestPostsByTypeResponse represents the response payload for getting
+// the latest posts by type
+type GetLatestPostsByTypeResponse struct {
+	*post.GetLatestPostsByTypeResponse
+}

--- a/external/contentmanager/routes.go
+++ b/external/contentmanager/routes.go
@@ -1,0 +1,71 @@
+package contentmanager
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/ooaklee/ghatd/external/router"
+)
+
+// contentManagerHandler holds methods for contentManager handler
+type contentManagerHandler interface {
+	// GetPosts(w http.ResponseWriter, r *http.Request)
+	CreatePost(w http.ResponseWriter, r *http.Request)
+	UpdatePostById(w http.ResponseWriter, r *http.Request)
+	DeletePostById(w http.ResponseWriter, r *http.Request)
+	RestorePostById(w http.ResponseWriter, r *http.Request)
+
+	GetChangelogItems(w http.ResponseWriter, r *http.Request)
+	GetChangelogItemByUrlFriendlyId(w http.ResponseWriter, r *http.Request)
+
+	GetGlossaryItems(w http.ResponseWriter, r *http.Request)
+	GetFaqItems(w http.ResponseWriter, r *http.Request)
+	GetArticles(w http.ResponseWriter, r *http.Request)
+	GetArticleItemByUrlFriendlyId(w http.ResponseWriter, r *http.Request)
+
+	GetLatestPostsByType(w http.ResponseWriter, r *http.Request)
+}
+
+// AttachRoutesRequest holds everything needed to attach contentManager
+// routes to router
+type AttachRoutesRequest struct {
+	// Router main router being served by Api
+	Router *router.Router
+
+	// Handler valid contentManager handler
+	Handler contentManagerHandler
+
+	// MiddlewareAdminApiTokenOrJwtRequired middleware used to lock endpoints down to admin only
+	MiddlewareAdminApiTokenOrJwtRequired mux.MiddlewareFunc
+
+	// RateLimitOrActiveMiddleware middleware used to open endpoints up (with rate limite) or active users only
+	RateLimitOrActiveMiddleware mux.MiddlewareFunc
+
+	// MiddlewareValidApiTokenOrJWTMiddleware middleware used to lock endpoints down to valid users only
+	MiddlewareValidApiTokenOrJWTMiddleware mux.MiddlewareFunc
+}
+
+// AttachRoutes handles attaching contentManager routes to router
+func AttachRoutes(request *AttachRoutesRequest) {
+	httpRouter := request.Router.GetRouter()
+
+	contentManagerAdminOnlyRoutes := httpRouter.PathPrefix("/api/v1/cms").Subrouter()
+	contentManagerAdminOnlyRoutes.HandleFunc("/posts", request.Handler.CreatePost).Methods(http.MethodPost, http.MethodOptions)
+	contentManagerAdminOnlyRoutes.HandleFunc("/posts/{postId}", request.Handler.UpdatePostById).Methods(http.MethodPatch, http.MethodOptions)
+	contentManagerAdminOnlyRoutes.HandleFunc("/posts/{postId}", request.Handler.DeletePostById).Methods(http.MethodDelete, http.MethodOptions)
+	contentManagerAdminOnlyRoutes.HandleFunc("/posts/{postId}/restore", request.Handler.RestorePostById).Methods(http.MethodPatch, http.MethodOptions)
+	contentManagerAdminOnlyRoutes.Use(request.MiddlewareAdminApiTokenOrJwtRequired)
+
+	contentManagerValidUserOnlyRoutes := httpRouter.PathPrefix("/api/v1/cms").Subrouter()
+	contentManagerValidUserOnlyRoutes.Use(request.MiddlewareValidApiTokenOrJWTMiddleware)
+
+	contentManagerOpenRoutes := httpRouter.PathPrefix("/api/v1/cms").Subrouter()
+	contentManagerOpenRoutes.HandleFunc("/changelog", request.Handler.GetChangelogItems).Methods(http.MethodGet, http.MethodOptions)
+	contentManagerOpenRoutes.HandleFunc("/changelog/{urlFriendlyId}", request.Handler.GetChangelogItemByUrlFriendlyId).Methods(http.MethodGet, http.MethodOptions)
+	contentManagerOpenRoutes.HandleFunc("/glossary", request.Handler.GetGlossaryItems).Methods(http.MethodGet, http.MethodOptions)
+	contentManagerOpenRoutes.HandleFunc("/faq", request.Handler.GetFaqItems).Methods(http.MethodGet, http.MethodOptions)
+	contentManagerOpenRoutes.HandleFunc("/articles", request.Handler.GetArticles).Methods(http.MethodGet, http.MethodOptions)
+	contentManagerOpenRoutes.HandleFunc("/articles/{urlFriendlyId}", request.Handler.GetArticleItemByUrlFriendlyId).Methods(http.MethodGet, http.MethodOptions)
+	contentManagerOpenRoutes.HandleFunc("/latest", request.Handler.GetLatestPostsByType).Methods(http.MethodGet, http.MethodOptions)
+	contentManagerOpenRoutes.Use(request.RateLimitOrActiveMiddleware)
+}

--- a/external/contentmanager/service.go
+++ b/external/contentmanager/service.go
@@ -1,0 +1,548 @@
+package contentmanager
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"github.com/ooaklee/ghatd/external/post"
+	userV2 "github.com/ooaklee/ghatd/external/user/v2"
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultPostAuthor is the entity to assign to post if user cannot
+	// be found
+	DefaultPostAuthor = "Team"
+)
+
+// ResponseHolder represents a valid post type response
+type ResponseHolder interface {
+	GetEmbeddedPostsResponse() *post.GetPostsResponse
+}
+
+// userService represents the user service
+type userService interface {
+	GetUserByID(ctx context.Context, req *userV2.GetUserByIDRequest) (*userV2.GetUserByIDResponse, error)
+}
+
+// postService represents the post service
+type postService interface {
+	GetArticles(ctx context.Context, req *post.GetArticlesRequest) (*post.GetArticlesResponse, error)
+	GetChangelogItems(ctx context.Context, req *post.GetChangelogItemsRequest) (*post.GetChangelogItemsResponse, error)
+	GetFaqItems(ctx context.Context, req *post.GetFaqItemsRequest) (*post.GetFaqItemsResponse, error)
+	GetGlossaryItems(ctx context.Context, req *post.GetGlossaryItemsRequest) (*post.GetGlossaryItemsResponse, error)
+
+	CreatePost(ctx context.Context, req *post.CreatePostRequest) (*post.CreatePostResponse, error)
+	UpdatePost(ctx context.Context, req *post.UpdatePostRequest) (*post.UpdatePostResponse, error)
+	DeletePostById(ctx context.Context, req *post.DeletePostByIdRequest) (*post.DeletePostByIdResponse, error)
+	RestorePostById(ctx context.Context, req *post.RestorePostByIdRequest) (*post.RestorePostByIdResponse, error)
+	GetPosts(ctx context.Context, req *post.GetPostsRequest) (*post.GetPostsResponse, error)
+
+	GetPostByUrlFriendlyId(ctx context.Context, urlFriendlyId string) (*post.Post, error)
+	GetLatestPostsByType(ctx context.Context, req *post.GetLatestPostsByTypeRequest) (*post.GetLatestPostsByTypeResponse, error)
+}
+
+// Service represents the vehicle tax manager service
+type Service struct {
+
+	// postService represents the post service
+	postService postService
+
+	// userService represents the user service
+	userService userService
+}
+
+// NewService returns a new instance of the vehicle tax manager service
+func NewService(postService postService, userService userService) *Service {
+	return &Service{
+		postService: postService,
+		userService: userService,
+	}
+}
+
+// CreatePost handles logic associate with creating a new post
+func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*CreatePostResponse, error) {
+
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Info("handling-create-post-request", zap.Any("request", req))
+
+	requestingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+		ID: req.UserId,
+	})
+	if err != nil {
+		log.Error("failed-to-get-user-associated-with-post-creation-request", zap.String("user-id", req.UserId), zap.Error(err))
+		return nil, err
+	}
+
+	if !requestingUser.User.IsAdmin() {
+		log.Warn("non-admin-user-attempting-to-create-post", zap.String("user-id", req.UserId), zap.Any("request", req))
+		return nil, errors.New(ErrKeyUnauthorisedCMUser)
+	}
+
+	newPost, err := s.postService.CreatePost(ctx, req.CreatePostRequest)
+	if err != nil {
+		log.Error("failed-to-create-post", zap.Error(err))
+		return nil, err
+	}
+
+	return &CreatePostResponse{
+		CreatePostResponse: newPost,
+	}, nil
+}
+
+// UpdatePostById handles logic associated with updating an existing post by its ID
+func (s *Service) UpdatePostById(ctx context.Context, req *UpdatePostByIdRequest) (*UpdatePostByIdResponse, error) {
+
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Info("handling-update-post-by-id-request", zap.Any("request", req))
+
+	requestingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+		ID: req.UserId,
+	})
+	if err != nil {
+		log.Error("failed-to-get-user-associated-with-post-update-request", zap.String("user-id", req.UserId), zap.Error(err))
+		return nil, err
+	}
+
+	if !requestingUser.User.IsAdmin() {
+		log.Warn("non-admin-user-attempting-to-update-post", zap.String("user-id", req.UserId), zap.Any("request", req))
+		return nil, errors.New(ErrKeyUnauthorisedCMUser)
+	}
+
+	updatedPost, err := s.postService.UpdatePost(ctx, req.UpdatePostRequest)
+	if err != nil {
+		log.Error("failed-to-update-post", zap.Error(err))
+		return nil, err
+	}
+
+	return &UpdatePostByIdResponse{
+		UpdatePostResponse: updatedPost,
+	}, nil
+}
+
+// DeletePostById handles logic associated with deleting an existing post by its ID
+func (s *Service) DeletePostById(ctx context.Context, req *DeletePostByIdRequest) (*DeletePostByIdResponse, error) {
+
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Info("handling-delete-post-by-id-request", zap.Any("request", req))
+
+	requestingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+		ID: req.UserId,
+	})
+	if err != nil {
+		log.Error("failed-to-get-user-associated-with-post-delete-request", zap.String("user-id", req.UserId), zap.Error(err))
+		return nil, err
+	}
+
+	if !requestingUser.User.IsAdmin() {
+		log.Warn("non-admin-user-attempting-to-delete-post", zap.String("user-id", req.UserId), zap.Any("request", req))
+		return nil, errors.New(ErrKeyUnauthorisedCMUser)
+	}
+
+	deletedPostResponse, err := s.postService.DeletePostById(ctx, req.DeletePostByIdRequest)
+	if err != nil {
+		log.Error("failed-to-delete-post", zap.Error(err))
+		return nil, err
+	}
+
+	return &DeletePostByIdResponse{
+		DeletePostByIdResponse: deletedPostResponse,
+	}, nil
+}
+
+// RestorePostById handles logic associated with restoring a soft-deleted post by ID
+func (s *Service) RestorePostById(ctx context.Context, req *RestorePostByIdRequest) (*RestorePostByIdResponse, error) {
+
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Info("handling-restore-post-by-id-request", zap.Any("request", req))
+
+	requestingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+		ID: req.UserId,
+	})
+	if err != nil {
+		log.Error("failed-to-get-user-associated-with-post-restore-request", zap.String("user-id", req.UserId), zap.Error(err))
+		return nil, err
+	}
+
+	if !requestingUser.User.IsAdmin() {
+		log.Warn("non-admin-user-attempting-to-restore-post", zap.String("user-id", req.UserId), zap.Any("request", req))
+		return nil, errors.New(ErrKeyUnauthorisedCMUser)
+	}
+
+	restoredPostResponse, err := s.postService.RestorePostById(ctx, req.RestorePostByIdRequest)
+	if err != nil {
+		log.Error("failed-to-restore-post", zap.Error(err))
+		return nil, err
+	}
+
+	return &RestorePostByIdResponse{
+		RestorePostByIdResponse: restoredPostResponse,
+	}, nil
+}
+
+// GetLatestPostsByType handles logic associated with getting the latest posts by type
+func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsByTypeRequest) (*GetLatestPostsByTypeResponse, error) {
+
+	var (
+		log            = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		requestingUser *userV2.UniversalUser
+	)
+
+	log.Info("handling-get-latest-posts-by-type-request")
+
+	if req.UserId != "" {
+		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+			ID: req.UserId,
+		})
+		if err != nil {
+			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			return nil, err
+		}
+
+		requestingUser = getRequestingUserResp.User
+	}
+
+	matchingPostOverviewsResp, err := s.postService.GetLatestPostsByType(ctx, req.GetLatestPostsByTypeRequest)
+	if err != nil {
+		log.Error("failed-to-get-latest-posts-by-type", zap.Error(err))
+		return nil, err
+	}
+
+	// Non-admin users can only see published, non-deleted content
+	// Admin users can see all content
+	// The post service already filters for published and non-deleted posts by default
+	// but we explicitly ensure it here for clarity
+	matchingPostOverviewsResp.Overviews = slices.DeleteFunc(matchingPostOverviewsResp.Overviews, func(overview post.PostOverview) bool {
+		return (requestingUser == nil || !requestingUser.IsAdmin()) && overview.PublishedAt == ""
+	})
+
+	return &GetLatestPostsByTypeResponse{
+		GetLatestPostsByTypeResponse: matchingPostOverviewsResp,
+	}, nil
+}
+
+// GetChangelogItemByUrlFriendlyId handles logic associated with getting a changelog item
+// by its url friendly id
+func (s *Service) GetChangelogItemByUrlFriendlyId(ctx context.Context, req *GetChangelogItemByUrlFriendlyIdRequest) (*post.Post, error) {
+
+	var (
+		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		requestingUser                   *userV2.UniversalUser
+		userIdToUserFirstNameLastInitial = make(map[string]string)
+	)
+
+	log.Info("handling-get-changelog-item-request")
+
+	if !strings.HasPrefix(req.UrlFriendlyId, "changelog-") {
+		// make sure only changelogs are returned
+		return nil, errors.New(ErrKeyUnauthorisedCMUser)
+	}
+
+	if req.UserId != "" {
+		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+			ID: req.UserId,
+		})
+		if err != nil {
+			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			return nil, err
+		}
+
+		userFirstNameLastInital := getRequestingUserResp.User.PersonalInfo.FirstName + " " + string(getRequestingUserResp.User.PersonalInfo.LastName[0]) + "."
+		userIdToUserFirstNameLastInitial[getRequestingUserResp.User.ID] = userFirstNameLastInital
+
+		requestingUser = getRequestingUserResp.User
+	}
+
+	matchingPost, err := s.postService.GetPostByUrlFriendlyId(ctx, req.UrlFriendlyId)
+	if err != nil {
+		log.Error("failed-to-get-changelog-item", zap.Error(err))
+		return nil, err
+	}
+
+	if (requestingUser == nil || !requestingUser.IsAdmin()) && matchingPost.PublishedAt == "" {
+		// make sure unauthed/ non-admon users can only see published content
+		return nil, errors.New(ErrKeyUnauthorisedCMUser)
+	}
+
+	postsResponse := GetChangelogItemsResponse{
+		GetChangelogItemsResponse: &post.GetChangelogItemsResponse{
+			GetPostsResponse: &post.GetPostsResponse{
+				Posts: []post.Post{*matchingPost},
+			},
+		},
+	}
+
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, postsResponse, userIdToUserFirstNameLastInitial, log)
+
+	return &postsResponse.Posts[0], nil
+}
+
+// GetArticleItemByUrlFriendlyId handles logic associated with getting an article item
+// by its url friendly id
+func (s *Service) GetArticleItemByUrlFriendlyId(ctx context.Context, req *GetArticleItemByUrlFriendlyIdRequest) (*post.Post, error) {
+
+	var (
+		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		requestingUser                   *userV2.UniversalUser
+		userIdToUserFirstNameLastInitial = make(map[string]string)
+	)
+
+	log.Info("handling-get-article-item-request")
+
+	if !strings.HasPrefix(req.UrlFriendlyId, "article-") {
+		// make sure only articles are returned
+		return nil, errors.New(ErrKeyUnauthorisedCMUser)
+	}
+
+	if req.UserId != "" {
+		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+			ID: req.UserId,
+		})
+		if err != nil {
+			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			return nil, err
+		}
+
+		userFirstNameLastInital := getRequestingUserResp.User.PersonalInfo.FirstName + " " + string(getRequestingUserResp.User.PersonalInfo.LastName[0]) + "."
+		userIdToUserFirstNameLastInitial[getRequestingUserResp.User.ID] = userFirstNameLastInital
+
+		requestingUser = getRequestingUserResp.User
+	}
+
+	matchingPost, err := s.postService.GetPostByUrlFriendlyId(ctx, req.UrlFriendlyId)
+	if err != nil {
+		log.Error("failed-to-get-article-item", zap.Error(err))
+		return nil, err
+	}
+
+	if (requestingUser == nil || !requestingUser.IsAdmin()) && matchingPost.PublishedAt == "" {
+		// make sure unauthed/ non-admon users can only see published content
+		return nil, errors.New(ErrKeyUnauthorisedCMUser)
+	}
+
+	postsResponse := GetArticlesResponse{
+		GetArticlesResponse: &post.GetArticlesResponse{
+			GetPostsResponse: &post.GetPostsResponse{
+				Posts: []post.Post{*matchingPost},
+			},
+		},
+	}
+
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, postsResponse, userIdToUserFirstNameLastInitial, log)
+
+	return &postsResponse.Posts[0], nil
+}
+
+// GetChangelogItems handles logic associated with getting changelog posts
+func (s *Service) GetChangelogItems(ctx context.Context, req *GetChangelogItemsRequest) (*GetChangelogItemsResponse, error) {
+
+	var (
+		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		requestingUser                   *userV2.UniversalUser
+		userIdToUserFirstNameLastInitial = make(map[string]string)
+	)
+
+	log.Info("handling-get-changelog-items-request")
+
+	if req.UserId != "" {
+		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+			ID: req.UserId,
+		})
+		if err != nil {
+			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			return nil, err
+		}
+
+		userFirstNameLastInital := getRequestingUserResp.User.PersonalInfo.FirstName + " " + string(getRequestingUserResp.User.PersonalInfo.LastName[0]) + "."
+		userIdToUserFirstNameLastInitial[getRequestingUserResp.User.ID] = userFirstNameLastInital
+
+		requestingUser = getRequestingUserResp.User
+	}
+
+	if requestingUser == nil || !requestingUser.IsAdmin() {
+		// make sure unauthed/ non-admon users can only see published content
+		req.GetChangelogItemsRequest.GetPostsRequest.IsPublished = true
+		req.GetChangelogItemsRequest.GetPostsRequest.IsNotDeleted = true
+	}
+
+	matchingPosts, err := s.postService.GetChangelogItems(ctx, req.GetChangelogItemsRequest)
+	if err != nil {
+		log.Error("failed-to-get-changelog-items", zap.Error(err))
+		return nil, err
+	}
+
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, log)
+
+	return &GetChangelogItemsResponse{
+		GetChangelogItemsResponse: matchingPosts,
+	}, nil
+}
+
+// GetGlossaryItems handles logic associated with getting glossary posts
+func (s *Service) GetGlossaryItems(ctx context.Context, req *GetGlossaryItemsRequest) (*GetGlossaryItemsResponse, error) {
+
+	var (
+		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		requestingUser                   *userV2.UniversalUser
+		userIdToUserFirstNameLastInitial = make(map[string]string)
+	)
+
+	log.Info("handling-get-glossary-items-request")
+
+	if req.UserId != "" {
+		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+			ID: req.UserId,
+		})
+		if err != nil {
+			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			return nil, err
+		}
+
+		userFirstNameLastInital := getRequestingUserResp.User.PersonalInfo.FirstName + " " + string(getRequestingUserResp.User.PersonalInfo.LastName[0]) + "."
+		userIdToUserFirstNameLastInitial[getRequestingUserResp.User.ID] = userFirstNameLastInital
+
+		requestingUser = getRequestingUserResp.User
+	}
+
+	if requestingUser == nil || !requestingUser.IsAdmin() {
+		// make sure unauthed/ non-admon users can only see published content
+		req.GetGlossaryItemsRequest.GetPostsRequest.IsPublished = true
+		req.GetGlossaryItemsRequest.GetPostsRequest.IsNotDeleted = true
+	}
+
+	matchingPosts, err := s.postService.GetGlossaryItems(ctx, req.GetGlossaryItemsRequest)
+	if err != nil {
+		log.Error("failed-to-get-glossary-items", zap.Error(err))
+		return nil, err
+	}
+
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, log)
+
+	return &GetGlossaryItemsResponse{
+		GetGlossaryItemsResponse: matchingPosts,
+	}, nil
+}
+
+// GetFaqItems handles logic associated with getting faq post
+func (s *Service) GetFaqItems(ctx context.Context, req *GetFaqItemsRequest) (*GetFaqItemsResponse, error) {
+
+	var (
+		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		requestingUser                   *userV2.UniversalUser
+		userIdToUserFirstNameLastInitial = make(map[string]string)
+	)
+
+	log.Info("handling-get-faq-items-request")
+
+	if req.UserId != "" {
+		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+			ID: req.UserId,
+		})
+		if err != nil {
+			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			return nil, err
+		}
+
+		userFirstNameLastInital := getRequestingUserResp.User.PersonalInfo.FirstName + " " + string(getRequestingUserResp.User.PersonalInfo.LastName[0]) + "."
+		userIdToUserFirstNameLastInitial[getRequestingUserResp.User.ID] = userFirstNameLastInital
+
+		requestingUser = getRequestingUserResp.User
+	}
+
+	if requestingUser == nil || !requestingUser.IsAdmin() {
+		// make sure unauthed/ non-admon users can only see published content
+		req.GetFaqItemsRequest.GetPostsRequest.IsPublished = true
+		req.GetFaqItemsRequest.GetPostsRequest.IsNotDeleted = true
+	}
+
+	matchingPosts, err := s.postService.GetFaqItems(ctx, req.GetFaqItemsRequest)
+	if err != nil {
+		log.Error("failed-to-get-faq-items", zap.Error(err))
+		return nil, err
+	}
+
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, log)
+
+	return &GetFaqItemsResponse{
+		GetFaqItemsResponse: matchingPosts,
+	}, nil
+}
+
+// GetArticles handles logic associated with getting article posts
+func (s *Service) GetArticles(ctx context.Context, req *GetArticlesRequest) (*GetArticlesResponse, error) {
+
+	var (
+		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		requestingUser                   *userV2.UniversalUser
+		userIdToUserFirstNameLastInitial = make(map[string]string)
+	)
+
+	log.Info("handling-get-articles-request")
+
+	if req.UserId != "" {
+		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+			ID: req.UserId,
+		})
+		if err != nil {
+			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			return nil, err
+		}
+
+		userFirstNameLastInital := getRequestingUserResp.User.PersonalInfo.FirstName + " " + string(getRequestingUserResp.User.PersonalInfo.LastName[0]) + "."
+		userIdToUserFirstNameLastInitial[getRequestingUserResp.User.ID] = userFirstNameLastInital
+
+		requestingUser = getRequestingUserResp.User
+	}
+
+	if requestingUser == nil || !requestingUser.IsAdmin() {
+		// make sure unauthed/ non-admon users can only see published content
+		req.GetArticlesRequest.GetPostsRequest.IsPublished = true
+		req.GetArticlesRequest.GetPostsRequest.IsNotDeleted = true
+	}
+
+	matchingPosts, err := s.postService.GetArticles(ctx, req.GetArticlesRequest)
+	if err != nil {
+		log.Error("failed-to-get-articles", zap.Error(err))
+		return nil, err
+	}
+
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, log)
+
+	return &GetArticlesResponse{
+		GetArticlesResponse: matchingPosts,
+	}, nil
+}
+
+// handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet handles instances publish_as is not set but a publish_at is given,
+// we must try to set and default to user's first name and last name initial
+func (s *Service) handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx context.Context, matchingPostsHolder ResponseHolder, userIdToUserFirstNameLastInitial map[string]string, log *zap.Logger) {
+	matchingPosts := matchingPostsHolder.GetEmbeddedPostsResponse()
+	for i, post := range matchingPosts.Posts {
+		if post.PublishedAs == "" && post.PublishedAt != "" {
+			matchingPosts.Posts[i].PublishedAs = DefaultPostAuthor
+
+			if userIdToUserFirstNameLastInitial[post.PublishedByUserId] == "" {
+				postPublishingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
+					ID: post.PublishedByUserId,
+				})
+				if err != nil {
+					log.Error("failed-to-get-user-associated-with-post-publication", zap.String("user-id", post.PublishedByUserId), zap.Error(err))
+
+					userIdToUserFirstNameLastInitial[post.PublishedByUserId] = DefaultPostAuthor
+					continue
+				}
+
+				userFirstNameLastInital := postPublishingUser.User.PersonalInfo.FirstName + " " + string(postPublishingUser.User.PersonalInfo.LastName[0]) + "."
+				userIdToUserFirstNameLastInitial[post.PublishedByUserId] = userFirstNameLastInital
+				matchingPosts.Posts[i].PublishedAs = userFirstNameLastInital
+				continue
+			}
+
+			matchingPosts.Posts[i].PublishedAs = userIdToUserFirstNameLastInitial[post.PublishedByUserId]
+			continue
+		}
+	}
+}

--- a/external/post/const.go
+++ b/external/post/const.go
@@ -1,0 +1,87 @@
+package post
+
+// Error keys
+const (
+
+	// ErrKeyInvalidPostPayload is the error key for when the Post payload is invalid
+	ErrKeyInvalidPostPayload = "InvalidPostPayload"
+
+	// ErrKeyHeaderImageMissing is the error key for when a change/ creation request is made
+	// but no header image in provided when needed for content type
+	ErrKeyHeaderImageMissing = "HeaderImageMissing"
+
+	// ErrKeyRequiredPostTitleIsMissing is the error key for when a post is missing a title
+	ErrKeyRequiredPostTitleIsMissing = "RequiredPostTitleIsMissing"
+
+	// ErrKeyRequiredPostTextIsMissing is the error key for when a post is missing its text
+	// body
+	ErrKeyRequiredPostTextIsMissing = "RequiredPostTextIsMissing"
+
+	// ErrKeyUserIdMustBeProvided is the error key returned when a user id cannot be obtained
+	// with the request
+	ErrKeyUserIdMustBeProvided = "UserIdMustBeProvided"
+
+	// ErrKeyInvalidPostPublishedAtProvided is the error key returned when the provided published
+	// at string fails to parse
+	ErrKeyInvalidPostPublishedAtProvided = "InvalidPostPublishedAtProvided"
+
+	// ErrKeyPostAlreadyExistsWithGivenUrlFriendlyId is the error key returned when attempting to
+	// save a post that's using a key already used by another post
+	ErrKeyPostAlreadyExistsWithGivenUrlFriendlyId = "PostAlreadyExistsWithGivenUrlFriendlyId"
+
+	// ErrKeyIdIsRequired is the error key returned when an operation that requires an Id on a post
+	// cannot detect/find one
+	ErrKeyIdIsRequired = "IdIsRequired"
+
+	// ErrKeyNanoIdIsRequired is the error key returned when an operation that requires a nano Id on a post
+	// cannot detect/find one
+	ErrKeyNanoIdIsRequired = "NanoIdIsRequired"
+
+	// ErrKeyUrlFriendlyIdIsRequired is the error key returned when an operation that requires a url friendly id
+	// on a post cannot detect/find one
+	ErrKeyUrlFriendlyIdIsRequired = "UrlFriendlyIdIsRequired"
+
+	// ErrKeyResourceNotFound is the error key returned when a post resource with given id cannot be found
+	ErrKeyResourceNotFound = "ResourceNotFound"
+
+	// ErrKeyPostBadRequest is the error key for when the post payload is invalid
+	ErrKeyPostBadRequest = "PostBadRequest"
+
+	// ErrKeyInvalidPostQueryParam is the error key for when an invalid query param is provided
+	// for a post related request
+	ErrKeyInvalidPostQueryParam = "InvalidPostQueryParam"
+
+	// ErrKeyChangelogPostMustHaveValidTagsSet is the error key for when missing or invalid tags have been
+	// passed for creating a changelog item post
+	ErrKeyChangelogPostMustHaveValidTagsSet = "ChangelogPostMustHaveValidTagsSet"
+
+	// ErrKeyPostInvalidHeaderImageFailedTypeAssigment is the error key for when a post has an invalid header image
+	// type that cannot be assigned to the post
+	ErrKeyPostInvalidHeaderImageFailedTypeAssigment = "PostInvalidHeaderImageFailedTypeAssigment"
+
+	// ErrKeyPostInvalidHeaderImageFailedSvgUnmarshal is the error key for when a post has an invalid svg header image
+	ErrKeyPostInvalidHeaderImageFailedSvgUnmarshal = "PostInvalidHeaderImageFailedSvgUnmarshal"
+
+	//  ErrKeyPostInvalidHeaderImageMissingRoleImgAttribute  is the error key for when a post has an invalid header image missing the role img attribute
+	ErrKeyPostInvalidHeaderImageMissingRoleImgAttribute = "PostInvalidHeaderImageMissingRoleImgAttribute"
+
+	// ErrKeyPostInvalidHeaderImageMissingTitleElement is the error key for when a post has an invalid header image missing the title element
+	ErrKeyPostInvalidHeaderImageMissingTitleElement = "PostInvalidHeaderImageMissingTitleElement"
+
+	// ErrKeyPostNotFoundForUpdate is the error key for when a post cannot be found for update
+	ErrKeyPostNotFoundForUpdate = "PostNotFoundForUpdate"
+
+	// ErrKeyPostUpdateAttemptOnDeletedPost is the error key for when attempting to update a soft-deleted post
+	ErrKeyPostUpdateAttemptOnDeletedPost = "PostUpdateAttemptOnDeletedPost"
+
+	// ErrKeyRequiredPostTypeIsMissing is the error key for when no valid post types are provided
+	ErrKeyRequiredPostTypeIsMissing = "RequiredPostTypeIsMissing"
+
+	// ErrKeyPostAlreadySoftDeleted is the error key for when attempting to delete a post that has already been soft deleted
+	ErrKeyPostAlreadySoftDeleted = "PostAlreadySoftDeleted"
+)
+
+var (
+	// DefaultValidPostTags is the default set of valid post tags that can be used for changelog posts
+	DefaultValidPostTags = []string{"announcement", "bug-fix", "product-news", "exciting-news"}
+)

--- a/external/post/errormap.go
+++ b/external/post/errormap.go
@@ -1,0 +1,29 @@
+package post
+
+import "github.com/ooaklee/reply"
+
+// PostErrorMap holds Error keys, their corresponding human-friendly message, and response status code
+// nolint will be used later
+var PostErrorMap reply.ErrorManifest = reply.ErrorManifest{
+	ErrKeyInvalidPostPayload:                            {Title: "Bad Request", Detail: "Invalid post payload", StatusCode: 400, Code: "CNT0-01"},
+	ErrKeyRequiredPostTitleIsMissing:                    {Title: "Bad Request", Detail: "Required post title is missing", StatusCode: 400, Code: "CNT0-02"},
+	ErrKeyHeaderImageMissing:                            {Title: "Bad Request", Detail: "Header image is missing", StatusCode: 400, Code: "CNT0-03"},
+	ErrKeyRequiredPostTextIsMissing:                     {Title: "Bad Request", Detail: "Required post text is missing", StatusCode: 400, Code: "CNT0-04"},
+	ErrKeyUserIdMustBeProvided:                          {Title: "Forbidden", Detail: "Who are you? You do not have permission to carry out this action", StatusCode: 403, Code: "CNT0-05"},
+	ErrKeyInvalidPostPublishedAtProvided:                {Title: "Bad Request", Detail: "Invalid post published at provided", StatusCode: 400, Code: "CNT0-06"},
+	ErrKeyPostAlreadyExistsWithGivenUrlFriendlyId:       {Title: "Conflict", Detail: "Post already exists with given url friendly id", StatusCode: 409, Code: "CNT0-07"},
+	ErrKeyIdIsRequired:                                  {Title: "Bad Request", Detail: "Post Id is required", StatusCode: 400, Code: "CNT0-08"},
+	ErrKeyNanoIdIsRequired:                              {Title: "Bad Request", Detail: "Post Nano Id is required", StatusCode: 400, Code: "CNT0-09"},
+	ErrKeyResourceNotFound:                              {Title: "Not Found", Detail: "Post not found", StatusCode: 404, Code: "CNT0-10"},
+	ErrKeyPostBadRequest:                                {Title: "Bad Request", Detail: "Post fails validation", StatusCode: 400, Code: "CNT0-11"},
+	ErrKeyUrlFriendlyIdIsRequired:                       {Title: "Bad Request", Detail: "Post Url Friendly Id is required", StatusCode: 400, Code: "CNT0-12"},
+	ErrKeyInvalidPostQueryParam:                         {Title: "Bad Request", Detail: "Invalid post query param", StatusCode: 400, Code: "CNT0-13"},
+	ErrKeyChangelogPostMustHaveValidTagsSet:             {Title: "Bad Request", Detail: "Changelog post must have valid tags set/ provided", StatusCode: 400, Code: "CNT0-14"},
+	ErrKeyPostInvalidHeaderImageFailedTypeAssigment:     {Title: "Bad Request", Detail: "Post has invalid header image that cannot be assigned a supported type", StatusCode: 400, Code: "CNT0-15"},
+	ErrKeyPostInvalidHeaderImageFailedSvgUnmarshal:      {Title: "Bad Request", Detail: "Post has invalid svg header image", StatusCode: 400, Code: "CNT0-16"},
+	ErrKeyPostInvalidHeaderImageMissingRoleImgAttribute: {Title: "Bad Request", Detail: "Post has invalid header svg image missing the role img attribute", StatusCode: 400, Code: "CNT0-17"},
+	ErrKeyPostInvalidHeaderImageMissingTitleElement:     {Title: "Bad Request", Detail: "Post has invalid header svg image missing the title element", StatusCode: 400, Code: "CNT0-18"},
+	ErrKeyPostNotFoundForUpdate:                         {Title: "Not Found", Detail: "Post not found for update", StatusCode: 404, Code: "CNT0-19"},
+	ErrKeyPostUpdateAttemptOnDeletedPost:                {Title: "Bad Request", Detail: "Cannot update a deleted post", StatusCode: 400, Code: "CNT0-20"},
+	ErrKeyPostAlreadySoftDeleted:                        {Title: "Conflict", Detail: "Provided post is already soft-deleted", StatusCode: 409, Code: "CNT0-21"},
+}

--- a/external/post/model.go
+++ b/external/post/model.go
@@ -1,0 +1,473 @@
+package post
+
+import (
+	"encoding/xml"
+	"errors"
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/toolbox"
+)
+
+// PostType represents the type of post
+type PostType string
+
+const (
+
+	// PostTypeChangelog represents a changelog item
+	PostTypeChangelog PostType = "changelog"
+
+	// PostTypeArticle represents an article that'll often be used
+	// to represent a blog post
+	PostTypeArticle PostType = "article"
+
+	// PostTypeFaq represents an faq entry
+	PostTypeFaq PostType = "faq"
+
+	// PostTypeGlossary represents a glossary item
+	PostTypeGlossary PostType = "glossary"
+
+	// PostTypeOther represents a other type of post
+	PostTypeOther PostType = "other"
+)
+
+// TextFormat represents the format of the post
+type TextFormat string
+
+const (
+
+	// TextFormatMarkdown represents the markdown text format
+	TextFormatMarkdown TextFormat = "markdown"
+
+	// TextFormatHtml represents the html text format
+	TextFormatHtml TextFormat = "html"
+)
+
+// HeaderImageType represents the type of the header image
+type HeaderImageType string
+
+const (
+
+	// HeaderImageTypeSvg represents the SVG header image
+	HeaderImageTypeSvg HeaderImageType = "svg"
+
+	// HeaderImageTypeUrl represents the header image that procided
+	// in the form of a URL
+	HeaderImageTypeUrl HeaderImageType = "url"
+)
+
+// SVG represents the structure of an inline SVG element with accessibility attributes.
+// It is used to parse and validate SVG content for post header images, ensuring proper
+// accessibility markup is present (role="img", title element, etc.).
+//
+// Expected format:
+//
+//	<svg role="img">
+//	    <title>Descriptive Title Here</title>
+//	    <use xlink:href="#some-icon"></use>
+//	</svg>
+type SVG struct {
+	// XMLName is the XML element name, expected to be "svg"
+	XMLName xml.Name `xml:"svg"`
+
+	// Text contains any character data within the SVG element
+	Text string `xml:",chardata"`
+
+	// Role is the ARIA role attribute, should be "img" for accessibility
+	Role string `xml:"role,attr"`
+
+	// Title is the descriptive title element used as alt text alternative for screen readers
+	Title string `xml:"title"`
+
+	// Use represents the <use> element that references an icon or graphic
+	Use struct {
+		// Text contains any character data within the use element
+		Text string `xml:",chardata"`
+
+		// Href is the xlink:href attribute pointing to the referenced graphic
+		Href string `xml:"href,attr"`
+	} `xml:"use"`
+}
+
+// Post represents a post item from a user
+//
+//			{
+//			    "id": "[SOME_UUID]",
+//			    "nano_id": "[SOME_NANO_ID]",
+//			    "url_friendly_id: "wrapping-up-q2-2025",
+//			    "type": "article",
+//		        "title": "Wrapping up: Q2 2025",
+//			    "header_image: "<svg> || https://"
+//	            "header_image_type": "url",
+//			    "text_format": "markdown",
+//			    "text": "We do our best to continuously\n\n# Conversion tracking\nShort links are great..",
+//			    "visibility": [], # If empty, the will be visible to all
+//			    "tags":   ["news", "overview"],
+//			    "publish_date": "", # If blank, then will be 'draft'
+//			    "publish_as": "", # if blank, pull information from created_by_id
+//			    "created_by_id": "[SOME_UUID]",
+//			    "created_at": "YYYY-MM-DDThh:mm:ss",
+//			    "updated_by_id": "",
+//			    "updated_at": "YYYY-MM-DDThh:mm:ss",
+//			    "deleted_by_id": "",
+//			    "deleted_at": "", # if date provided soft delete
+//			}
+type Post struct {
+
+	// Id is the unique identifier for the post item
+	Id string `json:"id" bson:"_id"`
+
+	// NanoId is the nano ID for the post item
+	NanoId string `json:"nano_id" bson:"_nano_id"`
+
+	// UrlFriendlyId is a unique URL friendly id that is used to
+	// identify a given post, it should have a its given type as
+	// a prefix
+	UrlFriendlyId string `json:"url_friendly_id" bson:"_url_friendly_id"`
+
+	// Title is the title to describe the post item
+	Title string `json:"title" bson:"title"`
+
+	// HeaderImage is the source of the header image for the given post
+	// not all post types will support header images
+	HeaderImage string `json:"header_image,omitempty" bson:"header_image,omitempty"`
+
+	// HeaderImageType is the type/format of the header image
+	HeaderImageType HeaderImageType `json:"header_image_type,omitempty" bson:"header_image_type,omitempty"`
+
+	// HeaderImageAltText is the alt text for the header image
+	HeaderImageAltText string `json:"header_image_alt_text,omitempty" bson:"header_image_alt_text,omitempty"`
+
+	// ProvidedType is the type of the post item provided by the user
+	// if the type is not valid, it will be set to other and this field
+	// will be set to the provided type
+	ProvidedType string `json:"provided_type,omitempty" bson:"provided_type,omitempty"`
+
+	// Type is the type of the post item
+	Type PostType `json:"type" bson:"type"`
+
+	// ProvidedTextFormat is the text format of the post item provided by the user
+	// if the type is not valid, it will be set to markdown and this field
+	// will be set to the provided text format
+	ProvidedTextFormat string `json:"provided_text_format,omitempty" bson:"provided_text_format,omitempty"`
+
+	// TextFormat is the format the post text will be written in, i.e. markdown
+	TextFormat TextFormat `json:"text_format" bson:"text_format"`
+
+	// Text is the body of text for the post
+	Text string `json:"text" bson:"text"`
+
+	// Tags are the categorisations that can be used to group the post further, i.e
+	// announcements, bug-fix, product, exciting-news
+	Tags []string `json:"tags,omitempty" bson:"tags,omitempty"`
+
+	// Visibility outlines the persons who can see this post item, if blank, everyone will be
+	// able to access the post item.
+	// TODO: implement later
+	Visibility []string `json:"visibility,omitempty" bson:"visibility,omitempty"`
+
+	// PublishedAs is the override that should be used when specifying who published
+	// the post item. If blank should use the CreatedByUserId
+	PublishedAs string `json:"published_as,omitempty" bson:"published_as"`
+
+	// PublishedAt is the date and time the post item was published, if
+	// blank, then the post should be treated as a 'darft'
+	PublishedAt string `json:"published_at,omitempty" bson:"published_at"`
+
+	// PublishedByUserId is the ID of the user most recently published the post item
+	PublishedByUserId string `json:"published_by_user_id,omitempty" bson:"published_by_user_id"`
+
+	// CreatedAt is the date and time the post item was created
+	CreatedAt string `json:"created_at" bson:"created_at"`
+
+	// CreatedByUserId is the ID of the user who created the post item
+	CreatedByUserId string `json:"created_by_user_id,omitempty" bson:"created_by_user_id"`
+
+	// UpdatedAt is the date and time the post item was updated
+	UpdatedAt string `json:"updated_at,omitempty" bson:"updated_at,omitempty"`
+
+	// UpdatedByUserId is the ID of the user who most recently updated the post item
+	UpdatedByUserId string `json:"updated_by_user_id,omitempty" bson:"updated_by_user_id,omitempty"`
+
+	// DeletedAt is the date and time the post item was deleted
+	DeletedAt string `json:"deleted_at,omitempty" bson:"deleted_at"`
+
+	// DeletedByUserId is the ID of the user who soft deleted the post item
+	DeletedByUserId string `json:"deleted_by_user_id,omitempty" bson:"deleted_by_user_id"`
+}
+
+// PostOverview represents a lightweight overview of a post item
+type PostOverview struct {
+
+	// Id is the unique identifier for the post
+	Id string `json:"id"`
+
+	// Title is the title of the post
+	Title string `json:"title"`
+
+	// PublishedAt is the date and time the post was published
+	PublishedAt string `json:"published_at"`
+
+	// UpdatedAt is the date and time the post was last updated
+	UpdatedAt string `json:"updated_at,omitempty"`
+
+	// NotificationTitle is the title of the notification for the post
+	NotificationTitle string `json:"notification_title,omitempty"`
+
+	// Type is the type of the post item
+	Type PostType `json:"type" bson:"type"`
+
+	// UrlFriendlyId is the URL-friendly version of the post title
+	UrlFriendlyId string `json:"url_friendly_id"`
+
+	// Href is the generated relative URL to access the post
+	Href string `json:"href"`
+
+	// RevisionHash is the hash representing the revision of the post
+	RevisionHash string `json:"revision_hash,omitempty"`
+}
+
+// ToOverview converts a Post to its Overview representation
+func (p *Post) ToOverview() *PostOverview {
+	overview := &PostOverview{
+		Id:            p.Id,
+		Title:         p.Title,
+		PublishedAt:   p.PublishedAt,
+		UpdatedAt:     p.UpdatedAt,
+		Type:          p.Type,
+		UrlFriendlyId: p.UrlFriendlyId,
+	}
+
+	var href string
+	var notificationTitle string
+	switch p.Type {
+	case PostTypeChangelog:
+		href = "/whats-new"
+		notificationTitle = "New: Platform Updates"
+	case PostTypeFaq:
+		notificationTitle = "New: FAQ"
+		href = "/faq#" + p.UrlFriendlyId
+	case PostTypeGlossary:
+		notificationTitle = "New: Glossary Terms"
+		href = "/glossary#" + p.UrlFriendlyId
+	case PostTypeArticle:
+		notificationTitle = "New: Blog Posts"
+		href = "/blog" + "/" + strings.Replace(p.UrlFriendlyId, string(PostTypeArticle)+"-", "", 1)
+	}
+
+	overview.Href = href
+	overview.NotificationTitle = notificationTitle
+
+	// Generate revision hash
+	revisionHashSource := strings.Join([]string{
+		overview.Id,
+		string(overview.Type),
+		overview.Title,
+		overview.PublishedAt,
+		overview.UpdatedAt,
+	}, "|")
+
+	overview.RevisionHash = GenerateSha256Hash(revisionHashSource)
+
+	return overview
+}
+
+// SetPostTextFormat takes string,sanitise, and set correct post item text format
+func (c *Post) SetPostTextFormat(providedTextFmt string) *Post {
+
+	var err error
+
+	// make provided type kebab case
+	providedTextFmt, err = toolbox.StringConvertToKebabCase(providedTextFmt)
+	if err != nil {
+		providedTextFmt = strings.ReplaceAll(
+			strings.ToLower(providedTextFmt),
+			" ",
+			"-",
+		)
+	}
+
+	// convert to post item type
+	textFormat := TextFormat(providedTextFmt)
+
+	// make sure the post item type is valid
+	if textFormat != TextFormatMarkdown &&
+		textFormat != TextFormatHtml {
+		c.ProvidedType = providedTextFmt
+		textFormat = TextFormatMarkdown
+	}
+
+	c.TextFormat = textFormat
+
+	return c
+}
+
+// SetPostType take string, sanitise, and set correct post item type
+func (c *Post) SetPostType(providedType string) *Post {
+
+	var err error
+
+	// make provided type kebab case
+	providedType, err = toolbox.StringConvertToKebabCase(providedType)
+	if err != nil {
+		providedType = strings.ReplaceAll(
+			strings.ToLower(providedType),
+			" ",
+			"-",
+		)
+	}
+
+	// convert to post item type
+	postType := PostType(providedType)
+
+	// make sure the post item type is valid
+	if postType != PostTypeChangelog &&
+		postType != PostTypeFaq &&
+		postType != PostTypeArticle &&
+		postType != PostTypeOther &&
+		postType != PostTypeGlossary {
+		postType = PostTypeOther
+		c.ProvidedType = providedType
+	}
+
+	c.Type = postType
+
+	return c
+}
+
+// SetHeaderImageType checks the provided header image and
+// set correct header image type
+func (c *Post) SetHeaderImageType() (*Post, error) {
+
+	if c.Type != PostTypeArticle {
+		c.HeaderImageType = ""
+
+		return c, nil
+	}
+
+	standardisedHeaderImage := strings.TrimSpace(
+		toolbox.StringStandardisedToLower(c.HeaderImage),
+	)
+
+	if strings.HasPrefix(standardisedHeaderImage, "http") || strings.HasPrefix(standardisedHeaderImage, "/") {
+		c.HeaderImageType = HeaderImageTypeUrl
+		return c, nil
+	}
+
+	if strings.HasPrefix(standardisedHeaderImage, "<svg") &&
+		strings.HasSuffix(standardisedHeaderImage, "</svg>") {
+		c.HeaderImageType = HeaderImageTypeSvg
+		return c, nil
+	}
+
+	return c, errors.New(ErrKeyPostInvalidHeaderImageFailedTypeAssigment)
+}
+
+// ValidateHeaderImageHasRequiredAltTextAlternativeElementsForInlineSvg validates that the header image (if SVG) has required
+// alt text alternative elements for accessibility
+// more info https://stackoverflow.com/q/4697100
+// expected format
+//
+// <svg role="img">
+//
+//	<title>Descriptive Title Here</title>
+//	<use xlink:href="#some-icon"></use>
+//
+// </svg>
+func (c *Post) ValidateHeaderImageHasRequiredAltTextAlternativeElementsForInlineSvg() error {
+
+	if c.HeaderImageType != HeaderImageTypeSvg {
+		return nil
+	}
+
+	var svgContent SVG
+	err := xml.Unmarshal([]byte(c.HeaderImage), &svgContent)
+	if err != nil {
+		return errors.New(ErrKeyPostInvalidHeaderImageFailedSvgUnmarshal)
+	}
+
+	if svgContent.Role != "img" {
+		return errors.New(ErrKeyPostInvalidHeaderImageMissingRoleImgAttribute)
+	}
+
+	if strings.TrimSpace(svgContent.Title) == "" {
+		return errors.New(ErrKeyPostInvalidHeaderImageMissingTitleElement)
+	}
+
+	return nil
+}
+
+// GenerateNanoId generates a new Nano Id for the post item
+func (c *Post) GenerateNanoId() *Post {
+
+	c.NanoId = toolbox.GenerateNanoId()
+
+	return c
+}
+
+// GenerateId generates a new Id for the post item
+func (c *Post) GenerateId() *Post {
+
+	c.Id = toolbox.GenerateUuidV4()
+
+	return c
+}
+
+// GenerateUrlFriendlyId generate a new URL friendly id for the post item, we
+// should use the post type as a prefix
+func (c *Post) GenerateUrlFriendlyId() *Post {
+
+	var (
+		urlFriendlyIdComponents []string
+		rawTitle                string
+	)
+
+	urlFriendlyIdComponents = append(
+		urlFriendlyIdComponents,
+		string(c.Type),
+	)
+
+	// get post title, strip all special character, make lowercase,
+	// swap space for hyphen
+	rawTitle = c.Title
+	rawTitle = strings.TrimSpace(rawTitle)
+	rawTitle = toolbox.NonAlphanumericRegexEnglishAlphabetStringsRegex.ReplaceAllString(rawTitle, "")
+	rawTitle = toolbox.StringStandardisedToLower(rawTitle)
+	standardisedRawTitleComponents := strings.Split(rawTitle, " ")
+
+	urlFriendlyIdComponents = append(
+		urlFriendlyIdComponents,
+		standardisedRawTitleComponents...,
+	)
+
+	c.UrlFriendlyId = strings.Join(
+		urlFriendlyIdComponents,
+		"-",
+	)
+
+	return c
+}
+
+// SetCreatedAtTimeToNow sets the created at date and time for the post item to now
+func (c *Post) SetCreatedAtTimeToNow() *Post {
+
+	c.CreatedAt = toolbox.TimeNowUTC()
+
+	return c
+}
+
+// SetUpdatedAtTimeToNow sets the updated at date and time for the post item to now
+func (c *Post) SetUpdatedAtTimeToNow() *Post {
+
+	c.UpdatedAt = toolbox.TimeNowUTC()
+
+	return c
+}
+
+// SetDeletedAtTimeToNow sets the deleted at date and time for the post item to now
+// if set, the the post is soft deleted
+func (c *Post) SetDeletedAtTimeToNow() *Post {
+
+	c.DeletedAt = toolbox.TimeNowUTC()
+
+	return c
+}

--- a/external/post/model_test.go
+++ b/external/post/model_test.go
@@ -1,0 +1,39 @@
+package post_test
+
+import (
+	"testing"
+
+	"github.com/go-playground/assert/v2"
+	"github.com/ooaklee/ghatd/external/post"
+)
+
+func TestModel_GenerateUrlFriendlyId(t *testing.T) {
+
+	tests := []struct {
+		name                string
+		rawTitle            string
+		providedType        string
+		expectedUrlFriendly string
+	}{
+		{
+			name:                "Success - Generated url with expected format",
+			rawTitle:            "Wrapping up: Q2 2025",
+			providedType:        "article",
+			expectedUrlFriendly: "article-wrapping-up-q2-2025",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			post := &post.Post{
+				Title: test.rawTitle,
+				Type:  post.PostType(test.providedType),
+			}
+
+			post.GenerateUrlFriendlyId()
+
+			assert.Equal(t, post.UrlFriendlyId, test.expectedUrlFriendly)
+		})
+	}
+}

--- a/external/post/repository.go
+++ b/external/post/repository.go
@@ -1,0 +1,700 @@
+package post
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/repository"
+	"github.com/ooaklee/ghatd/external/toolbox"
+	internalToolbox "github.com/ooaklee/ghatd/external/toolbox"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// PostCollection collection name for posts
+const PostCollection string = "posts"
+
+// MongoDbStore represents the datastore to hold resource data
+type MongoDbStore interface {
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
+	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
+	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
+	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
+	ExecuteAggregateCommand(ctx context.Context, collection *mongo.Collection, mongoPipeline []bson.D) (*mongo.Cursor, error)
+	// ExecuteReplaceOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, replacementObject interface{}, resultObjectName string) error
+	// ExecuteUpdateManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
+	// ExecuteInsertManyCommand(ctx context.Context, collection *mongo.Collection, documents []interface{}, resultObjectName string) (*mongo.InsertManyResult, error)
+
+	GetDatabase(ctx context.Context, dbName string) (*mongo.Database, error)
+	InitialiseClient(ctx context.Context) (*mongo.Client, error)
+	MapAllInCursorToResult(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error
+	MapOneInCursorToResult(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error
+}
+
+// Repository represents the datastore to hold resource data
+type Repository struct {
+	Store MongoDbStore
+}
+
+// NewRepository initiates new instance of repository
+func NewRepository(store MongoDbStore) *Repository {
+	return &Repository{
+		Store: store,
+	}
+}
+
+// GetPostCollection returns collection used for posts domain
+func (r *Repository) GetPostCollection(ctx context.Context) (*mongo.Collection, error) {
+
+	_, err := r.Store.InitialiseClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := r.Store.GetDatabase(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	collection := db.Collection(PostCollection)
+
+	return collection, nil
+}
+
+// CreateRawPosts handles creating a tax band from raw definition in repositry
+func (r *Repository) CreateRawPosts(ctx context.Context, newPost *Post) (*Post, error) {
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if newPost.CreatedAt == "" {
+		newPost.SetCreatedAtTimeToNow()
+	}
+
+	// verify the id is preset
+	if newPost.Id == "" {
+		return nil, errors.New(ErrKeyIdIsRequired)
+	}
+
+	// verify the nano id is preset
+	if newPost.NanoId == "" {
+		return nil, errors.New(ErrKeyNanoIdIsRequired)
+	}
+
+	// verify url friendly id is preset
+	if newPost.UrlFriendlyId == "" {
+		return nil, errors.New(ErrKeyUrlFriendlyIdIsRequired)
+	}
+
+	_, err = r.Store.ExecuteInsertOneCommand(ctx, collection, newPost, "post")
+	if err != nil {
+		return nil, err
+	}
+
+	return newPost, nil
+}
+
+// GetPostById handles fetching a post in repositry that match the provided Id
+func (r *Repository) GetPostById(ctx context.Context, postId string) (*Post, error) {
+
+	var (
+		post        Post
+		queryFilter = bson.M{"_id": postId}
+	)
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.Store.ExecuteFindOneCommandDecodeResult(ctx, collection, queryFilter, &post, "post", true, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &post, nil
+}
+
+// GetPostByNanoId handles fetching a post in repositry that match the provided nano Id
+func (r *Repository) GetPostByNanoId(ctx context.Context, postNanoId string) (*Post, error) {
+
+	var (
+		foundPost         Post
+		queryFilter       = bson.M{"_nano_id": postNanoId}
+		noDocumentMessage = "mongo: no documents in post"
+	)
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.Store.ExecuteFindOneCommandDecodeResult(ctx, collection, queryFilter, &foundPost, "post", true, nil)
+	if err != nil && err.Error() != noDocumentMessage {
+		return nil, err
+	}
+
+	if err != nil && err.Error() == noDocumentMessage {
+		return nil, errors.New(ErrKeyResourceNotFound)
+	}
+
+	return &foundPost, nil
+}
+
+// GetPostByUrlFriendlyId handles fetching a post in repositry that match the provided url friendly id
+func (r *Repository) GetPostByUrlFriendlyId(ctx context.Context, postUrlFriendlyId string) (*Post, error) {
+
+	var (
+		foundPost         Post
+		queryFilter       = bson.M{"_url_friendly_id": postUrlFriendlyId}
+		noDocumentMessage = "mongo: no documents in result"
+	)
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.Store.ExecuteFindOneCommandDecodeResult(ctx, collection, queryFilter, &foundPost, "post", true, nil)
+	if err != nil && err.Error() != noDocumentMessage {
+		return nil, err
+	}
+
+	if err != nil && err.Error() == noDocumentMessage {
+		return nil, errors.New(ErrKeyResourceNotFound)
+	}
+
+	return &foundPost, nil
+}
+
+// GetPostsByIds handles fetching posts in repositry that match the provided Ids
+func (r *Repository) GetPostsByIds(ctx context.Context, postIds []string) ([]Post, error) {
+
+	var (
+		post        []Post
+		queryFilter = bson.M{"_id": bson.M{"$in": postIds}}
+		findOptions = options.Find()
+	)
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, findOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = r.Store.MapAllInCursorToResult(ctx, c, &post, "posts"); err != nil {
+		return nil, err
+	}
+
+	return post, nil
+}
+
+// GetPostsByNanoIds handles fetching posts in repositry that match the provided nano Ids
+func (r *Repository) GetPostsByNanoIds(ctx context.Context, postNanoIds []string) ([]Post, error) {
+
+	var (
+		post        []Post
+		queryFilter = bson.M{"_nano_id": bson.M{"$in": postNanoIds}}
+		findOptions = options.Find()
+	)
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, findOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = r.Store.MapAllInCursorToResult(ctx, c, &post, "posts"); err != nil {
+		return nil, err
+	}
+
+	return post, nil
+}
+
+// GetPostsByUrlFriendlyIds handles fetching posts in repositry that match the provided url friendly Ids
+func (r *Repository) GetPostsByUrlFriendlyIds(ctx context.Context, postUrlFriendlyIds []string) ([]Post, error) {
+
+	var (
+		post        []Post
+		queryFilter = bson.M{"_url_friendly_id": bson.M{"$in": postUrlFriendlyIds}}
+		findOptions = options.Find()
+	)
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, findOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = r.Store.MapAllInCursorToResult(ctx, c, &post, "posts"); err != nil {
+		return nil, err
+	}
+
+	return post, nil
+}
+
+// CreatePost handles creating a tax band in repositry
+func (r *Repository) CreatePost(ctx context.Context, newPost *Post) (*Post, error) {
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	newPost.SetCreatedAtTimeToNow()
+
+	// only set Id if not already set
+	if newPost.Id == "" {
+		newPost.GenerateId()
+	}
+
+	// only set nano id if not already set
+	if newPost.NanoId == "" {
+		newPost.GenerateNanoId()
+	}
+
+	// verify url friendly id is preset
+	if newPost.UrlFriendlyId == "" {
+		return nil, errors.New(ErrKeyUrlFriendlyIdIsRequired)
+	}
+
+	_, err = r.Store.ExecuteInsertOneCommand(ctx, collection, newPost, "post")
+	if err != nil {
+		return nil, err
+	}
+
+	return newPost, nil
+}
+
+// UpdatePost handles updating a post in repositry
+func (r *Repository) UpdatePost(ctx context.Context, post *Post) (*Post, error) {
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	post.SetUpdatedAtTimeToNow()
+
+	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, bson.M{"_id": post.Id}, bson.M{"$set": post}, "post")
+	if err != nil {
+		return nil, err
+	}
+
+	return post, nil
+}
+
+// DeletePost handles deleting a tax band in repositry
+func (r *Repository) DeletePost(ctx context.Context, postId string) error {
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = r.Store.ExecuteDeleteOneCommand(ctx, collection, bson.M{"_id": postId}, "post")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SoftDeletePost handles soft-deleting a tax band in repositry
+func (r *Repository) SoftDeletePost(ctx context.Context, post *Post, userId string) error {
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return err
+	}
+
+	post.SetDeletedAtTimeToNow()
+	post.DeletedByUserId = userId
+
+	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, bson.M{"_id": post.Id}, bson.M{"$set": post}, "post")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetTotalPosts handles fetching the total count of posts in repository
+func (r *Repository) GetTotalPosts(ctx context.Context, req *GetTotalPostsRequest) (int64, error) {
+
+	// Example mongo query
+	// /// get posts total
+	// db.getCollection("posts").countDocuments({_id : { $ne : null }})
+	// /// get posts where title is "Hello World"
+	// db.getCollection("posts").find({"title": {$eq: "Hello World"}})
+
+	queryFilter := bson.M{"_id": bson.M{"$exists": true}}
+
+	if req.Title != "" {
+		regexQueryStringFmtString := ".*(%s).*"
+
+		regexQueryString := fmt.Sprintf(regexQueryStringFmtString,
+			strings.ReplaceAll(toolbox.StringRemoveMultiSpace(
+				strings.TrimSpace(req.Title),
+			), " ", "|"),
+		)
+
+		queryFilter["title"] = bson.M{"$regex": primitive.Regex{Pattern: regexQueryString, Options: "i"}}
+	}
+
+	if req.PublishedWithAlias {
+		queryFilter["published_as"] = bson.M{"$exists": true}
+	}
+	if req.PublishedWithoutAlias {
+		queryFilter["published_as"] = bson.M{"$exists": false}
+	}
+
+	if len(req.CreatedByIds) > 0 {
+		queryFilter["created_by_user_id"] = bson.M{"$in": req.CreatedByIds}
+	}
+
+	if len(req.UrlFriendlyIds) > 0 {
+		queryFilter["_url_friendly_id"] = bson.M{"$in": req.UrlFriendlyIds}
+	}
+
+	if len(req.PostTypes) > 0 {
+
+		standardisedProvidedPostTypes := internalToolbox.StandardisedTypesAsStrings(req.PostTypes)
+
+		queryFilter["type"] = bson.M{"$in": standardisedProvidedPostTypes}
+	}
+
+	if len(req.Tags) > 0 {
+		queryFilter["tags"] = bson.M{"$in": req.Tags}
+	}
+
+	if len(req.PostTextFormats) > 0 {
+		standardisedProvidedPostTextFormats := internalToolbox.StandardisedTypesAsStrings(req.PostTextFormats)
+
+		queryFilter["text_format"] = bson.M{"$in": standardisedProvidedPostTextFormats}
+	}
+
+	if req.TextContains != "" {
+		regexQueryStringFmtString := ".*(%s).*"
+
+		regexQueryString := fmt.Sprintf(regexQueryStringFmtString,
+			strings.ReplaceAll(toolbox.StringRemoveMultiSpace(
+				strings.TrimSpace(req.TextContains),
+			), " ", "|"),
+		)
+
+		queryFilter["text"] = bson.M{"$regex": primitive.Regex{Pattern: regexQueryString, Options: "i"}}
+	}
+
+	if len(req.PostHeaderImageTypes) > 0 {
+		standardisedProvidedPostHeaderImageTypes := internalToolbox.StandardisedTypesAsStrings(req.PostHeaderImageTypes)
+
+		queryFilter["header_image_type"] = bson.M{"$in": standardisedProvidedPostHeaderImageTypes}
+	}
+
+	if len(req.PublishedAs) > 0 {
+		queryFilter["published_as"] = bson.M{"$in": req.PublishedAs}
+	}
+
+	createdAtFilter := bson.M{}
+	if req.CreatedAtFrom != "" {
+		createdAtFilter["$gte"] = req.CreatedAtFrom
+	}
+	if req.CreatedAtTo != "" {
+		createdAtFilter["$lte"] = req.CreatedAtTo
+	}
+	if len(createdAtFilter) > 0 {
+		queryFilter["created_at"] = createdAtFilter
+	}
+
+	publishedAtFilter := bson.M{}
+	if req.PublishedAtFrom != "" {
+		publishedAtFilter["$gte"] = req.PublishedAtFrom
+	}
+	if req.PublishedAtTo != "" {
+		publishedAtFilter["$lte"] = req.PublishedAtTo
+	}
+	if len(publishedAtFilter) > 0 {
+		queryFilter["published_at"] = publishedAtFilter
+	}
+
+	deletedAtFilter := bson.M{}
+	if req.DeletedAtFrom != "" {
+		deletedAtFilter["$gte"] = req.DeletedAtFrom
+	}
+	if req.DeletedAtTo != "" {
+		deletedAtFilter["$lte"] = req.DeletedAtTo
+	}
+	if len(deletedAtFilter) > 0 {
+		queryFilter["deleted_at"] = deletedAtFilter
+	}
+
+	if req.IsDeleted {
+		queryFilter["deleted_at"] = bson.M{"$exists": true, "$ne": ""}
+	}
+	if req.IsNotDeleted {
+		queryFilter["$or"] = []bson.M{
+			{"deleted_at": bson.M{"$exists": false}},
+			{"deleted_at": ""},
+		}
+	}
+
+	if req.IsPublished {
+		// the date exists and it cannot be after now
+		currentTime := toolbox.TimeNowUTC()
+		queryFilter["published_at"] = bson.M{"$exists": true, "$lte": currentTime}
+	}
+	if req.IsNotPublished {
+		// the date does not exist or it is after now
+		currentTime := toolbox.TimeNowUTC()
+		queryFilter["published_at"] = bson.M{"$exists": false, "$gte": currentTime}
+	}
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	total, err := r.Store.ExecuteCountDocuments(ctx, collection, queryFilter)
+	if err != nil {
+		return 0, err
+	}
+
+	return total, nil
+}
+
+// GetPosts handles fetching posts from repositry
+func (r *Repository) GetPosts(ctx context.Context, req *GetPostsRequest) ([]Post, error) {
+
+	var (
+		post            []Post
+		queryFilter     bson.D = bson.D{}
+		requestFilter   bson.D = bson.D{}
+		paginationLimit *int64 = repository.GetPaginationLimit(int64(req.PerPage))
+	)
+
+	findOptions := options.Find()
+
+	findOptions.Limit = paginationLimit
+	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+
+	// generate query filter from request
+	if req.Title != "" {
+		regexQueryStringFmtString := ".*(%s).*"
+
+		regexQueryString := fmt.Sprintf(regexQueryStringFmtString,
+			strings.ReplaceAll(toolbox.StringRemoveMultiSpace(
+				strings.TrimSpace(req.Title),
+			), " ", "|"),
+		)
+
+		queryFilter = append(queryFilter, bson.E{Key: "title", Value: bson.M{"$regex": primitive.Regex{Pattern: regexQueryString, Options: "i"}}})
+	}
+
+	if req.PublishedWithAlias {
+		queryFilter = append(queryFilter, bson.E{Key: "published_as", Value: bson.M{"$exists": true}})
+	}
+	if req.PublishedWithoutAlias {
+		queryFilter = append(queryFilter, bson.E{Key: "published_as", Value: bson.M{"$exists": false}})
+	}
+
+	if req.CreatedByIds != "" {
+		queryFilter = append(queryFilter, bson.E{Key: "created_by_user_id", Value: bson.M{"$in": internalToolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.CreatedByIds)}})
+	}
+
+	if req.UrlFriendlyIds != "" {
+		queryFilter = append(queryFilter, bson.E{Key: "_url_friendly_id", Value: bson.M{"$in": internalToolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.UrlFriendlyIds)}})
+	}
+
+	if req.WithTypes != "" {
+		queryFilter = append(queryFilter, bson.E{Key: "type", Value: bson.M{"$in": internalToolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.WithTypes)}})
+	}
+
+	if req.WithTags != "" {
+		queryFilter = append(queryFilter, bson.E{Key: "tags", Value: bson.M{"$in": internalToolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.WithTags)}})
+	}
+
+	if req.WithTextFormats != "" {
+		queryFilter = append(queryFilter, bson.E{Key: "text_format", Value: bson.M{"$in": internalToolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.WithTextFormats)}})
+	}
+
+	if req.TextContains != "" {
+		regexQueryStringFmtString := ".*(%s).*"
+
+		regexQueryString := fmt.Sprintf(regexQueryStringFmtString,
+			strings.ReplaceAll(toolbox.StringRemoveMultiSpace(
+				strings.TrimSpace(req.TextContains),
+			), " ", "|"),
+		)
+
+		queryFilter = append(queryFilter, bson.E{Key: "text", Value: bson.M{"$regex": primitive.Regex{Pattern: regexQueryString, Options: "i"}}})
+	}
+
+	if req.WithHeaderImageType != "" {
+		queryFilter = append(queryFilter, bson.E{Key: "header_image_type", Value: bson.M{"$in": internalToolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.WithHeaderImageType)}})
+	}
+
+	if req.PublishedAs != "" {
+		queryFilter = append(queryFilter, bson.E{Key: "published_as", Value: bson.M{"$in": internalToolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.PublishedAs)}})
+	}
+
+	createdAtFilter := bson.M{}
+	if req.CreatedAtFrom != "" {
+		createdAtFilter["$gte"] = req.CreatedAtFrom
+	}
+	if req.CreatedAtTo != "" {
+		createdAtFilter["$lte"] = req.CreatedAtTo
+	}
+	if len(createdAtFilter) > 0 {
+		queryFilter = append(queryFilter, bson.E{Key: "created_at", Value: createdAtFilter})
+	}
+
+	publishedAtFilter := bson.M{}
+	if req.PublishedAtFrom != "" {
+		publishedAtFilter["$gte"] = req.PublishedAtFrom
+	}
+	if req.PublishedAtTo != "" {
+		publishedAtFilter["$lte"] = req.PublishedAtTo
+	}
+	if len(publishedAtFilter) > 0 {
+		queryFilter = append(queryFilter, bson.E{Key: "published_at", Value: publishedAtFilter})
+	}
+
+	deletedAtFilter := bson.M{}
+	if req.DeletedAtFrom != "" {
+		deletedAtFilter["$gte"] = req.DeletedAtFrom
+	}
+	if req.DeletedAtTo != "" {
+		deletedAtFilter["$lte"] = req.DeletedAtTo
+	}
+	if len(deletedAtFilter) > 0 {
+		queryFilter = append(queryFilter, bson.E{Key: "deleted_at", Value: deletedAtFilter})
+	}
+
+	if req.IsDeleted {
+		queryFilter = append(queryFilter, bson.E{Key: "deleted_at", Value: bson.M{"$exists": true, "$ne": ""}})
+	}
+	if req.IsNotDeleted {
+		queryFilter = append(queryFilter, bson.E{Key: "$or", Value: []bson.M{
+			{"deleted_at": bson.M{"$exists": false}},
+			{"deleted_at": ""},
+		}})
+	}
+
+	if req.IsPublished {
+		// the date exists and it cannot be after now
+		currentTime := toolbox.TimeNowUTC()
+		queryFilter = append(queryFilter, bson.E{Key: "published_at", Value: bson.M{"$exists": true, "$lte": currentTime}})
+	}
+	if req.IsNotPublished {
+		// the date does not exist or it is after now
+		currentTime := toolbox.TimeNowUTC()
+		queryFilter = append(queryFilter, bson.E{Key: "published_at", Value: bson.M{"$exists": false, "$gte": currentTime}})
+	}
+
+	// generate sort filter from request
+	switch req.Order {
+	case "created_at_asc":
+		requestFilter = append(requestFilter, bson.E{Key: "created_at", Value: 1})
+	case "created_at_desc":
+		requestFilter = append(requestFilter, bson.E{Key: "created_at", Value: -1})
+	case "updated_at_asc":
+		requestFilter = append(requestFilter, bson.E{Key: "updated_at", Value: 1})
+	case "updated_at_desc":
+		requestFilter = append(requestFilter, bson.E{Key: "updated_at", Value: -1})
+	case "deleted_at_asc":
+		requestFilter = append(requestFilter, bson.E{Key: "deleted_at", Value: 1})
+	case "deleted_at_desc":
+		requestFilter = append(requestFilter, bson.E{Key: "deleted_at", Value: -1})
+	case "published_at_asc":
+		requestFilter = append(requestFilter, bson.E{Key: "published_at", Value: 1})
+	case "published_at_desc":
+		requestFilter = append(requestFilter, bson.E{Key: "published_at", Value: -1})
+	default:
+		requestFilter = append(requestFilter, bson.E{Key: "created_at", Value: -1})
+	}
+
+	// Sort by request field
+	findOptions.SetSort(requestFilter)
+
+	collection, err := r.GetPostCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// If EnforceUniqueType is true, use aggregation pipeline
+	if req.EnforceUniqueType {
+		// Build aggregation pipeline
+		pipeline := []bson.D{}
+
+		// Add match stage if there are filters
+		if len(queryFilter) > 0 {
+			pipeline = append(pipeline, bson.D{{Key: "$match", Value: queryFilter}})
+		}
+
+		// Sort documents
+		pipeline = append(pipeline, bson.D{{Key: "$sort", Value: requestFilter}})
+
+		// Group by type and take first document of each type
+		pipeline = append(pipeline, bson.D{
+			{Key: "$group", Value: bson.D{
+				{Key: "_id", Value: "$type"},
+				{Key: "doc", Value: bson.D{{Key: "$first", Value: "$$ROOT"}}},
+			}},
+		})
+
+		// Replace root with the document
+		pipeline = append(pipeline, bson.D{{Key: "$replaceRoot", Value: bson.D{{Key: "newRoot", Value: "$doc"}}}})
+
+		// Sort again after grouping
+		pipeline = append(pipeline, bson.D{{Key: "$sort", Value: requestFilter}})
+
+		// Apply limit
+		if paginationLimit != nil {
+			pipeline = append(pipeline, bson.D{{Key: "$limit", Value: *paginationLimit}})
+		}
+
+		c, err := r.Store.ExecuteAggregateCommand(ctx, collection, pipeline)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = r.Store.MapAllInCursorToResult(ctx, c, &post, "posts"); err != nil {
+			return nil, err
+		}
+
+		return post, nil
+	}
+
+	// Standard find operation
+	c, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, findOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = r.Store.MapAllInCursorToResult(ctx, c, &post, "posts"); err != nil {
+		return nil, err
+	}
+
+	return post, nil
+}

--- a/external/post/request.go
+++ b/external/post/request.go
@@ -1,0 +1,343 @@
+package post
+
+// RestorePostByIdRequest represents the request to restore a soft deleted post by its ID
+type RestorePostByIdRequest struct {
+	// Id is the ID of the post to restore
+	Id string `validate:"required,uuid"`
+
+	// UserId is the ID of the user performing the restoration
+	UserId string `validate:"required,uuid"`
+}
+
+// DeletePostByIdRequest represents the request payload for deleting a post by its ID
+type DeletePostByIdRequest struct {
+
+	// Id is the ID of the post to delete
+	Id string `validate:"required,uuid"`
+
+	// UserId is the ID of the user performing the deletion
+	UserId string `validate:"required,uuid"`
+
+	// HardDelete indicates whether to perform a hard delete
+	// if true, or a soft delete if false
+	HardDelete bool `query:"hard_delete"`
+}
+
+// GetTotalPostsRequest holds everything needed to make
+// the request to get the total count of post from repository
+type GetTotalPostsRequest struct {
+
+	// Title is the title to filter by
+	Title string
+
+	// PublishedWithAlias is in to filter by the posts that have a publisher alias aligned
+	PublishedWithAlias bool
+
+	// PublishedWithoutAlias is in to filter by the posts that do not have a publisher alias aligned
+	PublishedWithoutAlias bool
+
+	// CreatedByIds is the list of user id that created a post to filter by
+	CreatedByIds []string
+
+	// UrlFriendlyIds is the list of url friendly post ids to filter by
+	UrlFriendlyIds []string
+
+	// PostTypes is the list of post types to filter by
+	PostTypes []PostType
+
+	// Tags is the list of tags to filter by
+	Tags []string
+
+	// PostTextFormats is the list of text formats to filter by
+	PostTextFormats []TextFormat
+
+	// TextContains is the text to filter by
+	TextContains string
+
+	// PostHeaderImageTypes is the list of header image type to filter by
+	PostHeaderImageTypes []HeaderImageType
+
+	// PublishedAs is the list of published as aliases to filter by
+	PublishedAs []string
+
+	// CreatedAtFrom is to filter by the date to which the post was created from
+	CreatedAtFrom string
+
+	// CreatedAtTo is to filter by the date to which the post was created up to
+	CreatedAtTo string
+
+	// PublishedAtFrom is to filter by the date which the post was published from
+	PublishedAtFrom string
+
+	// PublishedAtTo is to filter by the date which the post was published up to
+	PublishedAtTo string
+
+	// DeletedAtFrom is to filter by the date which the post was soft deleted from
+	DeletedAtFrom string
+
+	// DeletedAtTo is to filter by the date which the post was soft deleted up to
+	DeletedAtTo string
+
+	// IsDeleted is to filter by posts that are soft deleted
+	IsDeleted bool
+
+	// IsNotDeleted is to filter by posts that are not soft deleted
+	IsNotDeleted bool
+
+	// IsPublished is to filter by posts that have a published date
+	IsPublished bool
+
+	// IsNotPublished is to filter by posts that do not have a published date
+	IsNotPublished bool
+}
+
+// GetPostsRequest holds everything needed to make
+// the request to get post
+type GetPostsRequest struct {
+
+	// Order defines how should response be sorted. Default: newest -> oldest (created_at_desc)
+	// Valid options: created_at_asc, created_at_desc, updated_at_asc, updated_at_desc, deleted_at_asc, deleted_at_desc
+	// puvlished_at_asc, puvlished_at_desc,
+	Order string `query:"order"`
+
+	// Total number of post to return per page, if available. Default 25.
+	// Accepts anything between 1 and 100
+	PerPage int `query:"per_page"`
+
+	// Page specifies the page results should be taken from. Default 1.
+	Page int `query:"page"`
+
+	// TotalCount specifies the total count of all post
+	TotalCount int
+
+	// TotalPages specifies the total pages of results
+	TotalPages int
+
+	// Meta whether response should contain meta information
+	Meta bool `query:"meta"`
+
+	// Title filters for post with the provided title
+	Title string `query:"title"`
+
+	// PublishedWithAlias filters for post with a published alias
+	PublishedWithAlias bool `query:"published_with_alias"`
+
+	// PublishedWithoutAlias filters for post without a published alias
+	PublishedWithoutAlias bool `query:"published_without_alias"`
+
+	// CreatedByIds filters for post from the provided ids
+	// comma-separated list of ids
+	CreatedByIds string `query:"created_by_ids"`
+
+	// UrlFriendlyIds filters for posts from the provided url friendly ids
+	// comma-separated list of ids
+	UrlFriendlyIds string `query:"url_friendly_ids"`
+
+	// WithTypes filters for post with the provided types
+	// comma-separated list of types
+	WithTypes string `query:"with_types"`
+
+	// WithTags filters for post with the provided tags
+	// comma-separated list of tags
+	WithTags string `query:"with_tags"`
+
+	// WithTextFormats filters for post with the provided text format
+	// comma-separated list of text formats
+	WithTextFormats string `query:"with_text_formats"`
+
+	// TextContains filters for post with the provided text
+	TextContains string `query:"text_contains"`
+
+	// WithHeaderImageType filters for post with the provided header image
+	// comma-separated list of text formats
+	WithHeaderImageType string `query:"with_header_image_type"`
+
+	// PublishedAs filters for post with the provided provided as publisher
+	// comma-separated list of publish as aliases
+	PublishedAs string `query:"published_as"`
+
+	// CreatedAtFrom filters for post created at from the provided date
+	CreatedAtFrom string `query:"created_at_from"`
+
+	// CreatedAtTo filters for post created at up to the provided date
+	CreatedAtTo string `query:"created_at_to"`
+
+	// PublishedAtFrom filters for post published at from the provided date
+	PublishedAtFrom string `query:"published_at_from"`
+
+	// PublishedAtTo filters for post published at up to the provided date
+	PublishedAtTo string `query:"published_at_to"`
+
+	// DeletedAtFrom filters for post deleted at from the provided date
+	DeletedAtFrom string `query:"deleted_at_from"`
+
+	// DeletedAtTo filters for post deleted at up to the provided date
+	DeletedAtTo string `query:"deleted_at_to"`
+
+	// IsDeleted filters for post that are deleted
+	IsDeleted bool `query:"is_deleted"`
+
+	// IsNotDeleted filters for post that are not deleted
+	IsNotDeleted bool `query:"is_not_deleted"`
+
+	// IsPublished filters for post that are published
+	IsPublished bool `query:"is_published"`
+
+	// IsNotPublished filters for post that are not published
+	IsNotPublished bool `query:"is_not_published"`
+
+	// EnforceUniqueType when true, ensures only one post per type is returned
+	// When combined with Limit, it limits the total across all types
+	EnforceUniqueType bool `query:"enforce_unique_type"`
+}
+
+// GetMetaData returns a map of metadata about the GetPostsRequest, including the
+// number of resources per page, the total number of resources, the total
+// number of pages, and the current page.
+func (g *GetPostsRequest) GetMetaData() map[string]interface{} {
+	var responseMap = make(map[string]interface{})
+
+	responseMap["resources_per_page"] = g.PerPage
+	responseMap["total_resources"] = g.TotalCount
+	responseMap["total_pages"] = g.TotalPages
+	responseMap["page"] = g.Page
+
+	return responseMap
+}
+
+// CreatePostRequest holds everything needed to make
+// the request to create a post
+//
+//		{
+//			"title": "The state of Blogs in 2025",
+//			"type": "article",
+//			"text": "# Hello\nI love what you've done with this",
+//			"text_format": "markdown",
+//	        "publish_as": "tc"
+//		  }
+type CreatePostRequest struct {
+
+	// UserId is the ID of the user making requests to
+	// create the post on the platform
+	UserId string
+
+	// HeaderImage is the URL or the SVG of the header
+	// image for the post
+	HeaderImage string `json:"header_image,omitempty"`
+
+	// Title is the title of the post
+	Title string `json:"title" validate:"required"`
+
+	// Type is the type of the post
+	Type PostType `json:"type" validate:"required"`
+
+	// Tags is the tags to apply to the post
+	Tags []string `json:"tags,omitempty"`
+
+	// Text is the body of the post
+	Text string `json:"text" validate:"required"`
+
+	// TextFormat is the format the body of the post is written in
+	TextFormat string `json:"text_format,omitempty"`
+
+	// PublishAs is the alias that should be used to
+	// publish the post
+	PublishAs string `json:"publish_as,omitempty"`
+
+	// PublishNow is whether the post should be published immediately
+	PublishNow bool `json:"publish_now,omitempty"`
+
+	// PublishAtUtc is the target publish at date for the post
+	// Should be in the format YYYY-MM-DDThh:mm:ss
+	PublishAtUtc string `json:"publish_at_utc,omitempty"`
+}
+
+// GetChangelogItemsRequest holds everything needed to get
+// changelogs items from repository
+type GetChangelogItemsRequest struct {
+	*GetPostsRequest
+}
+
+// GetGlossaryItemsRequest holds everything needed to get
+// glossary items from repository
+type GetGlossaryItemsRequest struct {
+	*GetPostsRequest
+}
+
+// GetFaqItemsRequest holds everything needed to get
+// faq items from repository
+type GetFaqItemsRequest struct {
+	*GetPostsRequest
+}
+
+// GetArticlesRequest holds everything needed to get
+// articles from repository
+type GetArticlesRequest struct {
+	*GetPostsRequest
+}
+
+// GetLatestPostsByTypeRequest holds everything needed to get
+// the latest posts by type
+type GetLatestPostsByTypeRequest struct {
+
+	// Types is a comma-separated list of post types to retrieve
+	// If empty, defaults to "article,changelog"
+	Types string `query:"types"`
+
+	// Limit is the maximum total number of posts to return across all types
+	// With EnforceUniqueType, this limits the combined result
+	// Default is 5 if not specified
+	Limit int `query:"limit"`
+}
+
+// UpdatePostRequest holds everything needed to make
+// the request to update a post
+//
+//	{
+//		"post_id": "[SOME_UUID]",
+//		"title": "Updated Title",
+//		"text": "Updated content",
+//		"tags": ["updated-tag"]
+//	}
+type UpdatePostRequest struct {
+
+	// UserId is the ID of the user making the request to
+	// update the post on the platform
+	UserId string
+
+	// PostId is the ID of the post to update. This is required
+	// if Post is not provided
+	PostId string
+
+	// Post is the complete post object to update. If provided,
+	// this will be used instead of individual fields
+	Post *Post `json:"post,omitempty"`
+
+	// Title is the updated title of the post
+	Title *string `json:"title,omitempty"`
+
+	// Type is the updated type of the post
+	Type *PostType `json:"type,omitempty"`
+
+	// HeaderImage is the updated URL or SVG of the header image
+	HeaderImage *string `json:"header_image,omitempty"`
+
+	// Tags are the updated tags to apply to the post
+	Tags []string `json:"tags,omitempty"`
+
+	// Text is the updated body of the post
+	Text *string `json:"text,omitempty"`
+
+	// TextFormat is the updated format the body of the post is written in
+	TextFormat *string `json:"text_format,omitempty"`
+
+	// PublishAs is the updated alias that should be used to publish the post
+	PublishAs *string `json:"publish_as,omitempty"`
+
+	// PublishNow is whether the post should be published immediately
+	PublishNow *bool `json:"publish_now,omitempty"`
+
+	// PublishAtUtc is the updated target publish at date for the post
+	// Should be in the format YYYY-MM-DDThh:mm:ss
+	PublishAtUtc *string `json:"publish_at_utc,omitempty"`
+}

--- a/external/post/response.go
+++ b/external/post/response.go
@@ -1,0 +1,112 @@
+package post
+
+import "github.com/ooaklee/ghatd/external/toolbox"
+
+// RestorePostByIdResponse represents the response after restoring a soft deleted post
+type RestorePostByIdResponse struct {
+
+	// Post is the restored post
+	Post *Post
+}
+
+// DeletePostByIdResponse represents the response payload for deleting a post by its ID
+type DeletePostByIdResponse struct {
+
+	// HardDelete indicates whether a hard delete was performed
+	HardDelete bool `json:"hard_delete"`
+}
+
+// CreatePostResponse holds everything needed to return
+// the response to creating a post
+type CreatePostResponse struct {
+
+	// Post is the post that was created
+	Post *Post `json:"post"`
+}
+
+// GetPostsResponse holds everything needed to return
+// the response to get post
+type GetPostsResponse struct {
+	Posts []Post `json:"posts"`
+
+	// Total number of posts found that matched provided
+	// filters
+	Total int
+
+	// TotalPages total pages available, based on the provided
+	// filters and resources per page
+	TotalPages int
+
+	// PerPage number of posts set to be returned per page
+	PerPage int
+
+	// Page specifies the page results were taken from. Default 1.
+	Page int
+}
+
+// GetMetaData returns a map containing metadata about the GetPostsResponse,
+// including the number of resources per page, total resources, total pages,
+// and the current page.
+func (g *GetPostsResponse) GetMetaData() map[string]interface{} {
+	var responseMap = make(map[string]interface{})
+
+	responseMap[string(toolbox.ResponseMetaKeyResourcePerPage)] = g.PerPage
+	responseMap[string(toolbox.ResponseMetaKeyTotalResources)] = g.Total
+	responseMap[string(toolbox.ResponseMetaKeyTotalPages)] = g.TotalPages
+	responseMap[string(toolbox.ResponseMetaKeyPage)] = g.Page
+
+	return responseMap
+}
+
+// GetChangelogItemsResponse holds the response for getting the changelog
+// items response
+type GetChangelogItemsResponse struct {
+	*GetPostsResponse
+}
+
+func (g *GetChangelogItemsResponse) GetEmbeddedPostsResponse() *GetPostsResponse {
+	return g.GetPostsResponse
+}
+
+// GetGlossaryItemsResponse holds the response for getting the glossary
+// items response
+type GetGlossaryItemsResponse struct {
+	*GetPostsResponse
+}
+
+func (g *GetGlossaryItemsResponse) GetEmbeddedPostsResponse() *GetPostsResponse {
+	return g.GetPostsResponse
+}
+
+// GetFaqItemsResponse holds the response for getting the faq
+// items response
+type GetFaqItemsResponse struct {
+	*GetPostsResponse
+}
+
+func (g *GetFaqItemsResponse) GetEmbeddedPostsResponse() *GetPostsResponse {
+	return g.GetPostsResponse
+}
+
+// GetArticlesResponse holds the response for getting the articles response
+type GetArticlesResponse struct {
+	*GetPostsResponse
+}
+
+func (g *GetArticlesResponse) GetEmbeddedPostsResponse() *GetPostsResponse {
+	return g.GetPostsResponse
+}
+
+// GetLatestPostsByTypeResponse holds the response for getting the latest posts by type
+type GetLatestPostsByTypeResponse struct {
+	// Overviews is the list of latest overview posts
+	Overviews []PostOverview `json:"overviews"`
+}
+
+// UpdatePostResponse holds everything needed to return
+// the response to updating a post
+type UpdatePostResponse struct {
+
+	// Post is the post that was updated
+	Post *Post `json:"post"`
+}

--- a/external/post/service.go
+++ b/external/post/service.go
@@ -1,0 +1,820 @@
+package post
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/logger"
+	"github.com/ooaklee/ghatd/external/toolbox"
+	"go.uber.org/zap"
+)
+
+// contenterRepository is the expected methods needed to
+// interact with the database
+type contenterRepository interface {
+	GetTotalPosts(ctx context.Context, req *GetTotalPostsRequest) (int64, error)
+	GetPosts(ctx context.Context, req *GetPostsRequest) ([]Post, error)
+
+	CreatePost(ctx context.Context, newPost *Post) (*Post, error)
+
+	GetPostById(ctx context.Context, id string) (*Post, error)
+	GetPostByUrlFriendlyId(ctx context.Context, urlFriendlyId string) (*Post, error)
+	GetPostByNanoId(ctx context.Context, postNanoId string) (*Post, error)
+
+	GetPostsByIds(ctx context.Context, postIds []string) ([]Post, error)
+	GetPostsByUrlFriendlyIds(ctx context.Context, postUrlFriendlyIds []string) ([]Post, error)
+	GetPostsByNanoIds(ctx context.Context, postNanoIds []string) ([]Post, error)
+
+	UpdatePost(ctx context.Context, post *Post) (*Post, error)
+	DeletePost(ctx context.Context, postId string) error
+	SoftDeletePost(ctx context.Context, post *Post, userId string) error
+}
+
+// Service represents the contenter service
+type Service struct {
+	contenterRepository contenterRepository
+	validChangelogTags  []string
+}
+
+// NewService returns a new instance of the contenter service
+func NewService(contenterRepository contenterRepository, validChangelogTags []string) *Service {
+	return &Service{
+		contenterRepository: contenterRepository,
+		validChangelogTags:  validChangelogTags,
+	}
+}
+
+// CreatePost creates a new post
+func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*CreatePostResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		newPost                 *Post
+		standardiseTitle        string
+		standardisedText        string
+		standardisedPublishedAs string
+		publishedAt             string
+		err                     error
+	)
+
+	logger.Debug("initiating-create-post-request", zap.Any("request", req))
+
+	if req.UserId == "" {
+		logger.Warn("a-user-id-must-be-given-to-create-a-post")
+		return nil, errors.New(ErrKeyUserIdMustBeProvided)
+	}
+
+	if req.PublishAtUtc != "" {
+		standardisedPublishAtUtc := strings.TrimSpace(req.PublishAtUtc)
+		publishedAt, err = s.parsePostPublishTime(standardisedPublishAtUtc, logger)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if req.Title != "" {
+		standardiseTitle = strings.TrimSpace(req.Title)
+	}
+
+	if standardiseTitle == "" {
+		logger.Warn("attempt-made-to-create-post-without-title", zap.Any("request", req))
+		return nil, errors.New(ErrKeyRequiredPostTitleIsMissing)
+	}
+
+	if req.Text != "" {
+		standardisedText = strings.TrimSpace(req.Text)
+	}
+
+	if standardisedText == "" {
+		logger.Warn("attempt-made-to-create-post-without-text", zap.Any("request", req))
+		return nil, errors.New(ErrKeyRequiredPostTextIsMissing)
+	}
+
+	if req.PublishAs != "" {
+		standardisedPublishedAs = strings.TrimSpace(req.PublishAs)
+	}
+
+	standardiseTags := make([]string, len(req.Tags))
+	if len(standardiseTags) > 0 {
+		for i, tag := range req.Tags {
+			standardiseTags[i] = strings.TrimSpace(tag)
+		}
+	}
+	standardiseTags = slices.DeleteFunc(standardiseTags, func(s string) bool {
+		return s == ""
+	})
+
+	newPost = &Post{
+		Title:           standardiseTitle,
+		Text:            standardisedText,
+		PublishedAt:     publishedAt,
+		PublishedAs:     standardisedPublishedAs,
+		CreatedByUserId: req.UserId,
+		Tags:            standardiseTags,
+		HeaderImage:     req.HeaderImage,
+	}
+
+	if req.PublishNow {
+		newPost.PublishedAt = toolbox.TimeNowUTC()
+	}
+
+	if publishedAt != "" || req.PublishNow {
+		newPost.PublishedByUserId = req.UserId
+	}
+
+	newPost = newPost.SetPostType(string(req.Type)).SetPostTextFormat(req.TextFormat)
+
+	// verify that  blog has header image and everything else does not
+	// if blog does not have one provided, bad request
+	if newPost.Type == PostTypeArticle && newPost.HeaderImage == "" {
+		logger.Warn("attempt-made-to-create-post-without-header-image", zap.Any("request", req))
+		return nil, errors.New(ErrKeyHeaderImageMissing)
+	}
+
+	if newPost.Type != PostTypeArticle {
+		newPost.HeaderImage = ""
+	}
+
+	_, err = newPost.SetHeaderImageType()
+	if err != nil {
+		logger.Warn("attempt-made-to-create-post-with-invalid-header-image", zap.Any("request", req))
+		return nil, err
+	}
+	err = newPost.ValidateHeaderImageHasRequiredAltTextAlternativeElementsForInlineSvg()
+	if err != nil {
+		logger.Warn("attempt-made-to-create-post-with-invalid-svg-header-image", zap.Any("request", req))
+		return nil, err
+	}
+
+	// Verify that changelog can only be tagged with valid tag i.e.
+	// announcement, bug-fix, product-news, exciting-news
+	if newPost.Type == PostTypeChangelog && len(s.validChangelogTags) > 0 && len(newPost.Tags) == 0 {
+		logger.Warn("attempt-made-to-create-changelog-post-without-tags", zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", req))
+		return nil, errors.New(ErrKeyChangelogPostMustHaveValidTagsSet)
+	}
+
+	if newPost.Type == PostTypeChangelog && len(s.validChangelogTags) > 0 && len(newPost.Tags) > 0 {
+		invalidTags := []string{}
+		for _, tag := range newPost.Tags {
+			if slices.Contains(s.validChangelogTags, tag) {
+				continue
+			}
+			invalidTags = append(invalidTags, tag)
+		}
+
+		if len(invalidTags) > 0 {
+			logger.Warn("attempt-made-to-create-changelog-post-with-invalid-tags", zap.Strings("invalid-tags", invalidTags), zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", req))
+			return nil, errors.New(ErrKeyChangelogPostMustHaveValidTagsSet)
+		}
+	}
+
+	// generate url friendly id
+	newPost.GenerateUrlFriendlyId()
+
+	// check to make sure url friendly is is not already being used
+	_, err = s.contenterRepository.GetPostByUrlFriendlyId(ctx, newPost.UrlFriendlyId)
+	if err == nil {
+		logger.Warn("attempt-made-to-create-post-with-existing-url-friendly-id", zap.Any("new-post", newPost))
+		return nil, errors.New(ErrKeyPostAlreadyExistsWithGivenUrlFriendlyId)
+	}
+
+	createdPost, err := s.contenterRepository.CreatePost(ctx, newPost)
+	if err != nil {
+		logger.Error("failed-to-create-post-error-creating-post", zap.Any("request", req), zap.Error(err))
+		return &CreatePostResponse{}, err
+	}
+
+	logger.Debug("create-post-request-successful", zap.Any("request", req), zap.Any("created-post", createdPost))
+
+	return &CreatePostResponse{
+		Post: createdPost,
+	}, nil
+}
+
+// GetPosts returns a list of posts
+func (s *Service) GetPosts(ctx context.Context, req *GetPostsRequest) (*GetPostsResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+	)
+
+	// default
+	if req.Order == "" {
+		req.Order = "created_at_desc"
+	}
+
+	if req.PerPage == 0 {
+		req.PerPage = 25
+	}
+
+	if req.Page == 0 {
+		req.Page = 1
+	}
+
+	// get count of all posts
+	getTotalPostsRequest := &GetTotalPostsRequest{
+		Title:                 req.Title,
+		PublishedWithAlias:    req.PublishedWithAlias,
+		PublishedWithoutAlias: req.PublishedWithoutAlias,
+		CreatedByIds:          toolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.CreatedByIds),
+		UrlFriendlyIds:        toolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.UrlFriendlyIds),
+		PostTypes: func(types []string) []PostType {
+			var postsTypes []PostType
+			for _, typ := range types {
+				postsTypes = append(postsTypes, PostType(typ))
+			}
+			return postsTypes
+		}(
+			toolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.WithTypes),
+		),
+		Tags: toolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.WithTags),
+		PostTextFormats: func(types []string) []TextFormat {
+			var postsTextFormat []TextFormat
+			for _, fmt := range types {
+				postsTextFormat = append(postsTextFormat, TextFormat(fmt))
+			}
+			return postsTextFormat
+		}(
+			toolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.WithTextFormats),
+		),
+		TextContains: req.TextContains,
+		PostHeaderImageTypes: func(types []string) []HeaderImageType {
+			var postsHeaderImageType []HeaderImageType
+			for _, headerImg := range types {
+				postsHeaderImageType = append(postsHeaderImageType, HeaderImageType(headerImg))
+			}
+			return postsHeaderImageType
+		}(
+			toolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.WithTextFormats),
+		),
+		PublishedAs:     toolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(req.PublishedAs),
+		CreatedAtFrom:   req.CreatedAtFrom,
+		CreatedAtTo:     req.CreatedAtTo,
+		PublishedAtFrom: req.PublishedAtFrom,
+		PublishedAtTo:   req.PublishedAtTo,
+		DeletedAtFrom:   req.DeletedAtFrom,
+		DeletedAtTo:     req.DeletedAtTo,
+		IsDeleted:       req.IsDeleted,
+		IsNotDeleted:    req.IsNotDeleted,
+		IsPublished:     req.IsPublished,
+		IsNotPublished:  req.IsNotPublished,
+	}
+	totalPosts, err := s.contenterRepository.GetTotalPosts(ctx, getTotalPostsRequest)
+	if err != nil {
+		logger.Error("failed-to-get-posts-request-error-getting-total-posts", zap.Any("request", req), zap.Any("get-total-posts-request", getTotalPostsRequest), zap.Error(err))
+		return &GetPostsResponse{}, err
+	}
+
+	req.TotalCount = int(totalPosts)
+	logger.Debug("handling-get-posts-request-total-posts-found", zap.Int64("total", totalPosts), zap.Any("request", req))
+
+	posts, err := s.contenterRepository.GetPosts(ctx, req)
+	if err != nil {
+		logger.Error("failed-to-get-posts-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		return &GetPostsResponse{}, err
+	}
+
+	paginatedResponse, err := toolbox.Paginate(ctx, &toolbox.PaginationRequest{
+		PerPage: req.PerPage,
+		Page:    req.Page,
+	}, posts, req.TotalCount)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetPostsResponse{
+		Total:      paginatedResponse.Total,
+		TotalPages: paginatedResponse.TotalPages,
+		Posts:      paginatedResponse.Resources,
+		Page:       paginatedResponse.Page,
+		PerPage:    paginatedResponse.ResourcePerPage,
+	}, nil
+
+}
+
+// GetPostByUrlFriendlyId returns a post by its
+// url friendly id
+// TODO: how should we handle when target post is soft deleted?
+// normal users should not see this
+func (s *Service) GetPostByUrlFriendlyId(ctx context.Context, urlFriendlyId string) (*Post, error) {
+	return s.contenterRepository.GetPostByUrlFriendlyId(ctx, urlFriendlyId)
+}
+
+// GetChangelogItems returns a list of changelog post
+func (s *Service) GetChangelogItems(ctx context.Context, req *GetChangelogItemsRequest) (*GetChangelogItemsResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+	)
+
+	logger.Debug("handling-get-changelog-items-request", zap.Any("request", req))
+
+	req.GetPostsRequest.WithTypes = string(PostTypeChangelog)
+
+	retrievedPosts, err := s.GetPosts(ctx, req.GetPostsRequest)
+	if err != nil {
+		logger.Error("failed-to-get-changelog-items-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		return nil, err
+	}
+
+	return &GetChangelogItemsResponse{
+		GetPostsResponse: retrievedPosts,
+	}, nil
+
+}
+
+// GetGlossaryItems returns a list of glossary post
+func (s *Service) GetGlossaryItems(ctx context.Context, req *GetGlossaryItemsRequest) (*GetGlossaryItemsResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+	)
+
+	logger.Debug("handling-get-glossary-items-request", zap.Any("request", req))
+
+	req.GetPostsRequest.WithTypes = string(PostTypeGlossary)
+
+	retrievedPosts, err := s.GetPosts(ctx, req.GetPostsRequest)
+	if err != nil {
+		logger.Error("failed-to-get-glossary-items-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		return nil, err
+	}
+
+	return &GetGlossaryItemsResponse{
+		GetPostsResponse: retrievedPosts,
+	}, nil
+
+}
+
+// GetFaqItems returns a list of faq post
+func (s *Service) GetFaqItems(ctx context.Context, req *GetFaqItemsRequest) (*GetFaqItemsResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+	)
+
+	logger.Debug("handling-get-faq-items-request", zap.Any("request", req))
+
+	req.GetPostsRequest.WithTypes = string(PostTypeFaq)
+
+	retrievedPosts, err := s.GetPosts(ctx, req.GetPostsRequest)
+	if err != nil {
+		logger.Error("failed-to-get-faq-items-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		return nil, err
+	}
+
+	return &GetFaqItemsResponse{
+		GetPostsResponse: retrievedPosts,
+	}, nil
+
+}
+
+// GetArticles returns a list of article posts
+func (s *Service) GetArticles(ctx context.Context, req *GetArticlesRequest) (*GetArticlesResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+	)
+
+	logger.Debug("handling-get-articles-request", zap.Any("request", req))
+
+	req.GetPostsRequest.WithTypes = string(PostTypeArticle)
+
+	retrievedPosts, err := s.GetPosts(ctx, req.GetPostsRequest)
+	if err != nil {
+		logger.Error("failed-to-get-articles-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		return nil, err
+	}
+
+	return &GetArticlesResponse{
+		GetPostsResponse: retrievedPosts,
+	}, nil
+
+}
+
+// UpdatePost updates an existing post
+func (s *Service) UpdatePost(ctx context.Context, req *UpdatePostRequest) (*UpdatePostResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+
+		postToUpdate        *Post
+		err                 error
+		publishedAt         string
+		urlFriendlyIdChange bool
+	)
+
+	logger.Debug("initiating-update-post-request", zap.Any("request", req))
+
+	if req.UserId == "" {
+		logger.Warn("a-user-id-must-be-given-to-update-a-post")
+		return nil, errors.New(ErrKeyUserIdMustBeProvided)
+	}
+
+	// If a complete Post object is provided, use it
+	if req.Post != nil {
+		postToUpdate = req.Post
+
+		// Verify the post exists
+		existingPost, err := s.contenterRepository.GetPostById(ctx, postToUpdate.Id)
+		if err != nil {
+			logger.Warn("attempt-made-to-update-non-existent-post", zap.String("post-id", postToUpdate.Id), zap.Error(err))
+			return nil, errors.New(ErrKeyPostNotFoundForUpdate)
+		}
+
+		// Prevent updating deleted posts
+		if existingPost.DeletedAt != "" {
+			logger.Warn("attempt-made-to-update-deleted-post", zap.String("post-id", postToUpdate.Id))
+			return nil, errors.New(ErrKeyPostUpdateAttemptOnDeletedPost)
+		}
+
+	} else {
+		// Otherwise, fetch the post by ID and apply individual field updates
+		if req.PostId == "" {
+			logger.Warn("attempt-made-to-update-post-without-post-id-or-post-object")
+			return nil, errors.New(ErrKeyIdIsRequired)
+		}
+
+		postToUpdate, err = s.contenterRepository.GetPostById(ctx, req.PostId)
+		if err != nil {
+			logger.Warn("attempt-made-to-update-non-existent-post", zap.String("post-id", req.PostId), zap.Error(err))
+			return nil, errors.New(ErrKeyPostNotFoundForUpdate)
+		}
+
+		// Prevent updating deleted posts
+		if postToUpdate.DeletedAt != "" {
+			logger.Warn("attempt-made-to-update-deleted-post", zap.String("post-id", req.PostId))
+			return nil, errors.New(ErrKeyPostUpdateAttemptOnDeletedPost)
+		}
+
+		originalTitle := postToUpdate.Title
+
+		// Apply individual field updates
+		if req.Title != nil {
+			postToUpdate.Title = strings.TrimSpace(*req.Title)
+		}
+
+		if req.Text != nil {
+			postToUpdate.Text = strings.TrimSpace(*req.Text)
+		}
+
+		if req.Type != nil {
+			postToUpdate.SetPostType(string(*req.Type))
+		}
+
+		if req.TextFormat != nil {
+			postToUpdate.SetPostTextFormat(*req.TextFormat)
+		}
+
+		if req.HeaderImage != nil {
+			postToUpdate.HeaderImage = strings.TrimSpace(*req.HeaderImage)
+		}
+
+		if req.PublishAs != nil {
+			postToUpdate.PublishedAs = strings.TrimSpace(*req.PublishAs)
+		}
+
+		if req.Tags != nil {
+			standardiseTags := make([]string, len(req.Tags))
+			for i, tag := range req.Tags {
+				standardiseTags[i] = strings.TrimSpace(tag)
+			}
+			standardiseTags = slices.DeleteFunc(standardiseTags, func(s string) bool {
+				return s == ""
+			})
+			postToUpdate.Tags = standardiseTags
+		}
+
+		if req.PublishAtUtc != nil && *req.PublishAtUtc != "" {
+			standardisedPublishAtUtc := strings.TrimSpace(*req.PublishAtUtc)
+			publishedAt, err = s.parsePostPublishTime(standardisedPublishAtUtc, logger)
+			if err != nil {
+				return nil, err
+			}
+
+			postToUpdate.PublishedAt = publishedAt
+		}
+
+		if req.PublishNow != nil && *req.PublishNow {
+			postToUpdate.PublishedAt = toolbox.TimeNowUTC()
+			postToUpdate.PublishedByUserId = req.UserId
+		}
+
+		// Check if title changed (which affects URL friendly ID)
+		if originalTitle != postToUpdate.Title {
+			urlFriendlyIdChange = true
+		}
+	}
+
+	// Validate title is not empty
+	if strings.TrimSpace(postToUpdate.Title) == "" {
+		logger.Warn("attempt-made-to-update-post-with-empty-title", zap.Any("request", req))
+		return nil, errors.New(ErrKeyRequiredPostTitleIsMissing)
+	}
+
+	// Validate text is not empty
+	if strings.TrimSpace(postToUpdate.Text) == "" {
+		logger.Warn("attempt-made-to-update-post-with-empty-text", zap.Any("request", req))
+		return nil, errors.New(ErrKeyRequiredPostTextIsMissing)
+	}
+
+	// Validate header image requirements for articles
+	if postToUpdate.Type == PostTypeArticle && postToUpdate.HeaderImage == "" {
+		logger.Warn("attempt-made-to-update-article-post-without-header-image", zap.Any("request", req))
+		return nil, errors.New(ErrKeyHeaderImageMissing)
+	}
+
+	if postToUpdate.Type != PostTypeArticle {
+		postToUpdate.HeaderImage = ""
+	}
+
+	// Validate header image type and accessibility
+	if postToUpdate.HeaderImage != "" {
+		_, err = postToUpdate.SetHeaderImageType()
+		if err != nil {
+			logger.Warn("attempt-made-to-update-post-with-invalid-header-image", zap.Any("request", req))
+			return nil, err
+		}
+		err = postToUpdate.ValidateHeaderImageHasRequiredAltTextAlternativeElementsForInlineSvg()
+		if err != nil {
+			logger.Warn("attempt-made-to-update-post-with-invalid-svg-header-image", zap.Any("request", req))
+			return nil, err
+		}
+	}
+
+	// Verify changelog tags if applicable
+	if postToUpdate.Type == PostTypeChangelog && len(s.validChangelogTags) > 0 && len(postToUpdate.Tags) == 0 {
+		logger.Warn("attempt-made-to-update-changelog-post-without-tags", zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", req))
+		return nil, errors.New(ErrKeyChangelogPostMustHaveValidTagsSet)
+	}
+
+	if postToUpdate.Type == PostTypeChangelog && len(s.validChangelogTags) > 0 && len(postToUpdate.Tags) > 0 {
+		invalidTags := []string{}
+		for _, tag := range postToUpdate.Tags {
+			if slices.Contains(s.validChangelogTags, tag) {
+				continue
+			}
+			invalidTags = append(invalidTags, tag)
+		}
+
+		if len(invalidTags) > 0 {
+			logger.Warn("attempt-made-to-update-changelog-post-with-invalid-tags", zap.Strings("invalid-tags", invalidTags), zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", req))
+			return nil, errors.New(ErrKeyChangelogPostMustHaveValidTagsSet)
+		}
+	}
+
+	// Regenerate URL friendly ID if title changed
+	if urlFriendlyIdChange {
+		oldUrlFriendlyId := postToUpdate.UrlFriendlyId
+		postToUpdate.GenerateUrlFriendlyId()
+
+		// Check if new URL friendly ID conflicts with another post
+		if oldUrlFriendlyId != postToUpdate.UrlFriendlyId {
+			_, err = s.contenterRepository.GetPostByUrlFriendlyId(ctx, postToUpdate.UrlFriendlyId)
+			if err == nil {
+				logger.Warn("attempt-made-to-update-post-with-existing-url-friendly-id", zap.String("new-url-friendly-id", postToUpdate.UrlFriendlyId))
+				return nil, errors.New(ErrKeyPostAlreadyExistsWithGivenUrlFriendlyId)
+			}
+		}
+	}
+
+	// Set update metadata
+	postToUpdate.UpdatedByUserId = req.UserId
+	postToUpdate.SetUpdatedAtTimeToNow()
+
+	updatedPost, err := s.contenterRepository.UpdatePost(ctx, postToUpdate)
+	if err != nil {
+		logger.Error("failed-to-update-post-error-updating-post", zap.Any("request", req), zap.Error(err))
+		return &UpdatePostResponse{}, err
+	}
+
+	logger.Debug("update-post-request-successful", zap.Any("request", req), zap.Any("updated-post", updatedPost))
+
+	return &UpdatePostResponse{
+		Post: updatedPost,
+	}, nil
+}
+
+// parsePostPublishTime parses and standardises the publish time for a post's published at field
+func (s *Service) parsePostPublishTime(publishAtUtc string, logger *zap.Logger) (string, error) {
+
+	parsedPublishAtTime, err := time.Parse("2006-01-02T15:04:05", publishAtUtc)
+	if err != nil {
+		logger.Warn("invalid-publish-at-format-provided", zap.String("raw-publish-at", publishAtUtc))
+		return "", errors.New(ErrKeyInvalidPostPublishedAtProvided)
+	}
+
+	publishedAt := parsedPublishAtTime.UTC().Format(common.RFC3339NanoUTC)
+
+	// if publishedAt matches regex for "2006-01-02T15:04:05", I want to manually add
+	// .999999999
+	if len(publishedAt) == 19 {
+		publishedAt = publishedAt + ".999999999"
+	}
+
+	return publishedAt, nil
+}
+
+// GetLatestPostsByType returns the latest posts by the given types
+// This is a convenience method to get the latest PUBLISHED posts for multiple types in one call, allowing for more efficient retrieval of content
+// The posts should not be soft deleted either and not published in the future
+func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsByTypeRequest) (*GetLatestPostsByTypeResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+	)
+
+	logger.Debug("handling-get-latest-posts-by-type-request", zap.Any("request", req))
+
+	// Default to article,changelog if no types specified
+	types := req.Types
+	if types == "" {
+		types = "article,changelog"
+	}
+
+	// Default limit to 5 if not specified or invalid
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 5
+	}
+
+	// Parse the comma-separated types
+	typesList := toolbox.SplitCommaSeparatedStringAndRemoveEmptyStrings(types)
+	if len(typesList) == 0 {
+		logger.Warn("no-valid-types-provided-after-parsing")
+		return nil, errors.New(ErrKeyRequiredPostTypeIsMissing)
+	}
+
+	// Create request to get posts with unique type enforcement
+	getPostsReq := &GetPostsRequest{
+		WithTypes:         types,
+		IsPublished:       true,
+		IsNotDeleted:      true,
+		Order:             "published_at_desc",
+		PerPage:           limit,
+		Page:              1,
+		EnforceUniqueType: true,
+	}
+
+	// Get posts with unique type enforcement
+	retrievedPosts, err := s.GetPosts(ctx, getPostsReq)
+	if err != nil {
+		logger.Error("failed-to-get-latest-posts-by-type-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		return nil, err
+	}
+
+	var postOverviews []PostOverview
+
+	// // Organise posts by type
+	// postsByType := make(map[string][]Post)
+	// for _, post := range retrievedPosts.Posts {
+	// 	postsByType[string(post.Type)] = append(postsByType[string(post.Type)], post)
+	// }
+
+	for _, post := range retrievedPosts.Posts {
+		postOverviews = append(postOverviews, *post.ToOverview())
+	}
+
+	logger.Debug("retrieved-posts-by-type", zap.Int("total-posts", len(retrievedPosts.Posts)), zap.Int("unique-types", len(postOverviews)))
+
+	logger.Debug("get-latest-posts-by-type-request-successful", zap.Any("request", req), zap.Int("types-count", len(postOverviews)))
+
+	return &GetLatestPostsByTypeResponse{
+		Overviews: postOverviews,
+	}, nil
+}
+
+// DeletePostById deletes a post by its ID
+func (s *Service) DeletePostById(ctx context.Context, req *DeletePostByIdRequest) (*DeletePostByIdResponse, error) {
+
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+		response *DeletePostByIdResponse = &DeletePostByIdResponse{}
+	)
+	logger.Debug("handling-delete-post-by-id-request", zap.Any("request", req))
+
+	if req.Id == "" {
+		logger.Warn("attempt-made-to-delete-post-without-post-id")
+		return nil, errors.New(ErrKeyIdIsRequired)
+	}
+
+	if req.UserId == "" {
+		logger.Warn("a-user-id-must-be-given-to-delete-a-post")
+		return nil, errors.New(ErrKeyUserIdMustBeProvided)
+	}
+
+	// Perform soft delete
+	postToDelete, err := s.contenterRepository.GetPostById(ctx, req.Id)
+	if err != nil {
+		logger.Warn("attempt-made-to-delete-non-existent-post", zap.String("post-id", req.Id), zap.Error(err))
+		return nil, errors.New(ErrKeyResourceNotFound)
+	}
+
+	if req.HardDelete {
+		// Perform hard delete
+		err := s.contenterRepository.DeletePost(ctx, postToDelete.Id)
+		if err != nil {
+			logger.Error("failed-to-delete-post-error-deleting-post", zap.Any("request", req), zap.Error(err))
+			return nil, err
+		}
+		response.HardDelete = true
+	} else {
+		// Prevent soft deleting an already deleted post
+		if postToDelete.DeletedAt != "" {
+			logger.Warn("attempt-made-to-soft-delete-already-deleted-post", zap.String("post-id", postToDelete.Id))
+			return nil, errors.New(ErrKeyPostAlreadySoftDeleted)
+		}
+
+		err = s.contenterRepository.SoftDeletePost(ctx, postToDelete, req.UserId)
+		if err != nil {
+			logger.Error("failed-to-soft-delete-post-error-soft-deleting-post", zap.Any("request", req), zap.Error(err))
+			return nil, err
+		}
+		response.HardDelete = false
+	}
+
+	logger.Debug("delete-post-by-id-request-successful", zap.Any("request", req))
+
+	return response, nil
+}
+
+// RestorePostById restores a soft deleted post by its ID
+func (s *Service) RestorePostById(ctx context.Context, req *RestorePostByIdRequest) (*RestorePostByIdResponse, error) {
+	var (
+		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+			zap.AddStacktrace(zap.DPanicLevel),
+		)
+	)
+
+	logger.Debug("handling-restore-post-by-id-request", zap.Any("request", req))
+
+	if req.Id == "" {
+		logger.Warn("attempt-made-to-restore-post-without-post-id")
+		return nil, errors.New(ErrKeyIdIsRequired)
+	}
+
+	if req.UserId == "" {
+		logger.Warn("a-user-id-must-be-given-to-restore-a-post")
+		return nil, errors.New(ErrKeyUserIdMustBeProvided)
+	}
+
+	postToRestore, err := s.contenterRepository.GetPostById(ctx, req.Id)
+	if err != nil {
+		logger.Warn("attempt-made-to-restore-non-existent-post", zap.String("post-id", req.Id), zap.Error(err))
+		return nil, errors.New(ErrKeyResourceNotFound)
+	}
+
+	if postToRestore.DeletedAt == "" {
+		logger.Warn("attempt-made-to-restore-a-post-that-is-not-deleted", zap.String("post-id", req.Id))
+		return &RestorePostByIdResponse{
+			Post: postToRestore,
+		}, nil
+	}
+
+	postToRestore.DeletedAt = ""
+	postToRestore.DeletedByUserId = ""
+
+	postToRestore.UpdatedByUserId = req.UserId
+	postToRestore.SetUpdatedAtTimeToNow()
+
+	// Remove any publish metadata so that it has to be explicitly republished
+	postToRestore.PublishedAt = ""
+	postToRestore.PublishedByUserId = ""
+
+	restoredPost, err := s.contenterRepository.UpdatePost(ctx, postToRestore)
+	if err != nil {
+		logger.Error("failed-to-restore-post-error-restoring-post", zap.Any("request", req), zap.Error(err))
+		return nil, err
+	}
+
+	logger.Info("restore-post-by-id-request-successful", zap.Any("request", req), zap.Any("restored-post", restoredPost))
+
+	return &RestorePostByIdResponse{
+		Post: restoredPost,
+	}, nil
+
+}

--- a/external/post/utils.go
+++ b/external/post/utils.go
@@ -1,0 +1,13 @@
+package post
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// GenerateSha256Hash creates a SHA-256 hash of the input string
+func GenerateSha256Hash(input string) string {
+	hash := sha256.New()
+	hash.Write([]byte(input))
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}

--- a/external/toolbox/errormap.go
+++ b/external/toolbox/errormap.go
@@ -1,0 +1,9 @@
+package toolbox
+
+import "github.com/ooaklee/reply"
+
+// ToolboxErrorMap holds Error keys, their corresponding human-friendly message, and response status code
+var ToolboxErrorMap reply.ErrorManifest = reply.ErrorManifest{
+	ErrKeyPageOutOfRange:     {Title: "Bad Request", Detail: "Page out of range", StatusCode: 400, Code: "TLB-001"},
+	ErrKeyMissingUriVariable: {Title: "Bad Request", Detail: "Missing URI variable", StatusCode: 400, Code: "TLB-002"},
+}

--- a/external/toolbox/paginator.go
+++ b/external/toolbox/paginator.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ettle/strcase"
 	"github.com/ooaklee/ghatd/external/logger"
-	"github.com/ooaklee/reply"
 	"go.uber.org/zap"
 )
 
@@ -15,11 +14,6 @@ const (
 	// ErrKeyPageOutOfRange returned when requested page is out of range
 	ErrKeyPageOutOfRange string = "PageOutOfRange"
 )
-
-// GetResourcePaginationErrorMap holds Error keys, their corresponding human-friendly message, and response status code
-var GetResourcePaginationErrorMap reply.ErrorManifest = map[string]reply.ErrorManifestItem{
-	ErrKeyPageOutOfRange: {Title: "Bad Request", Detail: "Page out of range", StatusCode: 400, Code: "TLBPG-001"},
-}
 
 // ResponseMetaKey is a string type used as the keys in the map returned
 // by requests

--- a/external/toolbox/regex.go
+++ b/external/toolbox/regex.go
@@ -1,5 +1,7 @@
 package toolbox
 
+import "regexp"
+
 // ExampleEmailAddressDomainRegex regex pattern for the an example email address domain
 const ExampleEmailAddressDomainRegex string = ".*@example.io$"
 
@@ -18,3 +20,11 @@ const Base64EncodedRegex string = "^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-
 
 // UserRoleIdSuffixRegex is the pattern used when versioning the different roles (from payment integrators)
 const UserRoleIdSuffixRegex string = "(__[0-9]+)"
+
+// NonAlphanumericRegexEnglishAlphabetStringsRegex is the regex for pulling non alphanumeric characters
+// from english based alphabet strings
+var NonAlphanumericRegexEnglishAlphabetStringsRegex = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
+
+// NonAlphanumericRegexNonEnglishAlphabetStringsRegex is the regex for pulling non alphanumeric characters
+// from non-english based alphabet strings
+var NonAlphanumericRegexNonEnglishAlphabetStringsRegex = regexp.MustCompile(`[^\p{L}\p{N} ]+`)

--- a/external/toolbox/toolbox.go
+++ b/external/toolbox/toolbox.go
@@ -512,3 +512,46 @@ func SplitCommaSeparatedStringAndRemoveEmptyStrings(str string) []string {
 	}
 	return result
 }
+
+// StringConvertToLowerSnakeCase converts a string to lowercase snake case by
+// trimming whitespace, removing special characters, converting to lowercase,
+// and replacing spaces with underscores.
+func StringConvertToLowerSnakeCase(text string) (string, error) {
+
+	// Trim string
+	text = strings.TrimSpace(text)
+
+	// Remove all the special characters
+	reg, err := regexp.Compile(`[^a-zA-Z0-9\\s]+`)
+	if err != nil {
+		return "", err
+	}
+	cleanedText := reg.ReplaceAllString(text, " ")
+
+	// Make sure it's lower case and remove double space
+	cleanedText = strings.ToLower(
+		StringRemoveMultiSpace(
+			cleanedText,
+		),
+	)
+
+	// Remove Spaces for hyphen
+	cleanedText = strings.ReplaceAll(cleanedText, " ", "_")
+
+	return cleanedText, nil
+}
+
+// StandardisedTypesAsStrings takes a slice of strings representing types and
+// returns a new slice with each type string converted to lowercase and with
+// spaces replaced by hyphens.
+func StandardisedTypesAsStrings[T ~string](types []T) []string {
+	standardisedTypes := []string{}
+	for _, typ := range types {
+		standardisedTypes = append(standardisedTypes, strings.ReplaceAll(
+			strings.ToLower(string(typ)),
+			" ",
+			"-",
+		))
+	}
+	return standardisedTypes
+}


### PR DESCRIPTION
### Context:

This PR introduces the `post` / `contentmanager` into the main package so that the API can serve up blog articles, FAQs, and more.


### What has been done:

- add new `contentmanager` package
- add new `post` package
- add/update toolbox helpers (regex, paginator, uri/error handling support)
  - wire supporting constants and error maps

### ADR

- **Separate `post` (storage) from `contentmanager` (business logic)** - Allows future content types to reuse the post repository while maintaining domain-specific business logic in dedicated managers.

- **Admin-only write, public read** - Content creation/updates require admin auth; published content is world-readable. Non-published content remains invisible to unauthenticated requests.

- **Slug-based content routing** - Human-readable, SEO-friendly URIs (e.g. `/api/v1/cms/articles/how-to-make-content`) instead of MongoDB IDs. Slugs are validated and sanitised on creation.

- **Tags for content organisation** - A flexible tagging system allows content to be categorised without rigid hierarchies. Supports multi-tag filtering and discovery.
