### PR TITLE
[GHATD-X] Add refresh-token rotation with lock-based replay cache and login-email cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ GHAT(D) supports a dual-channel verification flow for login and email verificati
 | **Auto-blocking** | IPs exceeding the threshold are temporarily blocked (default: 1 hour) |
 | **One-time use** | Codes and tokens are invalidated after successful verification |
 | **Time-bounded** | All codes and tokens have TTLs (default: 10 minutes for login/verification) |
+| **Refresh rotation tolerance** | Near-concurrent duplicate refreshes can reuse the winning rotation result instead of consuming the same refresh token twice |
+| **Login email cooldown** | Duplicate login email sends for the same active user/context are suppressed during a short cooldown window |
 | **Audit logging** | All verification attempts (pass and fail) and rate-limit blocks are logged for monitoring |
 | **Rate-limit response** | Blocked IPs receive HTTP 429 with `EPH0-002` — no information leakage |
 

--- a/docs/adr/adr008-refresh-rotation-and-login-email-cooldown.md
+++ b/docs/adr/adr008-refresh-rotation-and-login-email-cooldown.md
@@ -1,0 +1,94 @@
+---
+id: adrs-adr008
+title: 'ADR008: Refresh Rotation and Login Email Cooldown'
+# prettier-ignore
+description: Architecture Decision Record (ADR) for tolerating near-concurrent refresh-token rotation and suppressing duplicate login email sends
+date: 2026-05-21
+status: accepted
+---
+
+## Status
+
+Accepted.
+
+## Context
+
+Access Manager uses short-lived access tokens and longer-lived refresh tokens
+stored in `HttpOnly` cookies. When an access token expires, middleware or a
+client refresh call can rotate the refresh token and issue a new token pair.
+
+Refresh-token rotation is intentionally one-time use. That improves replay
+resistance, but browser applications can naturally create near-concurrent
+refresh attempts: multiple tabs resume at once, a service worker and foreground
+request both discover expiry, or several protected requests leave the browser
+while the access-token cookie is stale.
+
+Without coordination, the first refresh request consumes the old refresh token
+and later requests fail even though they are part of the same user-visible
+session recovery. That can sign users out after ordinary idle/resume behavior.
+
+Passwordless login has a related user-experience and quota problem. Login
+initiation returns an accepted response before the user verifies the email. If
+a client keeps the submit action available, repeated clicks can send repeated
+emails for the same user and return URL. This is noisy for users and wasteful
+for email providers.
+
+## Decision
+
+Access Manager will make refresh-token rotation tolerant of near-concurrent
+duplicates by adding a Redis-backed lock and replay result:
+
+1. A refresh request validates the refresh cookie and derives the user ID plus
+   refresh-token UUID.
+2. The service checks for a short-lived cached rotation result for that
+   user/token pair.
+3. If no result exists, the request attempts to acquire a short-lived rotation
+   lock.
+4. The lock winner consumes the old refresh token, creates the replacement
+   token pair, stores the new auth state, and stores a short-lived replay
+   result.
+5. A duplicate request that does not get the lock waits briefly for the replay
+   result and returns it when available.
+6. If no replay result appears before the wait expires, the duplicate request
+   fails and the client should resolve the session through the normal `/me`
+   probe or login flow.
+
+Middleware that refreshes during protected-route handling will update the
+request with the replacement access token and retry validation before writing
+replacement cookies. Refreshed cookies are committed only when retry
+validation succeeds.
+
+Access Manager will also suppress duplicate login email sends for active users
+within a short cooldown window. The cooldown key is scoped by user ID,
+dashboard flag, and a hash of the requested return URL. If the cooldown is
+already active, the service returns without sending another email. If token
+setup or email delivery fails before the email is accepted, the cooldown is
+released so a later retry can send a new email.
+
+Host applications should still keep their login forms disciplined: disable the
+submit button while the login request is in flight, treat any successful `2xx`
+login-initiation response as "check your email", and keep the form locked once
+the request is accepted.
+
+## Consequences
+
+Users are less likely to be signed out by ordinary idle/resume behavior or by
+multiple requests discovering token expiry at the same time.
+
+Refresh-token one-time-use semantics remain intact. Only the lock winner
+consumes the old refresh token; duplicates receive a short-lived replay of the
+winner's replacement token pair.
+
+The design adds a small Redis dependency surface: `SETNX` locks, replay
+payload storage, and cooldown keys. Ephemeral store implementations must
+provide the same semantics if they replace the Redis store.
+
+The replay window and wait timeout are intentionally short. They reduce common
+browser races without making consumed refresh tokens broadly reusable.
+
+Login email quota usage is protected at the server boundary, while clients
+remain responsible for presenting a stable check-email transition.
+
+Cooldown scoping by hashed return URL avoids storing raw return paths in Redis
+keys while still letting legitimately different login contexts send their own
+email.

--- a/docs/getting-started/access-manager/README.md
+++ b/docs/getting-started/access-manager/README.md
@@ -37,6 +37,16 @@ Cookie attributes come from the handler configuration:
 
 Browser clients should use credentialed requests, such as Axios `withCredentials: true`, and native clients should use a persistent cookie jar. Clients do not need to store JWTs themselves. To resolve the current session, call `GET /api/v1/ums/me`; a `200` response means the cookie session is usable, while `401` or `403` should clear local user state and send the user through the login flow again.
 
+## Refresh Rotation Tolerance
+
+Access Manager treats refresh-token rotation as a one-winner operation. The first request that validates a refresh token claims a short-lived rotation lock, consumes the old refresh token, creates the replacement access and refresh tokens, and stores a short-lived replay result in ephemeral storage.
+
+Near-concurrent duplicate refreshes for the same user and refresh token do not rotate a second time. They first check for an existing replay result, then wait briefly when another request already holds the lock. If the winning request completes, the duplicate receives the same replacement token pair. If no result appears before the wait expires, the duplicate is rejected and the client should resolve the session again through the normal `/me` probe or login flow.
+
+Middleware refreshes also validate the retried request before writing replacement cookies to the response. This avoids committing cookies for a token pair that the protected route would immediately reject.
+
+Clients should still avoid intentionally fanning out refresh calls, but host applications do not need every tab, worker, and retry path to serialize perfectly. The server tolerates the common browser race where multiple requests discover an expired access-token cookie at nearly the same time.
+
 ## Dual-Channel Verification
 
 The access manager supports a dual-channel verification flow: users receive both a **magic link** (with a JWT token) and an **8-character alphanumeric verification code** in the same login or verification email. Some apps label this manual-entry value as a secret code.
@@ -70,6 +80,10 @@ Use verification type `2` when the client is tracking a pending signup or email-
 6. The user clicks `/v0/auth/verify?type=1&__t=<token>&request_url=<path>`.
 7. The bridge redirects to `/api/v1/ams/login?t=<token>&next_step=<frontend-url>`.
 8. Access Manager validates the login token, creates an authenticated session, stores it in ephemeral storage, invalidates the initial login token, sets auth cookies, and returns `200 OK` or redirects to `next_step`.
+
+For an active user, duplicate login-initiation requests for the same user, dashboard flag, and requested return URL are suppressed for a short cooldown window. The API still preserves its non-enumerating response behavior, but only the first accepted request should send an email. If token setup or email delivery fails before the email is accepted, the cooldown is released so a retry can send a new email.
+
+Client login forms should treat any successful `2xx` response from `POST /api/v1/ams/login` as "check your email", disable duplicate submits while the request is in flight, and keep the form locked once the request is accepted. This protects email quotas and gives users a stable transition to the check-email screen.
 
 Use verification type `1` when the client is tracking a pending login email.
 
@@ -107,6 +121,8 @@ For an app-facing checklist that applies these flows from a client perspective, 
 | **Brute-force protection** | `HardenedRateLimitProtection` middleware tracks attempts per IP and per code within a configurable window (default: 5/hr per IP, 5/hr per code) |
 | **Auto-blocking** | IPs exceeding the threshold are temporarily blocked (default: 1 hour) |
 | **One-time use** | Codes and tokens are invalidated after successful verification |
+| **Refresh rotation tolerance** | One request rotates a refresh token while short-lived replay results tolerate near-concurrent duplicate refreshes |
+| **Login email cooldown** | Duplicate login email sends for the same active user/context are suppressed during a short cooldown window |
 | **Audit logging** | All verification attempts and rate-limit blocks are logged for monitoring |
 | **Rate-limit response** | Blocked IPs receive HTTP 429 with `EPH0-002` — no information leakage |
 

--- a/docs/how-to/authenticating-the-app.md
+++ b/docs/how-to/authenticating-the-app.md
@@ -48,6 +48,8 @@ Also keep the auth-initiation statuses separate from session-probe statuses:
 
 Neither status means the client is authenticated yet. Only the later magic-link or code verification response establishes the cookie session.
 
+For login initiation, treat any successful `2xx` response from `POST /api/v1/ams/login` as an accepted request and navigate the user to the check-email screen. Access Manager may suppress duplicate email sends for the same active user and request context during a short cooldown window, so retrying the same request repeatedly is not a useful user action. Keep the submit button disabled while the request is in flight, and keep it locked after the accepted response while the app transitions to the check-email route.
+
 For protected browser routes, preserve the intended destination in a `request_url` query value, such as `/auth/login?request_url=/app/projects`. Pass the same path to `POST /api/v1/ams/login` or `POST /api/v1/ams/signup` so email links can return the user to the right place.
 
 ## Email Magic Link
@@ -122,6 +124,10 @@ Clients can also call the explicit refresh endpoint when they need to rotate bef
 ```http
 POST /api/v1/ams/tokens/refresh
 ```
+
+Refresh-token rotation is tolerant of near-concurrent duplicate requests. The first valid request consumes the old refresh token and stores a short-lived replay result; duplicate requests for the same token can reuse that result instead of failing simply because another tab or request won the race. Middleware writes replacement cookies only after the retried protected request accepts the refreshed access token.
+
+Clients should still use `/api/v1/ums/me` as the source of truth after refresh uncertainty. If a refresh call fails or a protected request still returns an auth error, clear local session state and route through login rather than looping refresh attempts.
 
 For logout, clear local user state first, then call:
 

--- a/external/accessmanager/middleware/README.md
+++ b/external/accessmanager/middleware/README.md
@@ -36,3 +36,15 @@ usermanager.AttachRoutes(&usermanager.AttachRoutesRequest{
 When `ErrorMaps` is nil, `NewSuite` uses `bundles.AuthMiddleware()` as the
 default error map set. Pass a non-nil `ErrorMaps` slice, including an empty
 slice, to fully own the error mapping used by the suite.
+
+## Refresh Cookie Timing
+
+`JWTRequired` and `RateLimitOrActiveJWTRequired` can refresh an expired access
+token when the request still includes a valid refresh-token cookie. The
+middleware updates the request with the new access token, retries validation,
+and only then writes replacement auth cookies to the response.
+
+This keeps cookie state aligned with route authorization. If refresh succeeds
+but retry validation rejects the replacement access token, the response does
+not commit the new cookies and the client can fall back to its normal session
+probe or login flow.

--- a/external/accessmanager/middleware/middleware.go
+++ b/external/accessmanager/middleware/middleware.go
@@ -196,7 +196,16 @@ func (m *Middleware) attemptTokenRefresh(
 		return nil, err
 	}
 
-	// Set new tokens in cookies
+	// Update request header with new access token
+	req.Header["Authorization"] = []string{"Bearer " + tokenResp.AccessToken}
+
+	// Retry validation with new token
+	authedUserResp, err := validateFunc(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set new tokens in cookies only after the retry accepts the refreshed token.
 	toolbox.AddAuthCookies(
 		w,
 		m.environment,
@@ -209,11 +218,7 @@ func (m *Middleware) attemptTokenRefresh(
 		tokenResp.RefreshTokenExpiresAt,
 	)
 
-	// Update request header with new access token
-	req.Header["Authorization"] = []string{"Bearer " + tokenResp.AccessToken}
-
-	// Retry validation with new token
-	return validateFunc(req)
+	return authedUserResp, nil
 }
 
 // handleJWTRequest is a unified handler for all JWT validation types

--- a/external/accessmanager/middleware/middleware_test.go
+++ b/external/accessmanager/middleware/middleware_test.go
@@ -109,6 +109,17 @@ func createTestHandler() http.Handler {
 	})
 }
 
+// responseHasCookieValue reports whether a response included the expected cookie value.
+func responseHasCookieValue(cookies []*http.Cookie, name, value string) bool {
+	for _, cookie := range cookies {
+		if cookie.Name == name && cookie.Value == value {
+			return true
+		}
+	}
+
+	return false
+}
+
 func TestNewMiddleware(t *testing.T) {
 	service := &mockAccessManagerService{}
 
@@ -332,6 +343,13 @@ func TestJWTRequired_TokenRefresh(t *testing.T) {
 	if callCount != 2 {
 		t.Errorf("Expected middleware function to be called twice (initial + retry), got %d", callCount)
 	}
+
+	if !responseHasCookieValue(w.Result().Cookies(), "test_auth", "new-access-token") {
+		t.Error("Expected refreshed access cookie to be set after successful retry validation")
+	}
+	if !responseHasCookieValue(w.Result().Cookies(), "test_refresh", "new-refresh-token") {
+		t.Error("Expected refreshed refresh cookie to be set after successful retry validation")
+	}
 }
 
 func TestJWTRequired_RefreshTokenFailure(t *testing.T) {
@@ -357,6 +375,54 @@ func TestJWTRequired_RefreshTokenFailure(t *testing.T) {
 
 	if w.Code == http.StatusOK {
 		t.Error("Expected non-200 status code when refresh token is invalid")
+	}
+}
+
+// TestJWTRequired_RefreshRetryValidationFailureDoesNotSetNewCookies verifies refreshed cookies are only committed after retry validation succeeds.
+func TestJWTRequired_RefreshRetryValidationFailureDoesNotSetNewCookies(t *testing.T) {
+	callCount := 0
+	refreshCallCount := 0
+	mockService := &mockAccessManagerService{
+		middlewareJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			callCount++
+			return nil, errors.New("token invalid")
+		},
+		refreshTokenFunc: func(ctx context.Context, r *accessmanager.RefreshTokenRequest) (*accessmanager.RefreshTokenResponse, error) {
+			refreshCallCount++
+			return &accessmanager.RefreshTokenResponse{
+				AccessToken:           "new-access-token",
+				RefreshToken:          "new-refresh-token",
+				AccessTokenExpiresAt:  1700000000,
+				RefreshTokenExpiresAt: 1700000000,
+			}, nil
+		},
+	}
+
+	middleware := createTestMiddleware(mockService)
+	handler := createTestHandler()
+	wrappedHandler := middleware.JWTRequired(handler)
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "test_auth", Value: "expired-jwt-token"})
+	req.AddCookie(&http.Cookie{Name: "test_refresh", Value: "valid-refresh-token"})
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Error("Expected non-200 status code when retry validation rejects refreshed token")
+	}
+	if callCount != 2 {
+		t.Errorf("Expected middleware function to be called twice (initial + retry), got %d", callCount)
+	}
+	if refreshCallCount != 1 {
+		t.Errorf("Expected refresh token function to be called once, got %d", refreshCallCount)
+	}
+	if responseHasCookieValue(w.Result().Cookies(), "test_auth", "new-access-token") {
+		t.Error("Did not expect refreshed access cookie to be set before retry validation succeeds")
+	}
+	if responseHasCookieValue(w.Result().Cookies(), "test_refresh", "new-refresh-token") {
+		t.Error("Did not expect refreshed refresh cookie to be set before retry validation succeeds")
 	}
 }
 
@@ -575,6 +641,101 @@ func TestRateLimitOrActiveJWTRequired_TokenRefresh(t *testing.T) {
 
 	if callCount != 2 {
 		t.Errorf("Expected middleware function to be called twice, got %d", callCount)
+	}
+
+	if !responseHasCookieValue(w.Result().Cookies(), "test_auth", "new-access-token") {
+		t.Error("Expected refreshed access cookie to be set after successful retry validation")
+	}
+	if !responseHasCookieValue(w.Result().Cookies(), "test_refresh", "new-refresh-token") {
+		t.Error("Expected refreshed refresh cookie to be set after successful retry validation")
+	}
+}
+
+// TestRateLimitOrActiveJWTRequired_RefreshRetryValidationFailureDoesNotSetNewCookies verifies RateLimitOrActiveJWTRequired uses the same cookie timing.
+func TestRateLimitOrActiveJWTRequired_RefreshRetryValidationFailureDoesNotSetNewCookies(t *testing.T) {
+	callCount := 0
+	refreshCallCount := 0
+
+	mockService := &mockAccessManagerService{
+		middlewareRateLimitOrActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			callCount++
+			return nil, errors.New("token invalid")
+		},
+		refreshTokenFunc: func(ctx context.Context, r *accessmanager.RefreshTokenRequest) (*accessmanager.RefreshTokenResponse, error) {
+			refreshCallCount++
+			return &accessmanager.RefreshTokenResponse{
+				AccessToken:           "new-access-token",
+				RefreshToken:          "new-refresh-token",
+				AccessTokenExpiresAt:  1700000000,
+				RefreshTokenExpiresAt: 1700000000,
+			}, nil
+		},
+	}
+
+	middleware := createTestMiddleware(mockService)
+	handler := createTestHandler()
+	wrappedHandler := middleware.RateLimitOrActiveJWTRequired(handler)
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "test_auth", Value: "expired-jwt-token"})
+	req.AddCookie(&http.Cookie{Name: "test_refresh", Value: "valid-refresh-token"})
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Error("Expected non-200 status code when retry validation rejects refreshed token")
+	}
+	if callCount != 2 {
+		t.Errorf("Expected middleware function to be called twice, got %d", callCount)
+	}
+	if refreshCallCount != 1 {
+		t.Errorf("Expected refresh token function to be called once, got %d", refreshCallCount)
+	}
+	if responseHasCookieValue(w.Result().Cookies(), "test_auth", "new-access-token") {
+		t.Error("Did not expect refreshed access cookie to be set before retry validation succeeds")
+	}
+	if responseHasCookieValue(w.Result().Cookies(), "test_refresh", "new-refresh-token") {
+		t.Error("Did not expect refreshed refresh cookie to be set before retry validation succeeds")
+	}
+}
+
+// TestRateLimitOrActiveJWTRequired_RefreshTokenFailure verifies failed refreshes do not set replacement cookies.
+func TestRateLimitOrActiveJWTRequired_RefreshTokenFailure(t *testing.T) {
+	refreshCallCount := 0
+
+	mockService := &mockAccessManagerService{
+		middlewareRateLimitOrActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			return nil, errors.New("token expired")
+		},
+		refreshTokenFunc: func(ctx context.Context, r *accessmanager.RefreshTokenRequest) (*accessmanager.RefreshTokenResponse, error) {
+			refreshCallCount++
+			return nil, errors.New("refresh token invalid")
+		},
+	}
+
+	middleware := createTestMiddleware(mockService)
+	handler := createTestHandler()
+	wrappedHandler := middleware.RateLimitOrActiveJWTRequired(handler)
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "test_auth", Value: "expired-jwt-token"})
+	req.AddCookie(&http.Cookie{Name: "test_refresh", Value: "invalid-refresh-token"})
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Error("Expected non-200 status code when refresh token is invalid")
+	}
+	if refreshCallCount != 1 {
+		t.Errorf("Expected refresh token function to be called once, got %d", refreshCallCount)
+	}
+	if responseHasCookieValue(w.Result().Cookies(), "test_auth", "new-access-token") {
+		t.Error("Did not expect refreshed access cookie to be set when refresh service fails")
+	}
+	if responseHasCookieValue(w.Result().Cookies(), "test_refresh", "new-refresh-token") {
+		t.Error("Did not expect refreshed refresh cookie to be set when refresh service fails")
 	}
 }
 

--- a/external/accessmanager/service.go
+++ b/external/accessmanager/service.go
@@ -50,6 +50,18 @@ type EphemeralStore interface {
 	StoreToken(ctx context.Context, accessTokenUUID string, userID string, ttl time.Duration) error
 	FetchAuth(ctx context.Context, accessDetails ephemeral.TokenDetailsAccess) (string, error)
 	DeleteAuth(ctx context.Context, tokenID string) (int64, error)
+	// AcquireRefreshTokenRotationLock claims the right to rotate one refresh token.
+	AcquireRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error)
+	// ReleaseRefreshTokenRotationLock releases a previously claimed refresh rotation lock.
+	ReleaseRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string) (int64, error)
+	// StoreRefreshTokenRotationResult stores a short-lived replay payload for duplicate refreshes.
+	StoreRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string, result *ephemeral.RefreshTokenRotationResult, ttl time.Duration) error
+	// GetRefreshTokenRotationResult fetches a short-lived replay payload for duplicate refreshes.
+	GetRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string) (*ephemeral.RefreshTokenRotationResult, error)
+	// AcquireLoginEmailCooldown claims the login-email send window for one user/context.
+	AcquireLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error)
+	// ReleaseLoginEmailCooldown releases a login-email send window after a failed send setup.
+	ReleaseLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string) (int64, error)
 	AddRequestCountEntry(ctx context.Context, clientIp string) error
 	DeleteAllTokenExceptedSpecified(ctx context.Context, userId string, exemptionTokenIds []string) error
 	CodeExists(ctx context.Context, code string) (bool, error)
@@ -127,6 +139,19 @@ type Service struct {
 	OauthServices         []OauthService
 	StaticPlaceholderUuid string
 }
+
+const (
+	// refreshTokenRotationReplayTTL bounds how long a consumed refresh token can replay the winning rotation result.
+	refreshTokenRotationReplayTTL = 30 * time.Second
+	// refreshTokenRotationLockTTL bounds how long one process may hold the refresh rotation lock.
+	refreshTokenRotationLockTTL = 5 * time.Second
+	// refreshTokenRotationWaitTimeout bounds how long duplicate refreshes wait for the winning rotation result.
+	refreshTokenRotationWaitTimeout = 2 * time.Second
+	// refreshTokenRotationWaitInterval controls how often duplicate refreshes poll for the winning rotation result.
+	refreshTokenRotationWaitInterval = 25 * time.Millisecond
+	// loginEmailCooldownTTL bounds duplicate login-initiation email sends for the same user/context.
+	loginEmailCooldownTTL = 60 * time.Second
+)
 
 // NewServiceRequest holds all expected dependencies for an accessmanager service
 type NewServiceRequest struct {
@@ -1139,21 +1164,71 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 		zap.AddStacktrace(zap.DPanicLevel),
 	)
 
-	tokenUser, refreshTokenUuid, err := s.RemoveRefreshTokenWithCookieValue(ctx, r.RefreshToken)
+	tokenUser, refreshTokenDetails, err := s.refreshTokenUserFromCookieValue(ctx, r.RefreshToken)
 	if err != nil {
 		return nil, err
 	}
 
+	refreshTokenUuid := refreshTokenDetails.RefreshUUID
+	userID := tokenUser.GetUserId()
+
+	if response, err := s.refreshTokenRotationResponse(ctx, userID, refreshTokenUuid); err != nil {
+		return nil, err
+	} else if response != nil {
+		log.Info("refresh-token-rotation-replayed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+		return response, nil
+	}
+
+	lockAcquired, err := s.EphemeralStore.AcquireRefreshTokenRotationLock(ctx, userID, refreshTokenUuid, refreshTokenRotationLockTTL)
+	if err != nil {
+		log.Error("refresh-token-rotation-lock-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
+		return nil, err
+	}
+	if !lockAcquired {
+		response, waitErr := s.waitForRefreshTokenRotationResponse(ctx, userID, refreshTokenUuid)
+		if waitErr != nil {
+			return nil, waitErr
+		}
+		if response != nil {
+			log.Info("refresh-token-rotation-replayed-after-wait", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+			return response, nil
+		}
+
+		log.Error("refresh-token-rotation-lock-timeout-without-result", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+		return nil, ErrUnauthorizedRefreshTokenCacheDeletionFailure
+	}
+	defer func() {
+		if _, releaseErr := s.EphemeralStore.ReleaseRefreshTokenRotationLock(ctx, userID, refreshTokenUuid); releaseErr != nil {
+			log.Warn("refresh-token-rotation-lock-release-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(releaseErr))
+		}
+	}()
+
+	// Delete previous refresh token matching key (<userID>:<tokenUUID>)
+	deleted, err := s.EphemeralStore.DeleteAuth(ctx, toolbox.CombinedUuidFormat(userID, refreshTokenUuid))
+	if err != nil || deleted == 0 {
+		if response, replayErr := s.refreshTokenRotationResponse(ctx, userID, refreshTokenUuid); replayErr != nil {
+			return nil, replayErr
+		} else if response != nil {
+			log.Info("refresh-token-rotation-replayed-after-delete-miss", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+			return response, nil
+		}
+
+		log.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id:", userID), zap.Error(err))
+		return nil, ErrUnauthorizedRefreshTokenCacheDeletionFailure
+	}
+
+	log.Info("refresh-token-successfully-removed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+
 	// check if access token is present and clean up along with it
 	if r.AccessToken != "" {
 
-		log.Info("access-token-present-in-refresh-token-request", zap.String("user-id", tokenUser.GetUserId()), zap.String("refresh-token", refreshTokenUuid))
+		log.Info("access-token-present-in-refresh-token-request", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 
-		err := s.RemoveAccessTokenWithCookieValue(ctx, tokenUser.GetUserId(), r.AccessToken)
+		err := s.RemoveAccessTokenWithCookieValue(ctx, userID, r.AccessToken)
 		if err != nil {
-			log.Warn("access-token-failed-to-delete-after-successful-refresh-token-clean-up", zap.String("user-id", tokenUser.GetUserId()), zap.Error(err))
+			log.Warn("access-token-failed-to-delete-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.Error(err))
 		} else {
-			log.Info("access-token-deleted-after-successful-refresh-token-clean-up", zap.String("user-id", tokenUser.GetUserId()), zap.String("refresh-token", refreshTokenUuid))
+			log.Info("access-token-deleted-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 		}
 
 	}
@@ -1165,10 +1240,21 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 	}
 
 	// Save the tokens to ephemeralstore
-	err = s.EphemeralStore.CreateAuth(ctx, tokenUser.GetUserId(), newTokensDetails)
+	err = s.EphemeralStore.CreateAuth(ctx, userID, newTokensDetails)
 	if err != nil {
-		log.Error("ephemeral-store-failed-after-successful-refresh-token-regeneration", zap.String("user-id:", tokenUser.GetUserId()), zap.Error(err))
+		log.Error("ephemeral-store-failed-after-successful-refresh-token-regeneration", zap.String("user-id:", userID), zap.Error(err))
 		return nil, err
+	}
+
+	// rotationResult lets duplicate refresh attempts receive the same replacement token pair.
+	rotationResult := &ephemeral.RefreshTokenRotationResult{
+		AccessToken:           newTokensDetails.AccessToken,
+		RefreshToken:          newTokensDetails.RefreshToken,
+		AccessTokenExpiresAt:  newTokensDetails.AtExpires,
+		RefreshTokenExpiresAt: newTokensDetails.RtExpires,
+	}
+	if err := s.EphemeralStore.StoreRefreshTokenRotationResult(ctx, userID, refreshTokenUuid, rotationResult, refreshTokenRotationReplayTTL); err != nil {
+		log.Warn("refresh-token-rotation-result-store-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
 	}
 
 	return &RefreshTokenResponse{
@@ -1177,6 +1263,54 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 		AccessTokenExpiresAt:  newTokensDetails.AtExpires,
 		RefreshTokenExpiresAt: newTokensDetails.RtExpires,
 	}, nil
+}
+
+// refreshTokenRotationResponse maps a cached rotation replay payload to the service response.
+func (s *Service) refreshTokenRotationResponse(ctx context.Context, userID, refreshTokenUuid string) (*RefreshTokenResponse, error) {
+	result, err := s.EphemeralStore.GetRefreshTokenRotationResult(ctx, userID, refreshTokenUuid)
+	if err != nil || result == nil {
+		return nil, err
+	}
+
+	return &RefreshTokenResponse{
+		AccessToken:           result.AccessToken,
+		RefreshToken:          result.RefreshToken,
+		AccessTokenExpiresAt:  result.AccessTokenExpiresAt,
+		RefreshTokenExpiresAt: result.RefreshTokenExpiresAt,
+	}, nil
+}
+
+// waitForRefreshTokenRotationResponse polls briefly for the winning refresh rotation result.
+func (s *Service) waitForRefreshTokenRotationResponse(ctx context.Context, userID, refreshTokenUuid string) (*RefreshTokenResponse, error) {
+	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+		zap.AddStacktrace(zap.DPanicLevel),
+	)
+
+	timeout := time.NewTimer(refreshTokenRotationWaitTimeout)
+	defer timeout.Stop()
+
+	ticker := time.NewTicker(refreshTokenRotationWaitInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		response, err := s.refreshTokenRotationResponse(ctx, userID, refreshTokenUuid)
+		if response != nil {
+			return response, nil
+		}
+		if err != nil {
+			lastErr = err
+			log.Warn("refresh-token-rotation-result-fetch-failed-during-wait", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timeout.C:
+			return nil, lastErr
+		case <-ticker.C:
+		}
+	}
 }
 
 // RemoveAccessTokenWithCookieValue removes access token with the given cookie value
@@ -1210,7 +1344,40 @@ func (s *Service) RemoveAccessTokenWithCookieValue(ctx context.Context, userId, 
 	return nil
 }
 
-// RemoveRefreshTokenWithCookieValue removes refresh token with the given cookie valu
+// refreshTokenUserFromCookieValue validates a refresh cookie and returns its user and token metadata.
+func (s *Service) refreshTokenUserFromCookieValue(ctx context.Context, refreshTokenCookieValue string) (auth.UserModel, *auth.TokenRefreshDetails, error) {
+	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
+		zap.AddStacktrace(zap.DPanicLevel),
+	)
+
+	log.Info("processing-refresh-token-by-cookie-value")
+
+	// Check validity
+	refreshToken, err := s.AuthService.CheckRefreshTokenIsValid(ctx, refreshTokenCookieValue)
+	if err != nil {
+		log.Error("failed-to-check-if-refresh-token-is-valid", zap.Error(err))
+		return nil, nil, err
+	}
+
+	// Get token details
+	refreshTokenDetails, err := s.AuthService.GetRefreshTokenUUID(ctx, refreshToken)
+	if err != nil {
+		log.Error("failed-to-get-refresh-token-by-its-uuid", zap.Error(err))
+		return nil, nil, err
+	}
+
+	// Get user details
+	persistentUserResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{
+		ID: refreshTokenDetails.UserID})
+	if err != nil {
+		log.Error("unable-to-find-user-for-refresh-token-by-its-provided-user-uuid", zap.Error(err))
+		return nil, refreshTokenDetails, err
+	}
+
+	return persistentUserResponse.User, refreshTokenDetails, nil
+}
+
+// RemoveRefreshTokenWithCookieValue removes refresh token with the given cookie value
 // returns the user id of the refresh token and an error if any
 func (s *Service) RemoveRefreshTokenWithCookieValue(ctx context.Context, refreshTokenCookieValue string) (auth.UserModel, string, error) {
 
@@ -1224,31 +1391,16 @@ func (s *Service) RemoveRefreshTokenWithCookieValue(ctx context.Context, refresh
 
 	log.Info("processing-refresh-token-removal-by-cookie-value")
 
-	// Check validity
-	refreshToken, err := s.AuthService.CheckRefreshTokenIsValid(ctx, refreshTokenCookieValue)
+	tokenUser, refreshTokenDetails, err := s.refreshTokenUserFromCookieValue(ctx, refreshTokenCookieValue)
 	if err != nil {
-		log.Error("failed-to-check-if-refresh-token-is-valid", zap.Error(err))
-		return nil, refreshTokenUuid, err
-	}
-
-	// Get token details
-	refreshTokenDetails, err := s.AuthService.GetRefreshTokenUUID(ctx, refreshToken)
-	if err != nil {
-		log.Error("failed-to-get-refresh-token-by-its-uuid", zap.Error(err))
+		if refreshTokenDetails != nil {
+			refreshTokenUuid = refreshTokenDetails.RefreshUUID
+		}
 		return nil, refreshTokenUuid, err
 	}
 
 	refreshTokenUuid = refreshTokenDetails.RefreshUUID
-
-	// Get user details
-	persistentUserResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{
-		ID: refreshTokenDetails.UserID})
-	if err != nil {
-		log.Error("unable-to-find-user-for-refresh-token-by-its-provided-user-uuid", zap.Error(err))
-		return nil, refreshTokenUuid, err
-	}
-
-	userId = persistentUserResponse.User.ID
+	userId = tokenUser.GetUserId()
 
 	// Delete previous refresh token matching key (<userID>:<tokenUUID>)
 	deleted, err := s.EphemeralStore.DeleteAuth(ctx, toolbox.CombinedUuidFormat(userId, refreshTokenDetails.RefreshUUID))
@@ -1258,7 +1410,7 @@ func (s *Service) RemoveRefreshTokenWithCookieValue(ctx context.Context, refresh
 	}
 
 	log.Info("refresh-token-successfully-removed", zap.String("user-id", userId), zap.String("refresh-token", refreshTokenDetails.RefreshUUID))
-	return persistentUserResponse.User, refreshTokenUuid, nil
+	return tokenUser, refreshTokenUuid, nil
 }
 
 // LoginUser handies verifying initial login token token, and  actioning all surrounding steps in
@@ -1704,6 +1856,29 @@ func (s *Service) CreateInitalLoginToken(ctx context.Context, user *userv2.Unive
 		zap.AddStacktrace(zap.DPanicLevel),
 	)
 
+	// cooldownAcquired is false when a recent accepted login email already exists for this user/context.
+	cooldownAcquired, err := s.EphemeralStore.AcquireLoginEmailCooldown(ctx, user.ID, isDashboardRequest, requestUrl, loginEmailCooldownTTL)
+	if err != nil {
+		log.Error("unable-to-acquire-login-email-cooldown:", zap.String("user-id", user.ID), zap.Error(err))
+		return "", err
+	}
+	if !cooldownAcquired {
+		log.Info("login-email-cooldown-active", zap.String("user-id", user.ID))
+		return "", nil
+	}
+
+	// keepCooldown flips to true only after the email send has been accepted by the email manager.
+	keepCooldown := false
+	defer func() {
+		if keepCooldown {
+			return
+		}
+
+		if _, releaseErr := s.EphemeralStore.ReleaseLoginEmailCooldown(ctx, user.ID, isDashboardRequest, requestUrl); releaseErr != nil {
+			log.Warn("login-email-cooldown-release-failed", zap.String("user-id", user.ID), zap.Error(releaseErr))
+		}
+	}()
+
 	tokenDetails, err := s.AuthService.CreateInitalToken(ctx, user)
 	if err != nil {
 		log.Error("unable-to-generate-initiate-login-email-token:", zap.String("user-id", user.ID))
@@ -1741,6 +1916,8 @@ func (s *Service) CreateInitalLoginToken(ctx context.Context, user *userv2.Unive
 		log.Error("unable-to-send-initiate-login-email:", zap.String("user-id", user.ID))
 		return "", err
 	}
+
+	keepCooldown = true
 
 	return tokenDetails.EphemeralToken, nil
 }

--- a/external/accessmanager/service_login_email_test.go
+++ b/external/accessmanager/service_login_email_test.go
@@ -1,0 +1,221 @@
+package accessmanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ooaklee/ghatd/external/accessmanager"
+	"github.com/ooaklee/ghatd/external/auth"
+	"github.com/ooaklee/ghatd/external/emailmanager"
+	userv2 "github.com/ooaklee/ghatd/external/user/v2"
+)
+
+// loginEmailEphemeralStoreMock records cooldown, token, and code behavior for login-email tests.
+type loginEmailEphemeralStoreMock struct {
+	refreshEphemeralStoreMock
+	acquireLoginEmailCooldownFunc func(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error)
+	storeTokenFunc                func(ctx context.Context, accessTokenUUID string, userID string, ttl time.Duration) error
+	storeCodeFunc                 func(ctx context.Context, code string, ttl time.Duration) error
+	storeCodeMappingFunc          func(ctx context.Context, code, token string, ttl time.Duration) error
+	releaseLoginEmailCooldowns    int
+}
+
+func (m *loginEmailEphemeralStoreMock) AcquireLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error) {
+	if m.acquireLoginEmailCooldownFunc != nil {
+		return m.acquireLoginEmailCooldownFunc(ctx, userID, isDashboardRequest, requestURL, ttl)
+	}
+	return true, nil
+}
+
+func (m *loginEmailEphemeralStoreMock) ReleaseLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string) (int64, error) {
+	m.releaseLoginEmailCooldowns++
+	return 1, nil
+}
+
+func (m *loginEmailEphemeralStoreMock) StoreToken(ctx context.Context, accessTokenUUID string, userID string, ttl time.Duration) error {
+	if m.storeTokenFunc != nil {
+		return m.storeTokenFunc(ctx, accessTokenUUID, userID, ttl)
+	}
+	return nil
+}
+
+func (m *loginEmailEphemeralStoreMock) CodeExists(ctx context.Context, code string) (bool, error) {
+	return false, nil
+}
+
+func (m *loginEmailEphemeralStoreMock) StoreCode(ctx context.Context, code string, ttl time.Duration) error {
+	if m.storeCodeFunc != nil {
+		return m.storeCodeFunc(ctx, code, ttl)
+	}
+	return nil
+}
+
+func (m *loginEmailEphemeralStoreMock) StoreCodeMapping(ctx context.Context, code, token string, ttl time.Duration) error {
+	if m.storeCodeMappingFunc != nil {
+		return m.storeCodeMappingFunc(ctx, code, token, ttl)
+	}
+	return nil
+}
+
+// loginEmailManagerMock captures SendLoginEmail behavior for login-email tests.
+type loginEmailManagerMock struct {
+	sendLoginEmailFunc func(ctx context.Context, req *emailmanager.SendLoginEmailRequest) error
+}
+
+func (m *loginEmailManagerMock) SendCustomEmail(ctx context.Context, req *emailmanager.SendCustomEmailRequest) error {
+	return nil
+}
+
+func (m *loginEmailManagerMock) SendLoginEmail(ctx context.Context, req *emailmanager.SendLoginEmailRequest) error {
+	if m.sendLoginEmailFunc != nil {
+		return m.sendLoginEmailFunc(ctx, req)
+	}
+	return nil
+}
+
+func (m *loginEmailManagerMock) SendVerificationEmail(ctx context.Context, req *emailmanager.SendVerificationEmailRequest) error {
+	return nil
+}
+
+// newLoginEmailTestUser returns a fixed active user for login-email tests.
+func newLoginEmailTestUser() *userv2.UniversalUser {
+	return &userv2.UniversalUser{
+		ID:     "user-1",
+		Email:  "user@example.com",
+		Status: userv2.AccountStatusKeyActive,
+	}
+}
+
+// newInitialTokenDetails returns a deterministic initial login token for login-email tests.
+func newInitialTokenDetails() *auth.TokenDetails {
+	return &auth.TokenDetails{
+		EphemeralToken: "initial-login-token",
+		EphemeralUUID:  "initial-login-uuid",
+		EtTTL:          time.Minute,
+	}
+}
+
+// TestServiceCreateInitalLoginTokenSkipsDuplicateWithinCooldown verifies duplicate sends are suppressed while the cooldown is active.
+func TestServiceCreateInitalLoginTokenSkipsDuplicateWithinCooldown(t *testing.T) {
+	t.Parallel()
+
+	createTokenCalls := 0
+	sendEmailCalls := 0
+	store := &loginEmailEphemeralStoreMock{
+		acquireLoginEmailCooldownFunc: func(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error) {
+			require.Equal(t, "user-1", userID)
+			require.False(t, isDashboardRequest)
+			require.Equal(t, "/app", requestURL)
+			require.Greater(t, ttl, time.Duration(0))
+			return false, nil
+		},
+	}
+	service := &accessmanager.Service{
+		EphemeralStore: store,
+		AuthService: &refreshAuthServiceMock{
+			createInitalTokenFunc: func(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error) {
+				createTokenCalls++
+				return newInitialTokenDetails(), nil
+			},
+		},
+		EmailManager: &loginEmailManagerMock{
+			sendLoginEmailFunc: func(ctx context.Context, req *emailmanager.SendLoginEmailRequest) error {
+				sendEmailCalls++
+				return nil
+			},
+		},
+	}
+
+	token, err := service.CreateInitalLoginToken(context.Background(), newLoginEmailTestUser(), false, "/app")
+
+	require.NoError(t, err)
+	require.Empty(t, token)
+	require.Zero(t, createTokenCalls)
+	require.Zero(t, sendEmailCalls)
+	require.Zero(t, store.releaseLoginEmailCooldowns)
+}
+
+// TestServiceCreateInitalLoginTokenSendsOnceWhenCooldownAcquired verifies the first accepted request creates and sends one token.
+func TestServiceCreateInitalLoginTokenSendsOnceWhenCooldownAcquired(t *testing.T) {
+	t.Parallel()
+
+	var sentRequest *emailmanager.SendLoginEmailRequest
+	storeTokenCalls := 0
+	storeCodeMappingCalls := 0
+	store := &loginEmailEphemeralStoreMock{
+		storeTokenFunc: func(ctx context.Context, accessTokenUUID string, userID string, ttl time.Duration) error {
+			storeTokenCalls++
+			require.Equal(t, "initial-login-uuid", accessTokenUUID)
+			require.Equal(t, "user-1", userID)
+			return nil
+		},
+		storeCodeMappingFunc: func(ctx context.Context, code, token string, ttl time.Duration) error {
+			storeCodeMappingCalls++
+			require.Len(t, code, 8)
+			require.Equal(t, "initial-login-token", token)
+			return nil
+		},
+	}
+	service := &accessmanager.Service{
+		EphemeralStore: store,
+		AuthService: &refreshAuthServiceMock{
+			createInitalTokenFunc: func(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error) {
+				return newInitialTokenDetails(), nil
+			},
+		},
+		EmailManager: &loginEmailManagerMock{
+			sendLoginEmailFunc: func(ctx context.Context, req *emailmanager.SendLoginEmailRequest) error {
+				sentRequest = req
+				return nil
+			},
+		},
+	}
+
+	token, err := service.CreateInitalLoginToken(context.Background(), newLoginEmailTestUser(), true, "/app/plan")
+
+	require.NoError(t, err)
+	require.Equal(t, "initial-login-token", token)
+	require.Equal(t, 1, storeTokenCalls)
+	require.Equal(t, 1, storeCodeMappingCalls)
+	require.NotNil(t, sentRequest)
+	require.Equal(t, "user@example.com", sentRequest.Email)
+	require.Equal(t, "initial-login-token", sentRequest.Token)
+	require.Len(t, sentRequest.Code, 8)
+	require.True(t, sentRequest.IsDashboardRequest)
+	require.Equal(t, "/app/plan", sentRequest.RequestUrl)
+	require.Zero(t, store.releaseLoginEmailCooldowns)
+}
+
+// TestServiceCreateInitalLoginTokenReleasesCooldownWhenSendFails verifies failed sends allow a later retry.
+func TestServiceCreateInitalLoginTokenReleasesCooldownWhenSendFails(t *testing.T) {
+	t.Parallel()
+
+	store := &loginEmailEphemeralStoreMock{}
+	service := &accessmanager.Service{
+		EphemeralStore: store,
+		AuthService: &refreshAuthServiceMock{
+			createInitalTokenFunc: func(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error) {
+				return newInitialTokenDetails(), nil
+			},
+		},
+		EmailManager: &loginEmailManagerMock{
+			sendLoginEmailFunc: func(ctx context.Context, req *emailmanager.SendLoginEmailRequest) error {
+				return errors.New("send failed")
+			},
+		},
+	}
+
+	token, err := service.CreateInitalLoginToken(context.Background(), newLoginEmailTestUser(), false, "/app")
+
+	require.Error(t, err)
+	require.Empty(t, token)
+	require.Equal(t, 1, store.releaseLoginEmailCooldowns)
+}
+
+// Compile-time guards keep the login-email mocks aligned with service dependencies.
+var _ accessmanager.EphemeralStore = (*loginEmailEphemeralStoreMock)(nil)
+var _ accessmanager.EmailManager = (*loginEmailManagerMock)(nil)

--- a/external/accessmanager/service_refresh_test.go
+++ b/external/accessmanager/service_refresh_test.go
@@ -1,0 +1,374 @@
+package accessmanager_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ooaklee/ghatd/external/accessmanager"
+	"github.com/ooaklee/ghatd/external/auth"
+	"github.com/ooaklee/ghatd/external/ephemeral"
+	userv2 "github.com/ooaklee/ghatd/external/user/v2"
+)
+
+// refreshEphemeralStoreMock records and controls ephemeral storage behavior for refresh tests.
+type refreshEphemeralStoreMock struct {
+	createAuthFunc                       func(ctx context.Context, userID string, tokenDetails ephemeral.TokenDetailsAuth) error
+	deleteAuthFunc                       func(ctx context.Context, tokenID string) (int64, error)
+	acquireRefreshTokenRotationLockFunc  func(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error)
+	releaseRefreshTokenRotationLockFunc  func(ctx context.Context, userID, refreshTokenUUID string) (int64, error)
+	storeRefreshTokenRotationResultFunc  func(ctx context.Context, userID, refreshTokenUUID string, result *ephemeral.RefreshTokenRotationResult, ttl time.Duration) error
+	getRefreshTokenRotationResultFunc    func(ctx context.Context, userID, refreshTokenUUID string) (*ephemeral.RefreshTokenRotationResult, error)
+	deleteAuthCalls                      int
+	acquireRefreshTokenRotationLockCalls int
+	releaseRefreshTokenRotationLockCalls int
+}
+
+func (m *refreshEphemeralStoreMock) CreateAuth(ctx context.Context, userID string, tokenDetails ephemeral.TokenDetailsAuth) error {
+	if m.createAuthFunc != nil {
+		return m.createAuthFunc(ctx, userID, tokenDetails)
+	}
+	return nil
+}
+
+func (m *refreshEphemeralStoreMock) StoreToken(ctx context.Context, accessTokenUUID string, userID string, ttl time.Duration) error {
+	return nil
+}
+
+func (m *refreshEphemeralStoreMock) FetchAuth(ctx context.Context, accessDetails ephemeral.TokenDetailsAccess) (string, error) {
+	return "", nil
+}
+
+func (m *refreshEphemeralStoreMock) DeleteAuth(ctx context.Context, tokenID string) (int64, error) {
+	m.deleteAuthCalls++
+	if m.deleteAuthFunc != nil {
+		return m.deleteAuthFunc(ctx, tokenID)
+	}
+	return 0, nil
+}
+
+func (m *refreshEphemeralStoreMock) AcquireRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error) {
+	m.acquireRefreshTokenRotationLockCalls++
+	if m.acquireRefreshTokenRotationLockFunc != nil {
+		return m.acquireRefreshTokenRotationLockFunc(ctx, userID, refreshTokenUUID, ttl)
+	}
+	return true, nil
+}
+
+func (m *refreshEphemeralStoreMock) ReleaseRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string) (int64, error) {
+	m.releaseRefreshTokenRotationLockCalls++
+	if m.releaseRefreshTokenRotationLockFunc != nil {
+		return m.releaseRefreshTokenRotationLockFunc(ctx, userID, refreshTokenUUID)
+	}
+	return 1, nil
+}
+
+func (m *refreshEphemeralStoreMock) StoreRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string, result *ephemeral.RefreshTokenRotationResult, ttl time.Duration) error {
+	if m.storeRefreshTokenRotationResultFunc != nil {
+		return m.storeRefreshTokenRotationResultFunc(ctx, userID, refreshTokenUUID, result, ttl)
+	}
+	return nil
+}
+
+func (m *refreshEphemeralStoreMock) GetRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string) (*ephemeral.RefreshTokenRotationResult, error) {
+	if m.getRefreshTokenRotationResultFunc != nil {
+		return m.getRefreshTokenRotationResultFunc(ctx, userID, refreshTokenUUID)
+	}
+	return nil, nil
+}
+
+func (m *refreshEphemeralStoreMock) AcquireLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (m *refreshEphemeralStoreMock) ReleaseLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string) (int64, error) {
+	return 1, nil
+}
+
+func (m *refreshEphemeralStoreMock) AddRequestCountEntry(ctx context.Context, clientIp string) error {
+	return nil
+}
+
+func (m *refreshEphemeralStoreMock) DeleteAllTokenExceptedSpecified(ctx context.Context, userId string, exemptionTokenIds []string) error {
+	return nil
+}
+
+func (m *refreshEphemeralStoreMock) CodeExists(ctx context.Context, code string) (bool, error) {
+	return false, nil
+}
+
+func (m *refreshEphemeralStoreMock) StoreCode(ctx context.Context, code string, ttl time.Duration) error {
+	return nil
+}
+
+func (m *refreshEphemeralStoreMock) StoreCodeMapping(ctx context.Context, code, token string, ttl time.Duration) error {
+	return nil
+}
+
+func (m *refreshEphemeralStoreMock) GetCodeMapping(ctx context.Context, code string) (string, error) {
+	return "", nil
+}
+
+// refreshAuthServiceMock supplies controllable auth-token behavior for refresh tests.
+type refreshAuthServiceMock struct {
+	createInitalTokenFunc func(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error)
+	createTokenFunc       func(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error)
+}
+
+func (m *refreshAuthServiceMock) CreateInitalToken(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error) {
+	if m.createInitalTokenFunc != nil {
+		return m.createInitalTokenFunc(ctx, user)
+	}
+	return nil, nil
+}
+
+func (m *refreshAuthServiceMock) CreateToken(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error) {
+	if m.createTokenFunc != nil {
+		return m.createTokenFunc(ctx, user)
+	}
+	return nil, nil
+}
+
+func (m *refreshAuthServiceMock) ExtractTokenMetadata(ctx context.Context, r *http.Request) (*auth.TokenAccessDetails, error) {
+	return nil, nil
+}
+
+func (m *refreshAuthServiceMock) CheckRefreshTokenIsValid(ctx context.Context, t string) (*jwt.Token, error) {
+	return &jwt.Token{Valid: true}, nil
+}
+
+func (m *refreshAuthServiceMock) GetRefreshTokenUUID(ctx context.Context, token *jwt.Token) (*auth.TokenRefreshDetails, error) {
+	return &auth.TokenRefreshDetails{
+		RefreshUUID: "old-refresh-uuid",
+		UserID:      "user-1",
+	}, nil
+}
+
+func (m *refreshAuthServiceMock) CheckAccessTokenValidityGetDetails(ctx context.Context, token *jwt.Token) (*auth.TokenAccessDetails, error) {
+	return nil, nil
+}
+
+func (m *refreshAuthServiceMock) ParseAccessTokenFromString(ctx context.Context, tokenAsString string) (*jwt.Token, error) {
+	return nil, nil
+}
+
+func (m *refreshAuthServiceMock) CreateEmailVerificationToken(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error) {
+	return nil, nil
+}
+
+func (m *refreshAuthServiceMock) ExtractRefreshTokenMetadataByString(ctx context.Context, tokenAsString string) (*auth.TokenRefreshDetails, error) {
+	return nil, nil
+}
+
+func (m *refreshAuthServiceMock) ExtractAccessTokenMetadataByString(ctx context.Context, tokenAsString string) (*auth.TokenAccessDetails, error) {
+	return nil, nil
+}
+
+// refreshUserServiceMock returns a fixed user for refresh-service tests.
+type refreshUserServiceMock struct {
+	user *userv2.UniversalUser
+}
+
+func (m *refreshUserServiceMock) GetUserByNanoID(ctx context.Context, r *userv2.GetUserByNanoIDRequest) (*userv2.GetUserByNanoIDResponse, error) {
+	return nil, nil
+}
+
+func (m *refreshUserServiceMock) GetUserByID(ctx context.Context, r *userv2.GetUserByIDRequest) (*userv2.GetUserByIDResponse, error) {
+	return &userv2.GetUserByIDResponse{User: m.user}, nil
+}
+
+func (m *refreshUserServiceMock) GetUserByEmail(ctx context.Context, r *userv2.GetUserByEmailRequest) (*userv2.GetUserByEmailResponse, error) {
+	return nil, nil
+}
+
+func (m *refreshUserServiceMock) UpdateUser(ctx context.Context, r *userv2.UpdateUserRequest) (*userv2.UpdateUserResponse, error) {
+	return nil, nil
+}
+
+func (m *refreshUserServiceMock) CreateUser(ctx context.Context, r *userv2.CreateUserRequest) (*userv2.CreateUserResponse, error) {
+	return nil, nil
+}
+
+// newRefreshTokenTestService wires the minimal service dependencies used by refresh tests.
+func newRefreshTokenTestService(store *refreshEphemeralStoreMock, authService *refreshAuthServiceMock) *accessmanager.Service {
+	return &accessmanager.Service{
+		EphemeralStore: store,
+		AuthService:    authService,
+		UserService: &refreshUserServiceMock{user: &userv2.UniversalUser{
+			ID:     "user-1",
+			Email:  "user@example.com",
+			Status: userv2.AccountStatusKeyActive,
+		}},
+	}
+}
+
+// TestServiceRefreshTokenReplaysCachedRotation verifies duplicate refreshes can reuse a cached rotation result.
+func TestServiceRefreshTokenReplaysCachedRotation(t *testing.T) {
+	t.Parallel()
+
+	cached := &ephemeral.RefreshTokenRotationResult{
+		AccessToken:           "cached-access-token",
+		RefreshToken:          "cached-refresh-token",
+		AccessTokenExpiresAt:  100,
+		RefreshTokenExpiresAt: 200,
+	}
+	store := &refreshEphemeralStoreMock{
+		getRefreshTokenRotationResultFunc: func(ctx context.Context, userID, refreshTokenUUID string) (*ephemeral.RefreshTokenRotationResult, error) {
+			return cached, nil
+		},
+	}
+	service := newRefreshTokenTestService(store, &refreshAuthServiceMock{})
+
+	response, err := service.RefreshToken(context.Background(), &accessmanager.RefreshTokenRequest{RefreshToken: "old-refresh-token"})
+
+	require.NoError(t, err)
+	require.Equal(t, cached.AccessToken, response.AccessToken)
+	require.Equal(t, cached.RefreshToken, response.RefreshToken)
+	require.Zero(t, store.deleteAuthCalls)
+	require.Zero(t, store.acquireRefreshTokenRotationLockCalls)
+}
+
+// TestServiceRefreshTokenWaitsForInFlightRotation verifies concurrent refreshes wait for the winning rotation result.
+func TestServiceRefreshTokenWaitsForInFlightRotation(t *testing.T) {
+	t.Parallel()
+
+	cached := &ephemeral.RefreshTokenRotationResult{
+		AccessToken:           "cached-access-token",
+		RefreshToken:          "cached-refresh-token",
+		AccessTokenExpiresAt:  100,
+		RefreshTokenExpiresAt: 200,
+	}
+	getCalls := 0
+	store := &refreshEphemeralStoreMock{
+		getRefreshTokenRotationResultFunc: func(ctx context.Context, userID, refreshTokenUUID string) (*ephemeral.RefreshTokenRotationResult, error) {
+			getCalls++
+			if getCalls >= 2 {
+				return cached, nil
+			}
+			return nil, nil
+		},
+		acquireRefreshTokenRotationLockFunc: func(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error) {
+			return false, nil
+		},
+	}
+	service := newRefreshTokenTestService(store, &refreshAuthServiceMock{})
+
+	response, err := service.RefreshToken(context.Background(), &accessmanager.RefreshTokenRequest{RefreshToken: "old-refresh-token"})
+
+	require.NoError(t, err)
+	require.Equal(t, cached.AccessToken, response.AccessToken)
+	require.Equal(t, cached.RefreshToken, response.RefreshToken)
+	require.Zero(t, store.deleteAuthCalls)
+	require.Equal(t, 1, store.acquireRefreshTokenRotationLockCalls)
+}
+
+// TestServiceRefreshTokenStoresRotationResultAfterSuccessfulRotation verifies the winning refresh stores its replay payload.
+func TestServiceRefreshTokenStoresRotationResultAfterSuccessfulRotation(t *testing.T) {
+	t.Parallel()
+
+	newTokens := &auth.TokenDetails{
+		AccessToken:  "new-access-token",
+		AccessUUID:   "new-access-uuid",
+		AtExpires:    100,
+		AtTTL:        time.Minute,
+		RefreshToken: "new-refresh-token",
+		RefreshUUID:  "new-refresh-uuid",
+		RtExpires:    200,
+		RtTTL:        time.Hour,
+	}
+	var storedResult *ephemeral.RefreshTokenRotationResult
+	store := &refreshEphemeralStoreMock{
+		deleteAuthFunc: func(ctx context.Context, tokenID string) (int64, error) {
+			require.Equal(t, "user-1:old-refresh-uuid", tokenID)
+			return 1, nil
+		},
+		storeRefreshTokenRotationResultFunc: func(ctx context.Context, userID, refreshTokenUUID string, result *ephemeral.RefreshTokenRotationResult, ttl time.Duration) error {
+			require.Equal(t, "user-1", userID)
+			require.Equal(t, "old-refresh-uuid", refreshTokenUUID)
+			require.Greater(t, ttl, time.Duration(0))
+			storedResult = result
+			return nil
+		},
+	}
+	service := newRefreshTokenTestService(store, &refreshAuthServiceMock{
+		createTokenFunc: func(ctx context.Context, user auth.UserModel) (*auth.TokenDetails, error) {
+			return newTokens, nil
+		},
+	})
+
+	response, err := service.RefreshToken(context.Background(), &accessmanager.RefreshTokenRequest{RefreshToken: "old-refresh-token"})
+
+	require.NoError(t, err)
+	require.Equal(t, newTokens.AccessToken, response.AccessToken)
+	require.Equal(t, newTokens.RefreshToken, response.RefreshToken)
+	require.Equal(t, &ephemeral.RefreshTokenRotationResult{
+		AccessToken:           newTokens.AccessToken,
+		RefreshToken:          newTokens.RefreshToken,
+		AccessTokenExpiresAt:  newTokens.AtExpires,
+		RefreshTokenExpiresAt: newTokens.RtExpires,
+	}, storedResult)
+	require.Equal(t, 1, store.deleteAuthCalls)
+	require.Equal(t, 1, store.acquireRefreshTokenRotationLockCalls)
+	require.Equal(t, 1, store.releaseRefreshTokenRotationLockCalls)
+}
+
+// TestServiceRefreshTokenReplaysWhenDeleteMissesAfterAnotherRotation verifies a delete miss can still replay the cached result.
+func TestServiceRefreshTokenReplaysWhenDeleteMissesAfterAnotherRotation(t *testing.T) {
+	t.Parallel()
+
+	cached := &ephemeral.RefreshTokenRotationResult{
+		AccessToken:           "cached-access-token",
+		RefreshToken:          "cached-refresh-token",
+		AccessTokenExpiresAt:  100,
+		RefreshTokenExpiresAt: 200,
+	}
+	getCalls := 0
+	store := &refreshEphemeralStoreMock{
+		getRefreshTokenRotationResultFunc: func(ctx context.Context, userID, refreshTokenUUID string) (*ephemeral.RefreshTokenRotationResult, error) {
+			getCalls++
+			if getCalls >= 2 {
+				return cached, nil
+			}
+			return nil, nil
+		},
+		deleteAuthFunc: func(ctx context.Context, tokenID string) (int64, error) {
+			return 0, nil
+		},
+	}
+	service := newRefreshTokenTestService(store, &refreshAuthServiceMock{})
+
+	response, err := service.RefreshToken(context.Background(), &accessmanager.RefreshTokenRequest{RefreshToken: "old-refresh-token"})
+
+	require.NoError(t, err)
+	require.Equal(t, cached.AccessToken, response.AccessToken)
+	require.Equal(t, cached.RefreshToken, response.RefreshToken)
+	require.Equal(t, 1, store.deleteAuthCalls)
+	require.Equal(t, 1, store.acquireRefreshTokenRotationLockCalls)
+	require.Equal(t, 1, store.releaseRefreshTokenRotationLockCalls)
+}
+
+// TestServiceRefreshTokenReturnsContextCancellationWhileWaitingForRotation verifies waiters respect request cancellation.
+func TestServiceRefreshTokenReturnsContextCancellationWhileWaitingForRotation(t *testing.T) {
+	t.Parallel()
+
+	store := &refreshEphemeralStoreMock{
+		acquireRefreshTokenRotationLockFunc: func(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error) {
+			return false, nil
+		},
+	}
+	service := newRefreshTokenTestService(store, &refreshAuthServiceMock{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	response, err := service.RefreshToken(ctx, &accessmanager.RefreshTokenRequest{RefreshToken: "old-refresh-token"})
+
+	require.Nil(t, response)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, store.deleteAuthCalls)
+	require.Equal(t, 1, store.acquireRefreshTokenRotationLockCalls)
+	require.Zero(t, store.releaseRefreshTokenRotationLockCalls)
+}

--- a/external/ephemeral/model.go
+++ b/external/ephemeral/model.go
@@ -16,6 +16,19 @@ type TokenDetailsAuth interface {
 	GetTokenRefreshTimeToLive() time.Duration
 }
 
+// RefreshTokenRotationResult is the short-lived replay payload stored when a
+// refresh token has just been rotated.
+type RefreshTokenRotationResult struct {
+	// AccessToken is the replacement access token returned by the winning refresh.
+	AccessToken string `json:"access_token"`
+	// RefreshToken is the replacement refresh token returned by the winning refresh.
+	RefreshToken string `json:"refresh_token"`
+	// AccessTokenExpiresAt is the replacement access token expiry timestamp.
+	AccessTokenExpiresAt int64 `json:"access_token_expires_at"`
+	// RefreshTokenExpiresAt is the replacement refresh token expiry timestamp.
+	RefreshTokenExpiresAt int64 `json:"refresh_token_expires_at"`
+}
+
 // TokenDetailsAccess holds methods for a passing valid
 // token access details
 type TokenDetailsAccess interface {
@@ -62,14 +75,14 @@ type TokenDetails struct {
 	EvTtl time.Duration
 }
 
-// GetTokenAccessUuidreturns the access token's uuid
+// GetTokenAccessUuid returns the access token's uuid
 func (t *TokenDetails) GetTokenAccessUuid() string {
 	return t.AccessUuid
 }
 
 // GetTokenRefreshUuid returns the refresh token's uuid
 func (t *TokenDetails) GetTokenRefreshUuid() string {
-	return t.RefreshToken
+	return t.RefreshUuid
 }
 
 // GetTokenAccessTimeToLive returns the access token's time to live
@@ -77,7 +90,7 @@ func (t *TokenDetails) GetTokenAccessTimeToLive() time.Duration {
 	return t.AtTtl
 }
 
-// GetTokenAccessTimeToLive returns the refresh token's time to live
+// GetTokenRefreshTimeToLive returns the refresh token's time to live
 func (t *TokenDetails) GetTokenRefreshTimeToLive() time.Duration {
 	return t.RtTtl
 }
@@ -131,17 +144,17 @@ func (t *TokenAccessDetails) GetTokenAccessUuid() string {
 	return t.AccessUuid
 }
 
-// GetTokenAccessUuid returns the user id of the token's owner
+// GetUserId returns the user id of the token's owner
 func (t *TokenAccessDetails) GetUserId() string {
 	return t.UserId
 }
 
-// GetTokenAccessUuid returns whether the token's owner is an admin
+// IsUserAdmin returns whether the token's owner is an admin
 func (t *TokenAccessDetails) IsUserAdmin() bool {
 	return t.IsAdmin
 }
 
-// GetTokenAccessUuid returns whether the owner's account is in an active state
+// IsUserAuthorized returns whether the owner's account is in an active state
 func (t *TokenAccessDetails) IsUserAuthorized() bool {
 	return t.IsAuthorized
 }

--- a/external/ephemeral/redisstore.go
+++ b/external/ephemeral/redisstore.go
@@ -2,6 +2,8 @@ package ephemeral
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -15,6 +17,8 @@ import (
 // PersistentClient holds methods for a valid cache
 type PersistentClient interface {
 	Set(key string, value interface{}, expiration time.Duration) *redis.StatusCmd
+	// SetNX stores a value only when the key is not already present.
+	SetNX(key string, value interface{}, expiration time.Duration) *redis.BoolCmd
 	Get(key string) *redis.StringCmd
 	Del(keys ...string) *redis.IntCmd
 	Incr(key string) *redis.IntCmd
@@ -25,6 +29,24 @@ const (
 	// prefixTemplate is how the cache key prefix should be shaped, <appComponent>-<appEnvironment>_
 	prefixTemplate string = "%s-%s_"
 )
+
+// refreshTokenRotationKey returns the cache key for a completed refresh rotation result.
+func refreshTokenRotationKey(userID, refreshTokenUUID string) string {
+	return fmt.Sprintf("refresh-rotation:%s:%s", userID, refreshTokenUUID)
+}
+
+// refreshTokenRotationLockKey returns the cache key for the in-flight refresh rotation lock.
+func refreshTokenRotationLockKey(userID, refreshTokenUUID string) string {
+	return fmt.Sprintf("refresh-rotation-lock:%s:%s", userID, refreshTokenUUID)
+}
+
+// loginEmailCooldownKey returns a non-reversible login-email cooldown key for a user/context.
+func loginEmailCooldownKey(userID string, isDashboardRequest bool, requestURL string) string {
+	// requestURLHash keeps the request context out of the raw Redis key while still scoping cooldowns.
+	requestURLHash := sha256.Sum256([]byte(requestURL))
+
+	return fmt.Sprintf("login-email-cooldown:%s:%t:%x", userID, isDashboardRequest, requestURLHash)
+}
 
 // Client communicates with the persistent storage
 type Client struct {
@@ -77,6 +99,69 @@ func (c *Client) CreateAuth(ctx context.Context, userID string, tokenDetails Tok
 	}
 
 	return nil
+}
+
+// AcquireRefreshTokenRotationLock tries to claim the rotation for a refresh token.
+func (c *Client) AcquireRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error) {
+	completeKey := c.keyPrefix + refreshTokenRotationLockKey(userID, refreshTokenUUID)
+
+	return c.client.SetNX(completeKey, "1", ttl).Result()
+}
+
+// ReleaseRefreshTokenRotationLock releases a previously acquired refresh rotation lock.
+func (c *Client) ReleaseRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string) (int64, error) {
+	completeKey := c.keyPrefix + refreshTokenRotationLockKey(userID, refreshTokenUUID)
+
+	return c.client.Del(completeKey).Result()
+}
+
+// StoreRefreshTokenRotationResult stores the newly issued token pair for brief replay.
+func (c *Client) StoreRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string, result *RefreshTokenRotationResult, ttl time.Duration) error {
+	if result == nil {
+		return fmt.Errorf("nil refresh token rotation result")
+	}
+
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	completeKey := c.keyPrefix + refreshTokenRotationKey(userID, refreshTokenUUID)
+	return c.client.Set(completeKey, string(payload), ttl).Err()
+}
+
+// GetRefreshTokenRotationResult retrieves a recently rotated token pair.
+func (c *Client) GetRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string) (*RefreshTokenRotationResult, error) {
+	completeKey := c.keyPrefix + refreshTokenRotationKey(userID, refreshTokenUUID)
+
+	raw, err := c.client.Get(completeKey).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var result RefreshTokenRotationResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// AcquireLoginEmailCooldown tries to claim the login-email cooldown window.
+func (c *Client) AcquireLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error) {
+	completeKey := c.keyPrefix + loginEmailCooldownKey(userID, isDashboardRequest, requestURL)
+
+	return c.client.SetNX(completeKey, "1", ttl).Result()
+}
+
+// ReleaseLoginEmailCooldown releases a login-email cooldown claim.
+func (c *Client) ReleaseLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string) (int64, error) {
+	completeKey := c.keyPrefix + loginEmailCooldownKey(userID, isDashboardRequest, requestURL)
+
+	return c.client.Del(completeKey).Result()
 }
 
 // DeleteAllTokenExceptedSpecified deletes all keys except the ones specified

--- a/external/ephemeral/redisstore_test.go
+++ b/external/ephemeral/redisstore_test.go
@@ -1,0 +1,142 @@
+package ephemeral
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v7"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePersistentClient implements the Redis commands used by these store tests.
+type fakePersistentClient struct {
+	values map[string]string
+}
+
+// newFakePersistentClient creates an in-memory Redis-like client for store tests.
+func newFakePersistentClient() *fakePersistentClient {
+	return &fakePersistentClient{values: map[string]string{}}
+}
+
+func (f *fakePersistentClient) Set(key string, value interface{}, expiration time.Duration) *redis.StatusCmd {
+	f.values[key] = value.(string)
+	return redis.NewStatusResult("OK", nil)
+}
+
+func (f *fakePersistentClient) SetNX(key string, value interface{}, expiration time.Duration) *redis.BoolCmd {
+	if _, ok := f.values[key]; ok {
+		return redis.NewBoolResult(false, nil)
+	}
+
+	f.values[key] = value.(string)
+	return redis.NewBoolResult(true, nil)
+}
+
+func (f *fakePersistentClient) Get(key string) *redis.StringCmd {
+	value, ok := f.values[key]
+	if !ok {
+		return redis.NewStringResult("", redis.Nil)
+	}
+
+	return redis.NewStringResult(value, nil)
+}
+
+func (f *fakePersistentClient) Del(keys ...string) *redis.IntCmd {
+	var deleted int64
+	for _, key := range keys {
+		if _, ok := f.values[key]; ok {
+			delete(f.values, key)
+			deleted++
+		}
+	}
+
+	return redis.NewIntResult(deleted, nil)
+}
+
+func (f *fakePersistentClient) Incr(key string) *redis.IntCmd {
+	return redis.NewIntResult(1, nil)
+}
+
+func (f *fakePersistentClient) Scan(cursor uint64, match string, count int64) *redis.ScanCmd {
+	return redis.NewScanCmdResult([]string{}, 0, nil)
+}
+
+// TestRefreshTokenRotationResultStore verifies refresh rotation replay payload persistence.
+func TestRefreshTokenRotationResultStore(t *testing.T) {
+	t.Parallel()
+
+	store := NewRedisStore(newFakePersistentClient(), 10, "Astr", "local")
+	ctx := context.Background()
+
+	got, err := store.GetRefreshTokenRotationResult(ctx, "user-1", "old-refresh")
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	result := &RefreshTokenRotationResult{
+		AccessToken:           "access-token",
+		RefreshToken:          "refresh-token",
+		AccessTokenExpiresAt:  100,
+		RefreshTokenExpiresAt: 200,
+	}
+
+	require.NoError(t, store.StoreRefreshTokenRotationResult(ctx, "user-1", "old-refresh", result, time.Second))
+
+	got, err = store.GetRefreshTokenRotationResult(ctx, "user-1", "old-refresh")
+	require.NoError(t, err)
+	require.Equal(t, result, got)
+
+	require.Error(t, store.StoreRefreshTokenRotationResult(ctx, "user-1", "old-refresh", nil, time.Second))
+}
+
+// TestRefreshTokenRotationLock verifies one caller can hold a refresh rotation lock at a time.
+func TestRefreshTokenRotationLock(t *testing.T) {
+	t.Parallel()
+
+	store := NewRedisStore(newFakePersistentClient(), 10, "Astr", "local")
+	ctx := context.Background()
+
+	acquired, err := store.AcquireRefreshTokenRotationLock(ctx, "user-1", "old-refresh", time.Second)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	acquired, err = store.AcquireRefreshTokenRotationLock(ctx, "user-1", "old-refresh", time.Second)
+	require.NoError(t, err)
+	require.False(t, acquired)
+
+	deleted, err := store.ReleaseRefreshTokenRotationLock(ctx, "user-1", "old-refresh")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted)
+
+	acquired, err = store.AcquireRefreshTokenRotationLock(ctx, "user-1", "old-refresh", time.Second)
+	require.NoError(t, err)
+	require.True(t, acquired)
+}
+
+// TestLoginEmailCooldown verifies login-email cooldown keys suppress duplicate sends per context.
+func TestLoginEmailCooldown(t *testing.T) {
+	t.Parallel()
+
+	store := NewRedisStore(newFakePersistentClient(), 10, "Astr", "local")
+	ctx := context.Background()
+
+	acquired, err := store.AcquireLoginEmailCooldown(ctx, "user-1", false, "/app", time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	acquired, err = store.AcquireLoginEmailCooldown(ctx, "user-1", false, "/app", time.Minute)
+	require.NoError(t, err)
+	require.False(t, acquired)
+
+	acquired, err = store.AcquireLoginEmailCooldown(ctx, "user-1", false, "/different", time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	deleted, err := store.ReleaseLoginEmailCooldown(ctx, "user-1", false, "/app")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted)
+
+	acquired, err = store.AcquireLoginEmailCooldown(ctx, "user-1", false, "/app", time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+}

--- a/external/starter/v0/starter_test.go
+++ b/external/starter/v0/starter_test.go
@@ -1265,6 +1265,36 @@ func (fakeEphemeralStore) DeleteAuth(ctx context.Context, tokenID string) (int64
 	return 0, nil
 }
 
+// AcquireRefreshTokenRotationLock stubs refresh rotation locking for starter tests.
+func (fakeEphemeralStore) AcquireRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+// ReleaseRefreshTokenRotationLock stubs refresh rotation lock release for starter tests.
+func (fakeEphemeralStore) ReleaseRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string) (int64, error) {
+	return 1, nil
+}
+
+// StoreRefreshTokenRotationResult stubs refresh rotation replay storage for starter tests.
+func (fakeEphemeralStore) StoreRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string, result *ephemeral.RefreshTokenRotationResult, ttl time.Duration) error {
+	return nil
+}
+
+// GetRefreshTokenRotationResult stubs refresh rotation replay lookup for starter tests.
+func (fakeEphemeralStore) GetRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string) (*ephemeral.RefreshTokenRotationResult, error) {
+	return nil, nil
+}
+
+// AcquireLoginEmailCooldown stubs login-email cooldown acquisition for starter tests.
+func (fakeEphemeralStore) AcquireLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+// ReleaseLoginEmailCooldown stubs login-email cooldown release for starter tests.
+func (fakeEphemeralStore) ReleaseLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string) (int64, error) {
+	return 1, nil
+}
+
 func (fakeEphemeralStore) AddRequestCountEntry(ctx context.Context, clientIP string) error {
 	return nil
 }
@@ -1317,6 +1347,36 @@ func (fakeAccessEphemeralStore) FetchAuth(ctx context.Context, accessDetails eph
 
 func (fakeAccessEphemeralStore) DeleteAuth(ctx context.Context, tokenID string) (int64, error) {
 	return 0, nil
+}
+
+// AcquireRefreshTokenRotationLock stubs refresh rotation locking for access starter tests.
+func (fakeAccessEphemeralStore) AcquireRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+// ReleaseRefreshTokenRotationLock stubs refresh rotation lock release for access starter tests.
+func (fakeAccessEphemeralStore) ReleaseRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string) (int64, error) {
+	return 1, nil
+}
+
+// StoreRefreshTokenRotationResult stubs refresh rotation replay storage for access starter tests.
+func (fakeAccessEphemeralStore) StoreRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string, result *ephemeral.RefreshTokenRotationResult, ttl time.Duration) error {
+	return nil
+}
+
+// GetRefreshTokenRotationResult stubs refresh rotation replay lookup for access starter tests.
+func (fakeAccessEphemeralStore) GetRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string) (*ephemeral.RefreshTokenRotationResult, error) {
+	return nil, nil
+}
+
+// AcquireLoginEmailCooldown stubs login-email cooldown acquisition for access starter tests.
+func (fakeAccessEphemeralStore) AcquireLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+// ReleaseLoginEmailCooldown stubs login-email cooldown release for access starter tests.
+func (fakeAccessEphemeralStore) ReleaseLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string) (int64, error) {
+	return 1, nil
 }
 
 func (fakeAccessEphemeralStore) AddRequestCountEntry(ctx context.Context, clientIP string) error {


### PR DESCRIPTION
## Context

Concurrent refresh-token requests could trigger duplicate token generation, with the second request overwriting the first's new tokens in the ephemeral store — causing the first client to receive credentials that no longer match what's on the server. Login emails could also be sent multiple times for the same user/context when rapid duplicate requests arrived before the first email send completed.

We needed lock-based concurrency control for refresh token rotation so competing requests either run the rotation once or replay the winner's result, and a cooldown mechanism for login emails so only one email is sent per user/context within a configurable window.

## What has been done

### Refresh-token rotation with lock-based replay cache
- **`AcquireRefreshTokenRotationLock` / `ReleaseRefreshTokenRotationLock`** — distributed lock via `SetNX` keyed by `<userID>:<tokenUUID>` so only one goroutine performs the rotation
- **`StoreRefreshTokenRotationResult` / `GetRefreshTokenRotationResult`** — short-lived JSON payload (configurable TTL) that lets concurrent duplicate requests replay the winning token pair
- **`waitForRefreshTokenRotationResponse`** — polls the rotation result on a ticker until the winner completes, respects context cancellation and a hard timeout
- **Delete-miss replay** — when `DeleteAuth` returns 0 (another request already removed the old token), the loser falls back to the cached rotation result instead of erroring
- **Lock release via `defer`** — always releases, even on panics or early returns
- Refactored `RefreshToken` to extract `refreshTokenUserFromCookieValue` and `refreshTokenRotationResponse` helpers

### Login-email cooldown
- **`AcquireLoginEmailCooldown` / `ReleaseLoginEmailCooldown`** — `SetNX`-based cooldown keyed by user ID, dashboard flag, and a hash of the request URL
- **`defer`-based release** — cooldown is released if the email send fails, so a retry is not blocked; only committed (`keepCooldown = true`) after the email manager accepts the send
- Returns empty string (not an error) when cooldown is active, letting the caller treat it as a silent skip

### Ephemeral store additions
- `RedisStore` methods for all four operations above (`AcquireRefreshTokenRotationLock`, `Release`, `StoreRefreshTokenRotationResult`, `Get`, `AcquireLoginEmailCooldown`, `Release`)
- `PersistentClient` interface now includes `SetNX`
- Model fixes: `GetTokenRefreshUuid` was returning `RefreshToken` instead of `RefreshUuid`; various comment typos corrected

### Tests
- **`service_refresh_test.go`** — tests replay of cached rotation, waiting for in-flight rotation, storing result after successful rotation, delete-miss replay, and context cancellation during wait
- **`service_login_email_test.go`** — tests cooldown skips duplicate sends, normal flow when cooldown is acquired, and cooldown release when email send fails
- **`redisstore_test.go`** — in-memory fake Redis client testing refresh rotation result store, lock acquire/release (single vs. concurrent), and login-email cooldown per URL scope
- Updated starter test stubs to implement the new `EphemeralStore` interface methods

### Documentation
- ADR-008 covering the refresh rotation and login-email cooldown architecture decisions
- Updated getting-started/access-manager README, how-to/authenticating-the-app, and middleware README

## Tests

- Added unit tests for refresh rotation (replay, wait, lock lifecycle, cancellation, delete-miss)
- Added unit tests for login-email cooldown (duplicate suppression, flow-on-acquire, release-on-failure)
- Added unit tests for Redis store-level operations (rotation result, lock, cooldown)
- All existing tests continue to pass
