### PR TITLE
[GHATD-X] Allow public-or-active routes to clear bad auth cookies

### DIFF
--- a/docs/adr/adr009-public-rate-limit-or-active-cookie-downgrade.md
+++ b/docs/adr/adr009-public-rate-limit-or-active-cookie-downgrade.md
@@ -1,0 +1,87 @@
+---
+id: adrs-adr009
+title: 'ADR009: Public RateLimitOrActive Cookie Downgrade'
+# prettier-ignore
+description: Architecture Decision Record (ADR) for downgrading invalid cookie auth state to anonymous access on public-or-active middleware
+date: 2026-05-21
+status: accepted
+---
+
+## Status
+
+Accepted.
+
+## Context
+
+Access Manager supports routes that may be used by either authenticated active
+users or anonymous callers subject to rate limiting. These routes use
+`RateLimitOrActiveJWTRequired`: authenticated requests receive user context,
+while requests without credentials receive an anonymous placeholder user and
+still pass through the route handler.
+
+Some browser and crawler clients can send stale, empty, or otherwise invalid
+auth cookies to a public-or-active route. That can happen after cookie deletion,
+session expiry, failed refresh, restored browser state, or client-side replay of
+old headers. In the previous behavior, the presence of an auth or refresh cookie
+forced the middleware down the JWT validation path. If that validation or token
+refresh failed, the middleware cleared cookies and returned an auth error.
+
+That strict response is correct for protected routes, but it is surprising for
+public-or-active routes: the same request would have succeeded as anonymous if
+the client had not sent broken cookie state. The broken cookie therefore poisons
+public content until the client accepts and applies the deletion response.
+
+## Decision
+
+`RateLimitOrActiveJWTRequired` will preserve authenticated behavior when valid
+credentials are present:
+
+1. Valid auth cookies still attach authenticated user context.
+2. Expired access cookies with valid refresh cookies still attempt refresh.
+3. Successful refreshes still commit replacement cookies only after retry
+   validation succeeds.
+
+Cookie authentication remains the credential mechanism for this middleware.
+Unlike API-token-or-JWT middleware variants, `RateLimitOrActiveJWTRequired` does
+not validate `X-Api-Token` headers.
+
+When cookie auth is unusable on a public-or-active route, the middleware will
+clear auth cookies and downgrade the request to the anonymous rate-limited flow
+instead of returning an auth error:
+
+1. Missing or empty cookie values are treated as unauthenticated for this
+   middleware.
+2. Missing refresh cookies on an otherwise cookie-authenticated request clear
+   auth cookies and continue as anonymous.
+3. Failed auth validation, failed refresh, or failed retry validation clear auth
+   cookies and continue as anonymous.
+4. The `Authorization` header set from cookie auth is removed before the
+   anonymous retry so invalid cookie state cannot leak into the public flow.
+5. The middleware emits safe structured logs for downgrades without recording
+   token values.
+
+If a request also supplied its own `Authorization` header, cookie-derived auth
+continues to take precedence. A downgraded public-or-active request removes the
+header before entering the anonymous rate-limited flow.
+
+Protected middleware such as `JWTRequired`, `ActiveJWTRequired`, and
+`ActiveValidApiTokenOrJWTRequired` remains strict. Broken auth state on protected
+routes still clears cookies and returns an auth error.
+
+## Consequences
+
+Public-or-active endpoints become resilient to stale or empty auth cookie state.
+A client with broken cookies receives the same public body and status code it
+would have received with no cookies, while still receiving deletion headers for
+the invalid state.
+
+The downgrade does not grant private access. When auth validation fails, the
+request proceeds only with the anonymous placeholder user produced by the
+rate-limited flow.
+
+Host applications can rely on public-or-active routes for public content without
+letting stale auth cookies turn those routes into hard auth failures. They
+should still use protected middleware for endpoints that require a real user.
+
+Operationally, invalid cookie state is easier to observe because downgrades are
+logged with reason and cookie-presence metadata, but without auth token values.

--- a/external/accessmanager/middleware/middleware.go
+++ b/external/accessmanager/middleware/middleware.go
@@ -7,8 +7,10 @@ import (
 	"github.com/ooaklee/ghatd/external/accessmanager"
 	accessmanagerhelpers "github.com/ooaklee/ghatd/external/accessmanager/helpers"
 	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/ghatd/external/toolbox"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // jwtValidationType defines the type of JWT validation to perform
@@ -276,39 +278,34 @@ func (m *Middleware) RateLimitOrActiveJWTRequired(handler http.Handler) http.Han
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		authCookie, _ := req.Cookie(m.cookiePrefixAuthToken)
 		refreshCookie, _ := req.Cookie(m.cookiePrefixRefreshToken)
+		hasAuthCookie := authCookie != nil && authCookie.Value != ""
+		hasRefreshCookie := refreshCookie != nil && refreshCookie.Value != ""
 
-		// If both cookies are absent, use rate limiting flow
-		if authCookie == nil && refreshCookie == nil {
-			authedUserResp, err := m.service.MiddlewareRateLimitOrActiveJWTRequired(req)
-			if err != nil {
-				m.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
-				return
-			}
-
-			req = handleTransmittingAuthenticatedUserDetails(req, authedUserResp)
-
-			handler.ServeHTTP(w, req)
+		// If both cookies are absent or empty, use the public rate-limited flow.
+		if !hasAuthCookie && !hasRefreshCookie {
+			m.handleRateLimitOrActiveUnauthenticated(w, req, handler, authCookie != nil || refreshCookie != nil, "empty-or-missing-auth-cookies", nil, authCookie, refreshCookie)
 			return
 		}
 
 		// Otherwise handle JWT authentication with refresh capability
-		if refreshCookie == nil {
-			toolbox.RemoveAuthCookies(w, m.environment, m.cookieDomain, m.cookiePrefixAuthToken, m.cookiePrefixRefreshToken)
-			m.getBaseResponseHandler().NewHTTPErrorResponse(w, accessmanager.ErrUnauthorizedUnableToAttainRequestorID)
+		if !hasAuthCookie {
+			m.handleRateLimitOrActiveUnauthenticated(w, req, handler, true, "missing-auth-cookie", accessmanager.ErrUnauthorizedUnableToAttainRequestorID, authCookie, refreshCookie)
 			return
 		}
 
-		if authCookie != nil {
-			req.Header["Authorization"] = []string{"Bearer " + authCookie.Value}
+		if !hasRefreshCookie {
+			m.handleRateLimitOrActiveUnauthenticated(w, req, handler, true, "missing-refresh-cookie", accessmanager.ErrUnauthorizedUnableToAttainRequestorID, authCookie, refreshCookie)
+			return
 		}
+
+		req.Header["Authorization"] = []string{"Bearer " + authCookie.Value}
 
 		authedUserResp, err := m.service.MiddlewareRateLimitOrActiveJWTRequired(req)
 		if err != nil {
 			// Try token refresh
 			authedUserResp, refreshErr := m.attemptTokenRefresh(w, req, refreshCookie, m.service.MiddlewareRateLimitOrActiveJWTRequired)
 			if refreshErr != nil {
-				toolbox.RemoveAuthCookies(w, m.environment, m.cookieDomain, m.cookiePrefixAuthToken, m.cookiePrefixRefreshToken)
-				m.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+				m.handleRateLimitOrActiveUnauthenticated(w, req, handler, true, "auth-validation-or-refresh-failed", err, authCookie, refreshCookie)
 				return
 			}
 
@@ -322,6 +319,40 @@ func (m *Middleware) RateLimitOrActiveJWTRequired(handler http.Handler) http.Han
 
 		handler.ServeHTTP(w, req)
 	})
+}
+
+func (m *Middleware) handleRateLimitOrActiveUnauthenticated(
+	w http.ResponseWriter,
+	req *http.Request,
+	handler http.Handler,
+	clearCookies bool,
+	reason string,
+	authErr error,
+	authCookie *http.Cookie,
+	refreshCookie *http.Cookie,
+) {
+	if clearCookies {
+		toolbox.RemoveAuthCookies(w, m.environment, m.cookieDomain, m.cookiePrefixAuthToken, m.cookiePrefixRefreshToken)
+		logger.Info(req.Context(), "rate-limit-or-active-auth-downgraded",
+			zap.String("reason", reason),
+			zap.Bool("has-auth-cookie", authCookie != nil),
+			zap.Bool("auth-cookie-empty", authCookie != nil && authCookie.Value == ""),
+			zap.Bool("has-refresh-cookie", refreshCookie != nil),
+			zap.Bool("refresh-cookie-empty", refreshCookie != nil && refreshCookie.Value == ""),
+			zap.Error(authErr),
+		)
+	}
+
+	req.Header.Del("Authorization")
+	authedUserResp, err := m.service.MiddlewareRateLimitOrActiveJWTRequired(req)
+	if err != nil {
+		m.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	req = handleTransmittingAuthenticatedUserDetails(req, authedUserResp)
+
+	handler.ServeHTTP(w, req)
 }
 
 // handleAdminAPITokenRequiredRequest is checking to make sure the request

--- a/external/accessmanager/middleware/middleware_test.go
+++ b/external/accessmanager/middleware/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ooaklee/ghatd/external/accessmanager"
 	accessmanagerhelpers "github.com/ooaklee/ghatd/external/accessmanager/helpers"
 	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/ephemeral"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 	"github.com/ooaklee/reply/v2"
 )
@@ -113,6 +114,18 @@ func createTestHandler() http.Handler {
 func responseHasCookieValue(cookies []*http.Cookie, name, value string) bool {
 	for _, cookie := range cookies {
 		if cookie.Name == name && cookie.Value == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+// responseHasCookieRemoval reports whether a response included an expired cookie
+// marker for the supplied name.
+func responseHasCookieRemoval(cookies []*http.Cookie, name string) bool {
+	for _, cookie := range cookies {
+		if cookie.Name == name && cookie.Value == "" && cookie.MaxAge < 0 {
 			return true
 		}
 	}
@@ -578,6 +591,160 @@ func TestRateLimitOrActiveJWTRequired_NoCookies(t *testing.T) {
 	}
 }
 
+func TestRateLimitOrActiveJWTRequired_EmptyCookiesFallsBackToPublicFlowAndClearsCookies(t *testing.T) {
+	userID := "rate-limited-user"
+	callCount := 0
+	mockService := &mockAccessManagerService{
+		middlewareRateLimitOrActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			callCount++
+			if got := r.Header.Get("Authorization"); got != "" {
+				t.Errorf("Expected empty cookies to be removed from Authorization fallback, got %q", got)
+			}
+			return mockAuthedResp(userID, userv2.AccountStatusKeyActive, []string{userv2.UserRoleUser}), nil
+		},
+	}
+
+	middleware := createTestMiddleware(mockService)
+	handler := createTestHandler()
+	wrappedHandler := middleware.RateLimitOrActiveJWTRequired(handler)
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "test_auth", Value: ""})
+	req.AddCookie(&http.Cookie{Name: "test_refresh", Value: ""})
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
+	}
+	if callCount != 1 {
+		t.Errorf("Expected public flow to be called once, got %d", callCount)
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_auth") {
+		t.Error("Expected empty access cookie to be cleared")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_refresh") {
+		t.Error("Expected empty refresh cookie to be cleared")
+	}
+}
+
+func TestRateLimitOrActiveJWTRequired_MissingRefreshCookieFallsBackToPublicFlowAndClearsCookies(t *testing.T) {
+	userID := "rate-limited-user"
+	callCount := 0
+	mockService := &mockAccessManagerService{
+		middlewareRateLimitOrActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			callCount++
+			if got := r.Header.Get("Authorization"); got != "" {
+				t.Errorf("Expected missing refresh fallback to remove Authorization, got %q", got)
+			}
+			return mockAuthedResp(userID, userv2.AccountStatusKeyActive, []string{userv2.UserRoleUser}), nil
+		},
+	}
+
+	middleware := createTestMiddleware(mockService)
+	handler := createTestHandler()
+	wrappedHandler := middleware.RateLimitOrActiveJWTRequired(handler)
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "test_auth", Value: "orphaned-access-token"})
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
+	}
+	if callCount != 1 {
+		t.Errorf("Expected public flow to be called once, got %d", callCount)
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_auth") {
+		t.Error("Expected orphaned access cookie to be cleared")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_refresh") {
+		t.Error("Expected refresh cookie deletion marker to be set")
+	}
+}
+
+func TestRateLimitOrActiveJWTRequired_MissingAuthCookieFallsBackToPublicFlowAndClearsCookies(t *testing.T) {
+	userID := "rate-limited-user"
+	callCount := 0
+	mockService := &mockAccessManagerService{
+		middlewareRateLimitOrActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			callCount++
+			if got := r.Header.Get("Authorization"); got != "" {
+				t.Errorf("Expected missing auth fallback to remove Authorization, got %q", got)
+			}
+			return mockAuthedResp(userID, userv2.AccountStatusKeyActive, []string{userv2.UserRoleUser}), nil
+		},
+	}
+
+	middleware := createTestMiddleware(mockService)
+	handler := createTestHandler()
+	wrappedHandler := middleware.RateLimitOrActiveJWTRequired(handler)
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "test_refresh", Value: "orphaned-refresh-token"})
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
+	}
+	if callCount != 1 {
+		t.Errorf("Expected public flow to be called once, got %d", callCount)
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_auth") {
+		t.Error("Expected access cookie deletion marker to be set")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_refresh") {
+		t.Error("Expected orphaned refresh cookie to be cleared")
+	}
+}
+
+func TestRateLimitOrActiveJWTRequired_FallbackRateLimitErrorReturnsHTTPError(t *testing.T) {
+	handlerCalled := false
+	mockService := &mockAccessManagerService{
+		middlewareRateLimitOrActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			return nil, ephemeral.ErrRequestorLimitExceeded
+		},
+	}
+
+	middleware := NewMiddleware(&NewMiddlewareRequest{
+		Service:                  mockService,
+		ErrorMaps:                []reply.ErrorManifest{ephemeral.EphemeralStoreErrorMap},
+		Environment:              "test",
+		CookiePrefixAuthToken:    "test_auth",
+		CookiePrefixRefreshToken: "test_refresh",
+		CookieDomain:             "test.com",
+	})
+	wrappedHandler := middleware.RateLimitOrActiveJWTRequired(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "test_auth", Value: ""})
+	req.AddCookie(&http.Cookie{Name: "test_refresh", Value: ""})
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status code %d, got %d", http.StatusTooManyRequests, w.Code)
+	}
+	if handlerCalled {
+		t.Error("Did not expect handler to run when anonymous fallback is rate limited")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_auth") {
+		t.Error("Expected rate-limited fallback to clear access cookie")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_refresh") {
+		t.Error("Expected rate-limited fallback to clear refresh cookie")
+	}
+}
+
 func TestRateLimitOrActiveJWTRequired_WithValidJWT(t *testing.T) {
 	userID := "authenticated-user-123"
 	mockService := &mockAccessManagerService{
@@ -651,14 +818,17 @@ func TestRateLimitOrActiveJWTRequired_TokenRefresh(t *testing.T) {
 	}
 }
 
-// TestRateLimitOrActiveJWTRequired_RefreshRetryValidationFailureDoesNotSetNewCookies verifies RateLimitOrActiveJWTRequired uses the same cookie timing.
-func TestRateLimitOrActiveJWTRequired_RefreshRetryValidationFailureDoesNotSetNewCookies(t *testing.T) {
+// TestRateLimitOrActiveJWTRequired_RefreshRetryValidationFailureFallsBackWithoutNewCookies verifies RateLimitOrActiveJWTRequired downgrades to the public flow when retry validation rejects refreshed tokens.
+func TestRateLimitOrActiveJWTRequired_RefreshRetryValidationFailureFallsBackWithoutNewCookies(t *testing.T) {
 	callCount := 0
 	refreshCallCount := 0
 
 	mockService := &mockAccessManagerService{
 		middlewareRateLimitOrActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
 			callCount++
+			if r.Header.Get("Authorization") == "" {
+				return mockAuthedResp("rate-limited-user", userv2.AccountStatusKeyActive, []string{userv2.UserRoleUser}), nil
+			}
 			return nil, errors.New("token invalid")
 		},
 		refreshTokenFunc: func(ctx context.Context, r *accessmanager.RefreshTokenRequest) (*accessmanager.RefreshTokenResponse, error) {
@@ -683,11 +853,11 @@ func TestRateLimitOrActiveJWTRequired_RefreshRetryValidationFailureDoesNotSetNew
 
 	wrappedHandler.ServeHTTP(w, req)
 
-	if w.Code == http.StatusOK {
-		t.Error("Expected non-200 status code when retry validation rejects refreshed token")
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d after fallback, got %d", http.StatusOK, w.Code)
 	}
-	if callCount != 2 {
-		t.Errorf("Expected middleware function to be called twice, got %d", callCount)
+	if callCount != 3 {
+		t.Errorf("Expected middleware function to be called three times, got %d", callCount)
 	}
 	if refreshCallCount != 1 {
 		t.Errorf("Expected refresh token function to be called once, got %d", refreshCallCount)
@@ -698,14 +868,25 @@ func TestRateLimitOrActiveJWTRequired_RefreshRetryValidationFailureDoesNotSetNew
 	if responseHasCookieValue(w.Result().Cookies(), "test_refresh", "new-refresh-token") {
 		t.Error("Did not expect refreshed refresh cookie to be set before retry validation succeeds")
 	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_auth") {
+		t.Error("Expected failed refresh validation to clear access cookie")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_refresh") {
+		t.Error("Expected failed refresh validation to clear refresh cookie")
+	}
 }
 
-// TestRateLimitOrActiveJWTRequired_RefreshTokenFailure verifies failed refreshes do not set replacement cookies.
-func TestRateLimitOrActiveJWTRequired_RefreshTokenFailure(t *testing.T) {
+// TestRateLimitOrActiveJWTRequired_RefreshTokenFailureFallsBackWithoutNewCookies verifies failed refreshes do not set replacement cookies and continue as public.
+func TestRateLimitOrActiveJWTRequired_RefreshTokenFailureFallsBackWithoutNewCookies(t *testing.T) {
+	callCount := 0
 	refreshCallCount := 0
 
 	mockService := &mockAccessManagerService{
 		middlewareRateLimitOrActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			callCount++
+			if r.Header.Get("Authorization") == "" {
+				return mockAuthedResp("rate-limited-user", userv2.AccountStatusKeyActive, []string{userv2.UserRoleUser}), nil
+			}
 			return nil, errors.New("token expired")
 		},
 		refreshTokenFunc: func(ctx context.Context, r *accessmanager.RefreshTokenRequest) (*accessmanager.RefreshTokenResponse, error) {
@@ -725,8 +906,11 @@ func TestRateLimitOrActiveJWTRequired_RefreshTokenFailure(t *testing.T) {
 
 	wrappedHandler.ServeHTTP(w, req)
 
-	if w.Code == http.StatusOK {
-		t.Error("Expected non-200 status code when refresh token is invalid")
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d after fallback, got %d", http.StatusOK, w.Code)
+	}
+	if callCount != 2 {
+		t.Errorf("Expected middleware function to be called twice, got %d", callCount)
 	}
 	if refreshCallCount != 1 {
 		t.Errorf("Expected refresh token function to be called once, got %d", refreshCallCount)
@@ -736,6 +920,41 @@ func TestRateLimitOrActiveJWTRequired_RefreshTokenFailure(t *testing.T) {
 	}
 	if responseHasCookieValue(w.Result().Cookies(), "test_refresh", "new-refresh-token") {
 		t.Error("Did not expect refreshed refresh cookie to be set when refresh service fails")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_auth") {
+		t.Error("Expected failed refresh to clear access cookie")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_refresh") {
+		t.Error("Expected failed refresh to clear refresh cookie")
+	}
+}
+
+func TestActiveValidApiTokenOrJWTRequired_EmptyCookiesRemainProtected(t *testing.T) {
+	mockService := &mockAccessManagerService{
+		middlewareActiveJWTRequiredFunc: func(r *http.Request) (*accessmanager.MiddlewareAuthedUserResponse, error) {
+			return nil, errors.New("token invalid")
+		},
+	}
+
+	middleware := createTestMiddleware(mockService)
+	handler := createTestHandler()
+	wrappedHandler := middleware.ActiveValidApiTokenOrJWTRequired(handler)
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "test_auth", Value: ""})
+	req.AddCookie(&http.Cookie{Name: "test_refresh", Value: ""})
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Error("Expected protected middleware to reject empty auth cookies")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_auth") {
+		t.Error("Expected protected middleware to clear empty access cookie")
+	}
+	if !responseHasCookieRemoval(w.Result().Cookies(), "test_refresh") {
+		t.Error("Expected protected middleware to clear empty refresh cookie")
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR updates `RateLimitOrActiveJWTRequired` so public-or-active routes do not fail hard solely because a client carries unusable cookie auth state.

Public-or-active routes are meant to support either:

- authenticated active users, with user context attached, or
- anonymous callers, subject to rate limiting.

Before this change, the presence of an auth or refresh cookie forced the middleware down the cookie/JWT validation path. Empty, missing-pair, stale, invalid, or failed-refresh cookie state could therefore turn a route that should be publicly readable into an auth failure. This was especially noisy for browser or crawler clients that retained deleted cookie names with empty values.

## Changes

- Treat missing or empty auth/refresh cookie values as absent for `RateLimitOrActiveJWTRequired`.
- Clear bad cookie state before continuing as anonymous public traffic.
- Downgrade failed cookie validation, failed refresh, and failed retry validation to the anonymous rate-limited flow on public-or-active routes.
- Remove cookie-derived `Authorization` state before entering the anonymous fallback path.
- Preserve successful cookie auth and successful refresh behavior for valid sessions.
- Keep protected middleware strict: `JWTRequired`, `ActiveJWTRequired`, and `ActiveValidApiTokenOrJWTRequired` still clear cookies and return auth failures for protected routes.
- Add structured downgrade logging with reason and cookie-presence metadata, without token values.
- Document the decision in ADR009.

## Why

A public-or-active route should not become unavailable just because the caller has broken auth cookies. With this change, unusable cookie auth state is cleaned up and the request receives the same anonymous public response it would have received with no cookies.

This does not grant private access. Once auth validation fails, the request proceeds only through the anonymous placeholder user produced by the rate-limited flow.

## Tests

- `asdf exec go test ./external/accessmanager/...`
- `asdf exec go test ./external/starter/v0`
