### PR TITLE
[GHATD-X] Add timezone-aware streak and reminder integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A complete billing solution split into three composable packages for maximum fle
 - **[Logger](./external/logger/)** - Structured logging with middleware support
 - **[Notifier](./external/notifier/)** - Push notification registration, preferences, and delivery
 - **[Reminder](./docs/getting-started/reminder/)** - User-owned scheduled reminders with target-based lookups and execution tracking
+- **[Streaker](./docs/getting-started/streaker/)** - Generic idempotent streak completions, current/best stats, and history listing
 - **[Repository](./external/repository/)** - MongoDB repository patterns and utilities
 - **[Server](./external/http/server/)** - Ejectable HTTP server lifecycle helper with graceful shutdown
 - **[Starter/v0](./external/starter/v0/)** - Ejectable lazy composition layer for GHATD application wiring

--- a/docs/adr/adr007-starter-v0-lazy-composition-layer.md
+++ b/docs/adr/adr007-starter-v0-lazy-composition-layer.md
@@ -141,10 +141,17 @@ A follow-up slice adds package support for `external/reminder` and
   `RouteGroupUserManager` is attached.
 - `NewServicesRequest.ReminderService` remains an escape hatch for callers
   that want UMS to use a custom reminder implementation.
-- Streaker remains service-only in starter/v0. Host applications own any
-  streaker route shape, scheduler, or product-specific workflow.
+- Streaker is also attached to `Services.UserManager` by default when
+  available, enabling UMS streak routes while host applications continue to own
+  product-specific streak workflows and schedulers.
+- `NewServicesRequest.StreakService` remains an escape hatch for callers that
+  want UMS to use a custom streak implementation.
 - Starter does not run package migrations; consuming applications keep their
   Mongo migration flow and include reminder/streaker indexes there.
+
+ADR010 records the follow-up decision for optional reminder and streaker
+manager integrations, including the nil-service behaviour and product-workflow
+ownership boundary.
 
 ## Consequences
 

--- a/docs/adr/adr007-starter-v0-lazy-composition-layer.md
+++ b/docs/adr/adr007-starter-v0-lazy-composition-layer.md
@@ -128,6 +128,24 @@ This preserves ejectability: if the default wiring no longer fits, replace
 the single `AttachDefaultRoutes` call with per-package `AttachRoutes` calls
 or copy the function body.
 
+### Phase 4: Reminder and Streaker Package Support
+
+A follow-up slice adds package support for `external/reminder` and
+`external/streaker` without changing starter's ownership boundaries:
+
+- `NewRepositories` builds reminder and streaker Mongo repositories from the
+  core repository, while keeping per-repository overrides.
+- `NewServices` builds `Services.Reminder` and `Services.Streaker`.
+- The starter-created reminder service is attached to `Services.UserManager`
+  by default, so the existing UMS reminder routes are backed by reminder when
+  `RouteGroupUserManager` is attached.
+- `NewServicesRequest.ReminderService` remains an escape hatch for callers
+  that want UMS to use a custom reminder implementation.
+- Streaker remains service-only in starter/v0. Host applications own any
+  streaker route shape, scheduler, or product-specific workflow.
+- Starter does not run package migrations; consuming applications keep their
+  Mongo migration flow and include reminder/streaker indexes there.
+
 ## Consequences
 
 New GHATD projects gain a Lazy path that makes the first server easier to

--- a/docs/adr/adr010-optional-streaker-and-reminder-manager-integrations.md
+++ b/docs/adr/adr010-optional-streaker-and-reminder-manager-integrations.md
@@ -1,0 +1,99 @@
+---
+id: adrs-adr010
+title: 'ADR010: Optional Streaker and Reminder Manager Integrations'
+# prettier-ignore
+description: >
+  Architecture Decision Record (ADR) for exposing optional reminder and streaker
+  services through starter/v0 and User Manager while keeping product workflows
+  owned by host applications.
+date: 2026-05-22
+status: accepted
+---
+
+## Status
+
+Accepted.
+
+## Context
+
+GHATD provides reusable packages for reminder schedules and streak tracking.
+Both packages are intentionally generic: Reminder stores notification schedule
+intent, while Streaker records idempotent completions for a stable owner,
+target, period, and period key.
+
+Host applications often need these packages together with User Manager because
+reminders and streaks are usually user-scoped features. At the same time, the
+meaning of a reminder or streak is product-specific. One application might
+record a streak for opening the app, another for completing a lesson, and
+another for saving content. One application might send reminders through push,
+another through email, and another through a background job that selects content
+from a user-owned collection.
+
+Starter/v0 should make the common integration path easy without turning
+Reminder or Streaker into mandatory dependencies for every GHATD application.
+User Manager should expose user-scoped APIs when those services are configured,
+but applications that do not need reminders or streaks should still be able to
+build and run the rest of the stack.
+
+## Decision
+
+Reminder and Streaker will remain optional services in starter/v0.
+
+`NewRepositories` may build reminder and streaker repositories from the shared
+Mongo repository. `NewServices` may build `Services.Reminder` and
+`Services.Streaker` from those repositories. If either service cannot be built
+because its repository is absent, starter still constructs the rest of the
+service container.
+
+When available, starter attaches Reminder and Streaker to
+`Services.UserManager`. The User Manager route group can then expose
+authenticated `/me` reminder and streak APIs, plus admin/service read APIs where
+appropriate. The `/me` routes always scope operations to the authenticated
+requester. Admin/service streak reads may accept a target `user_id` after the
+caller has passed User Manager access checks.
+
+User Manager treats a missing optional service as a disabled integration. Direct
+calls to reminder or streak endpoints return a clear service-unavailable style
+error instead of panicking. Host application side effects should be even softer:
+they should log before attempting an optional record, skip when the service is
+not configured, and warn without failing the primary product action when an
+optional record fails.
+
+Product-specific semantics remain owned by host applications. A host
+application decides when a reminder is created, what schedule presets mean, when
+a streak should be recorded, which target IDs are stable aggregate scopes, which
+metadata should be stored, and which background job or notification transport
+uses reminder schedules. Streaker does not decide whether a playback, save,
+check-in, or task completion is valid; it only records the streak request it is
+given.
+
+Starter/v0 will not add a standalone Streaker route group. Streaker access is
+available through User Manager when attached, or directly through host-owned
+managers and handlers. Reminder keeps its existing package APIs and UMS
+integration, with starter wiring available as the lazy path.
+
+Package migrations remain host-owned. Starter may construct repositories and
+services, but it does not run Mongo migrations or background schedulers.
+
+## Consequences
+
+New GHATD applications can adopt reminders and streaks through the lazy starter
+path with minimal wiring, while applications that do not need those features do
+not pay an integration cost.
+
+User-scoped reminder and streak APIs become first-class User Manager
+integrations without making User Manager responsible for product-specific
+workflow decisions.
+
+Host applications have a clear failure policy. User-facing optional-service APIs
+can report that the integration is disabled, while primary product workflows can
+continue when optional streak or reminder side effects are unavailable.
+
+The boundary keeps Streaker accurate for aggregate actions. Host applications
+must choose stable target IDs for "once per period" goals and put
+event-specific resource IDs in metadata; otherwise they will create separate
+streak scopes per resource.
+
+The lazy starter API gains more surface area through optional services and
+override hooks. Documentation and tests need to stay explicit about nil-service
+behaviour so future packages follow the same optional-integration pattern.

--- a/docs/adr/adr011-timezone-aware-streaks-and-reminders.md
+++ b/docs/adr/adr011-timezone-aware-streaks-and-reminders.md
@@ -1,0 +1,81 @@
+---
+id: adrs-adr011
+title: 'ADR011: Timezone-Aware Streaks and Reminders'
+# prettier-ignore
+description: >
+  Architecture Decision Record (ADR) for deriving user-facing streak periods
+  and reminder due times from IANA timezones while keeping persisted timestamps
+  in UTC.
+date: 2026-05-23
+status: accepted
+---
+
+## Status
+
+Accepted.
+
+## Context
+
+Streaks and reminders are experienced in a user's local time. A daily streak
+should turn over at the user's local midnight, and a reminder set for 09:00
+should become due at 09:00 in the user's timezone. UTC remains the right storage
+format for timestamps, but UTC alone is not enough to derive user-facing period
+keys or scheduler due times.
+
+Before this decision, Streaker derived daily, weekly, and monthly period keys in
+UTC. Reminder stored a `timezone` value for display context, but scheduler due
+queries compared raw `target_time` strings. Host applications would therefore
+have needed to reimplement timezone-aware logic around GHATD, increasing the
+risk of inconsistent streak boundaries and reminder dispatch behaviour.
+
+## Decision
+
+GHATD will keep persisted event timestamps and due timestamps in UTC, but it
+will derive user-facing time concepts from IANA timezone names.
+
+Streaker accepts an optional `period_timezone` on `RecordStreakRequest`. Empty
+timezone values resolve to `UTC`; invalid non-empty values return a typed
+validation error. Streaker derives daily, weekly, and monthly `period_key`
+values after converting `occurred_at` into the effective timezone. The effective
+timezone is stored on each streak entry as `period_timezone` for auditability.
+`BuildPeriodKey` keeps its UTC-compatible behaviour, and
+`BuildPeriodKeyForTimezone` provides the timezone-aware helper for callers.
+
+`period_timezone` is not part of the streak uniqueness contract. Idempotency
+continues to use owner, streak type, target, period type, and period key. This
+keeps retries from different clients safe and prevents duplicate rows when a
+host application resolves the same local period through different request
+paths.
+
+Reminder treats `target_time` as the local wall-clock time for recurring
+reminder declarations. The initial supported wall-clock format is `HH:MM`, with
+legacy absolute timestamp parsing retained for compatibility. Reminder
+normalises the IANA `timezone`, computes `next_due_at` in UTC, and uses
+`next_due_at` for due scheduler lookups. Reminder execution records continue to
+store the attempted UTC scheduled time in `scheduled_for`.
+
+GHATD packages embed Go timezone data so consuming applications running in
+minimal containers can resolve IANA timezones without relying on OS tzdata.
+
+Host applications remain responsible for choosing the effective timezone source
+of truth. The preferred order is persisted user preference, request/client
+timezone, then `UTC`.
+
+## Consequences
+
+Users get streak boundaries and reminder due times that match their local day
+and local wall-clock expectations.
+
+Host applications can use shared GHATD helpers instead of writing their own
+timezone conversion code around Streaker and Reminder.
+
+Existing callers remain compatible. Missing timezone input preserves UTC
+behaviour, existing `BuildPeriodKey` calls stay UTC-based, and legacy reminder
+absolute target times can still be parsed.
+
+Reminder scheduler workers should poll by `next_due_at`. Existing reminder data
+that lacks `next_due_at` should be backfilled before a production worker relies
+exclusively on timezone-aware due polling.
+
+Embedding timezone data slightly increases binary size, but it removes a common
+deployment footgun for minimal images.

--- a/docs/adr/adr012-client-platform-and-timezone-request-context.md
+++ b/docs/adr/adr012-client-platform-and-timezone-request-context.md
@@ -1,0 +1,79 @@
+---
+id: adrs-adr012
+title: 'ADR012: Client Platform and Timezone Request Context'
+# prettier-ignore
+description: >
+  Architecture Decision Record (ADR) for treating client platform and timezone
+  headers as explicit GHATD integration context without making every platform
+  behave like a browser navigation surface.
+date: 2026-05-23
+status: accepted
+---
+
+## Status
+
+Accepted.
+
+## Context
+
+GHATD host applications can be used from multiple client surfaces: browser
+apps, native mobile apps, browser extensions, command-line tools, and other API
+clients. These clients often need to send lightweight request context that is
+not authentication state. Two examples are:
+
+- `X-Platform`, which identifies the client surface that made the request.
+- `X-Timezone`, which identifies the client's current IANA timezone.
+
+Before this decision, GHATD defined `X-Platform` as
+`WebPlatformHttpRequestHeader`. CORS allowed the header name, and Access Manager
+used a non-empty `X-Platform` value as a signal that logout should redirect the
+browser back to `/`. That was acceptable while the only intended value was the
+legacy browser app value `web`.
+
+Timezone-aware packages such as Streaker and Reminder now make client timezone
+context more important. Host applications may use request timezone context when
+recording streaks, building summaries, or creating reminders. At the same time,
+native and extension clients may send `X-Platform` on every request. Treating
+any non-empty platform value as a browser navigation request would make those
+clients receive redirects where they expect normal API responses.
+
+## Decision
+
+GHATD will treat client platform and timezone as explicit request-context
+headers.
+
+`common.WebPlatformHttpRequestHeader` remains the canonical header constant for
+the existing public API contract, and its value remains `X-Platform`. GHATD will
+also define explicit platform value constants:
+
+- `web`
+- `mobile`
+- `browser-extension`
+
+The `web` value identifies browser app surfaces for Access Manager logout
+redirects. HTMX requests keep their existing redirect behaviour. Other platform
+values, including mobile, browser extension, and unknown API clients, receive
+API responses rather than browser navigation redirects.
+
+GHATD will define `common.TimezoneHttpRequestHeader` as `X-Timezone` and allow
+it through the shared CORS middleware. `X-Timezone` should contain an IANA
+timezone such as `Europe/London`. GHATD will not use this header for
+authentication or authorization. Host applications can choose whether to pass
+the value into packages such as Streaker and Reminder.
+
+## Consequences
+
+Browser logout behaviour remains backward compatible for clients that send
+`X-Platform: web`.
+
+Native, extension, and API clients can safely send platform context without
+being treated as browser navigation flows.
+
+Timezone-aware integrations have a shared header name that CORS permits by
+default. Host applications still own precedence rules, such as preferring a
+persisted user timezone over a request header.
+
+The platform values are now part of the public integration contract. New client
+surfaces should either reuse one of the defined values when the semantics match
+or introduce a new explicit value with tests for any handler behaviour that
+branches on platform.

--- a/docs/getting-started/reminder/README.md
+++ b/docs/getting-started/reminder/README.md
@@ -55,6 +55,12 @@ if err := reminderMigrations.InitRemindersIndexesUp(db); err != nil {
 }
 ```
 
+With `external/starter/v0`, `starter.NewRepositories` and
+`starter.NewServices` create this repository/service pair for you as
+`Services.Reminder`. Starter attaches it to `Services.UserManager` by default;
+you still run the reminder migrations from the host application's migration
+flow.
+
 ## Creating a Reminder
 
 ```go

--- a/docs/getting-started/reminder/README.md
+++ b/docs/getting-started/reminder/README.md
@@ -23,7 +23,7 @@ The package uses two MongoDB collections.
 
 | Collection | Purpose |
 |---|---|
-| `reminders` | Stores the reminder declaration: owner, target, title, due time, timezone, status, and task data. |
+| `reminders` | Stores the reminder declaration: owner, target, local target time, timezone, next UTC due time, status, and task data. |
 | `reminder_executions` | Stores processing history: scheduled time, sent/failed/skipped status, attempt number, notification reference, error, and metadata. |
 
 This split keeps reminder configuration separate from delivery history. A user
@@ -34,8 +34,9 @@ Each reminder can include:
 - `user_id`: the owner of the reminder.
 - `target_type`: the kind of thing the reminder relates to.
 - `target_id`: the concrete target object, if applicable.
-- `target_time`: the UTC due time.
-- `timezone`: the user's timezone for local display and admin analysis.
+- `target_time`: the local wall-clock due time, initially `HH:MM`.
+- `timezone`: the user's IANA timezone. Defaults to `UTC` when omitted.
+- `next_due_at`: the UTC timestamp scheduler queries use for the next due occurrence.
 - `status`: `active`, `disabled`, `completed`, or `deleted`.
 - `task_data`: optional structured data for the host application.
 
@@ -70,7 +71,7 @@ created, err := reminderService.CreateReminder(ctx, &reminder.CreateReminderRequ
     TargetId:    "lesson-123",
     Title:       "Finish your lesson",
     Description: "You planned to complete this today.",
-    TargetTime:  "2026-05-15T18:30:00Z",
+    TargetTime:  "18:30",
     Timezone:    "Europe/London",
     TaskData: map[string]interface{}{
         "url": "/lessons/lesson-123",
@@ -83,8 +84,9 @@ if err != nil {
 _ = created.Reminder.Id
 ```
 
-Store `target_time` in UTC. Keep `timezone` as the user's local timezone so the
-front end and admin tools can show the intended local time.
+Store `target_time` as the user's local wall-clock time and pass an IANA
+`timezone`. GHATD computes `next_due_at` in UTC so schedulers can poll due
+reminders without reimplementing timezone logic.
 
 ## Target-Based Lookups
 
@@ -157,7 +159,7 @@ many users with `UserIDs`.
 
 ```go
 due, err := reminderService.GetDueReminders(ctx, &reminder.GetDueRemindersRequest{
-    DueBefore: "2026-05-15T18:35:00Z",
+    DueBefore: "2026-05-15T18:35:00",
     UserIDs:   []string{"user-123", "user-456"},
     Limit:     100,
 })
@@ -173,7 +175,7 @@ for _, item := range due.Reminders {
         UserID:          item.UserID,
         TargetType:      item.TargetType,
         TargetId:        item.TargetId,
-        ScheduledFor:    item.TargetTime,
+        ScheduledFor:    item.NextDueAt,
         Status:          reminder.ReminderExecutionStatusSent,
         Attempt:         1,
         NotificationRef: "notification-id",

--- a/docs/getting-started/starter-v0-host-application-style.md
+++ b/docs/getting-started/starter-v0-host-application-style.md
@@ -53,10 +53,11 @@ concept:
 | `NewStandardEmailManager` | `external/emailmanager` | Standard GHATD email templater plus email manager wiring. |
 | `AttachDefaultAuthVerifyRoute` | `external/router` | Default auth verification route registration from backend/frontend base URLs. |
 
-Starter builds `Services.Reminder` and attaches it to `Services.UserManager`
-by default, so UMS reminder routes work through `AttachDefaultRoutes`.
-Starter also builds `Services.Streaker` for host-owned handlers or background
-jobs. The host application still owns Mongo migrations for both packages.
+Starter builds `Services.Reminder` and `Services.Streaker` when their
+repositories are available and attaches both to `Services.UserManager` by
+default. UMS reminder and streak routes then work through
+`AttachDefaultRoutes`. Host applications still own product-specific streak
+workflows, reminder schedulers, and Mongo migrations for both packages.
 
 ## Trimmed Example
 
@@ -215,8 +216,9 @@ func runServer(embeddedContent fs.FS, embeddedContentFilePathPrefix string) erro
     if err != nil {
         return fmt.Errorf("server/starter-services-initialisation-failed: %v", err)
     }
-    // starterServices.Reminder is attached to starterServices.UserManager by default.
-    // starterServices.Streaker is available for host-owned handlers or jobs.
+    // starterServices.Reminder and starterServices.Streaker are attached to
+    // starterServices.UserManager by default when available. Host-owned
+    // managers can still call them directly for product-specific workflows.
 
     starterHandlers, err := starter.NewHandlers(&starter.NewHandlersRequest{
         Services:                 starterServices,

--- a/docs/getting-started/starter-v0-host-application-style.md
+++ b/docs/getting-started/starter-v0-host-application-style.md
@@ -53,6 +53,11 @@ concept:
 | `NewStandardEmailManager` | `external/emailmanager` | Standard GHATD email templater plus email manager wiring. |
 | `AttachDefaultAuthVerifyRoute` | `external/router` | Default auth verification route registration from backend/frontend base URLs. |
 
+Starter builds `Services.Reminder` and attaches it to `Services.UserManager`
+by default, so UMS reminder routes work through `AttachDefaultRoutes`.
+Starter also builds `Services.Streaker` for host-owned handlers or background
+jobs. The host application still owns Mongo migrations for both packages.
+
 ## Trimmed Example
 
 The example below is intentionally trimmed. It shows where starter/v0 fits in
@@ -210,6 +215,8 @@ func runServer(embeddedContent fs.FS, embeddedContentFilePathPrefix string) erro
     if err != nil {
         return fmt.Errorf("server/starter-services-initialisation-failed: %v", err)
     }
+    // starterServices.Reminder is attached to starterServices.UserManager by default.
+    // starterServices.Streaker is available for host-owned handlers or jobs.
 
     starterHandlers, err := starter.NewHandlers(&starter.NewHandlersRequest{
         Services:                 starterServices,

--- a/docs/getting-started/starter-v0.md
+++ b/docs/getting-started/starter-v0.md
@@ -55,11 +55,15 @@ setup without moving that ownership into `starter/v0`. Use
 endpoint paths.
 
 `NewRepositories` includes the reminder and streaker Mongo repositories, and
-`NewServices` exposes them as `Services.Reminder` and `Services.Streaker`. The
-reminder service is also attached to `Services.UserManager` by default so the
-UMS reminder endpoints are live when the User Manager route group is attached.
-Streaker remains host-routed in v0; call `Services.Streaker` from custom
-handlers or jobs.
+`NewServices` exposes them as `Services.Reminder` and `Services.Streaker` when
+those repositories are available. Both services are optional: host applications
+may omit them without preventing the rest of the starter stack from running.
+
+When present, starter attaches reminder and streaker to
+`Services.UserManager`. The User Manager route group then exposes UMS reminder
+and streak endpoints. Streaker still has no standalone starter route group in
+v0; host applications own product-specific streak workflows and may call
+`Services.Streaker` directly from custom managers, handlers, or jobs.
 
 For a fuller server-command example that mirrors a GHATD host application
 setup, see [starter/v0 Host Application Setup](starter-v0-host-application-style.md).
@@ -92,7 +96,7 @@ err := starter.AttachDefaultRoutes(&starter.AttachDefaultRoutesRequest{
 | `RouteGroupUser`                      | `/api/v2/users`     |
 | `RouteGroupGroup`                     | `/api/v1/groups`    |
 | `RouteGroupAccessManager`             | `/api/v1/ams`       |
-| `RouteGroupUserManager`               | `/api/v1/ums`, including reminders |
+| `RouteGroupUserManager`               | `/api/v1/ums`, including reminder and streak endpoints |
 | `RouteGroupContentManager`            | `/api/v1/cms`       |
 | `RouteGroupBillingManager`            | `/api/v1/bms`       |
 
@@ -136,7 +140,7 @@ piece they need:
 - `NewRepositoriesRequest` accepts per-repository overrides.
 - `NewServicesRequest` accepts custom policy stores, group/user config,
   audit services, notifier senders, OAuth services, payment registries, payment
-  providers, a custom UMS reminder service override, and post tag
+  providers, custom UMS reminder/streak service overrides, and post tag
   configuration. `ValidPostTags: nil` uses GHATD defaults, while
   `ValidPostTags: []string{}` intentionally disables them.
 - `NewHandlersRequest` accepts `HandlerErrorMaps`; `nil` uses starter defaults,

--- a/docs/getting-started/starter-v0.md
+++ b/docs/getting-started/starter-v0.md
@@ -35,7 +35,7 @@ The common Lazy path is:
 
 1. Build third-party and app-specific dependencies in `main`.
 2. Call `starter.NewRepositories` with a core Mongo repository.
-3. Call `starter.NewServices` with repositories plus explicit Redis/email/OAuth/policy/payment inputs.
+3. Call `starter.NewServices` with repositories plus explicit Redis/email/OAuth/policy/notification/payment inputs.
 4. Call `starter.NewHandlers` with services and a validator.
 5. Call `starter.NewMiddleware` with services.
 6. Group the results with `starter.NewStack`.
@@ -53,6 +53,13 @@ For the lazy path, package-owned helpers such as `repository.NewMongoRuntime`,
 setup without moving that ownership into `starter/v0`. Use
 `router.NewAuthVerifyHandler` directly when a project needs custom auth verify
 endpoint paths.
+
+`NewRepositories` includes the reminder and streaker Mongo repositories, and
+`NewServices` exposes them as `Services.Reminder` and `Services.Streaker`. The
+reminder service is also attached to `Services.UserManager` by default so the
+UMS reminder endpoints are live when the User Manager route group is attached.
+Streaker remains host-routed in v0; call `Services.Streaker` from custom
+handlers or jobs.
 
 For a fuller server-command example that mirrors a GHATD host application
 setup, see [starter/v0 Host Application Setup](starter-v0-host-application-style.md).
@@ -85,7 +92,7 @@ err := starter.AttachDefaultRoutes(&starter.AttachDefaultRoutesRequest{
 | `RouteGroupUser`                      | `/api/v2/users`     |
 | `RouteGroupGroup`                     | `/api/v1/groups`    |
 | `RouteGroupAccessManager`             | `/api/v1/ams`       |
-| `RouteGroupUserManager`               | `/api/v1/ums`       |
+| `RouteGroupUserManager`               | `/api/v1/ums`, including reminders |
 | `RouteGroupContentManager`            | `/api/v1/cms`       |
 | `RouteGroupBillingManager`            | `/api/v1/bms`       |
 
@@ -129,8 +136,9 @@ piece they need:
 - `NewRepositoriesRequest` accepts per-repository overrides.
 - `NewServicesRequest` accepts custom policy stores, group/user config,
   audit services, notifier senders, OAuth services, payment registries, payment
-  providers, and post tag configuration. `ValidPostTags: nil` uses GHATD
-  defaults, while `ValidPostTags: []string{}` intentionally disables them.
+  providers, a custom UMS reminder service override, and post tag
+  configuration. `ValidPostTags: nil` uses GHATD defaults, while
+  `ValidPostTags: []string{}` intentionally disables them.
 - `NewHandlersRequest` accepts `HandlerErrorMaps`; `nil` uses starter defaults,
   while an empty slice intentionally clears a bundle.
 - `NewMiddlewareRequest` accepts custom error maps, rate-limit tuning, and an

--- a/docs/getting-started/streaker/README.md
+++ b/docs/getting-started/streaker/README.md
@@ -1,10 +1,16 @@
 # Streaker
 
-The `streaker` package tracks repeat completions for a user or owner against any target on the platform. It is intentionally generic: an app can record an "app-open" streak, an "affirmation-listened" streak, a "content-read" streak, or a future to-do completion streak without changing the package.
+`external/streaker` records repeat completions for a user or owner against a
+stable target. It is intentionally generic: the package does not know whether
+a completion means an app open, lesson completion, saved item, reading play, or
+task check-off.
 
-## Model
+Use Streaker when a host application needs idempotent "completed this period"
+tracking plus current count, best count, and history.
 
-Each completion creates a `streaks` document for a scope:
+## Core Model
+
+Each streak entry is unique per:
 
 - `streak_type`
 - `owner_id`
@@ -13,103 +19,176 @@ Each completion creates a `streaks` document for a scope:
 - `period_type`
 - `period_key`
 
-The package computes `current_count` from the latest previous entry in the same scope. If the previous period is consecutive, the count increments. If there is a gap, the count resets to `1`. Each new entry stores a lightweight `previous` reference so consumers can trace how the count was calculated without extra queries.
+Calling `RecordStreak` more than once for the same scope and period returns the
+existing entry. It does not increment the count again.
 
-Mongo indexes include a unique compound index across the scope and period fields. That makes `RecordStreak` idempotent for the same user, target, streak type, and period.
+For `daily`, `weekly`, and `monthly` periods, Streaker derives `period_key`
+from `occurred_at` in UTC. For `custom`, callers must provide `period_key`.
 
-### How the "Period" System Works (aka How to keep your streak alive)
-
-Think of the `Period` fields like keeping a Snapchat or Duolingo streak alive. A streak isn't just "you clicked a button"—it's "you clicked a button *today*." The period fields tell the system what the rules are for your streak.
-
-- **`PeriodType` (The Rule):** How often do you need to do the thing?
-  - `daily`: You have to do it once a day.
-  - `weekly`: You have to do it once a week.
-  - `monthly`: You have to do it once a month.
-  - `custom`: You make up the rules! (Like beating specific levels in a game).
-
-- **`PeriodKey` (The Bucket):** Which exact day, week, or level did you just finish?
-  - daily: `2026-05-08` (Today's bucket)
-  - weekly: `2026-w19` (This week's bucket)
-  - custom: `level-4`, `boss-fight-3` (A specific challenge bucket)
-
-- **`OccurredAt` (The Exact Time):** The exact second you actually did the task. For daily, weekly, or monthly streaks, the code will look at this exact time and automatically figure out what your `PeriodKey` (Bucket) should be. 
-
-Because of this system, you can build streaks for *anything*. A "daily app open" streak. A "weekly math homework" streak. A custom "completed a game world" streak. 
-
-#### Examples of how it behaves:
-
-**1. You can't double-dip (Anti-cheat)**
-If you are on a daily streak, and you do the task 5 times on Tuesday, your streak only goes up by 1. The system sees you already filled the "Tuesday" bucket and ignores the extra attempts. Your streak count stays exactly the same.
-
-**2. Keeping it alive (Consecutive)**
-If you log in on Monday, your streak is 1. If you log in on Tuesday, your streak becomes 2! 
-
-**3. Dropping the ball (Gaps)**
-If you log in on Monday (streak = 1), skip Tuesday, and log in on Wednesday... oh no! Your streak resets back to 1. But don't worry, the system keeps a hidden memory of your past streak so you never lose your history.
-
-## Basic Usage
+## Setup
 
 ```go
-repo := streaker.NewRepository(mongoStore)
-service := streaker.NewService(repo)
+import (
+    "github.com/ooaklee/ghatd/external/streaker"
+    streakerMigrations "github.com/ooaklee/ghatd/external/streaker/migrations"
+)
 
-recorded, err := service.RecordStreak(ctx, &streaker.RecordStreakRequest{
-    StreakName:      "App Streak",
-    StreakType:      "app-streak",
+repo := streaker.NewRepository(mongoStore)
+streakService := streaker.NewService(repo)
+
+if err := streakerMigrations.InitStreaksIndexesUp(db); err != nil {
+    return err
+}
+```
+
+With `external/starter/v0`, `NewRepositories` creates the streaker repository
+when a core Mongo repository is supplied, and `NewServices` exposes
+`Services.Streaker`. Streaker is optional: if it is omitted, the rest of the
+starter stack can still run.
+
+Starter attaches `Services.Streaker` to `Services.UserManager` when available,
+which enables the UMS streak endpoints under `/api/v1/ums`.
+
+## Recording Aggregate Actions
+
+Use stable targets for aggregate daily actions. Put event-specific resource IDs
+in metadata.
+
+```go
+res, err := streakService.RecordStreak(ctx, &streaker.RecordStreakRequest{
+    StreakName:      "Daily saved item",
+    StreakType:      "saved-items",
     OwnerId:         userID,
-    TargetType:      "app",
-    TargetId:        "platform",
+    TargetType:      "item",
+    TargetId:        "daily-save",
+    PeriodType:      streaker.StreakPeriodTypeDaily,
     CreatedByUserId: userID,
+    Metadata: map[string]interface{}{
+        "item_id":  itemID,
+        "platform": "web",
+    },
 })
 if err != nil {
     return err
 }
 
-currentCount := recorded.Streak.CurrentCount
+_ = res.Streak.CurrentCount
 ```
 
-With `external/starter/v0`, `starter.NewRepositories` creates the streaker
-repository and `starter.NewServices` exposes the service as `Services.Streaker`.
-Starter/v0 does not attach streaker routes; use the service from host-owned
-handlers, jobs, or product workflows.
+Avoid using a changing resource ID as `target_id` when the product goal is
+"complete this once per period across any resource." A changing `target_id`
+creates one streak scope per resource.
 
-## Stats
+Call `RecordStreak` after the host application has accepted the user action as
+valid. Streaker does not know whether a play, save, check-in, or task
+completion should count; it only records the stable streak scope it receives.
 
-Stats requests require `PeriodType`, because current, longest, and total counts are only meaningful inside a specific rhythm. For example, a user's daily app streak and weekly app streak can both be valid, but they answer different product questions.
+## Consecutive Behaviour
+
+When the latest previous entry is in the immediately preceding period,
+`current_count` increments. If there is a gap, the new entry resets to `1`.
+
+Examples for a daily streak:
+
+| Action | Result |
+|--------|--------|
+| Record Monday | `current_count = 1` |
+| Record Tuesday | `current_count = 2` |
+| Record Tuesday again | existing Tuesday entry is returned |
+| Skip Wednesday, record Thursday | `current_count = 1` |
+
+The package stores a lightweight `previous` reference on new entries so callers
+can inspect how a count was calculated without an extra query.
+
+## Reading Stats
 
 ```go
-current, err := service.GetCurrentCountByStreakTypeAndUserID(ctx, &streaker.GetCurrentCountRequest{
+current, err := streakService.GetCurrentCount(ctx, &streaker.GetCurrentCountRequest{
     StreakStatsRequest: streaker.StreakStatsRequest{
-        StreakType:  "app-streak",
-        OwnerId:     userID,
-        PeriodType:  streaker.StreakPeriodTypeDaily,
+        StreakType: "saved-items",
+        OwnerId:    userID,
+        TargetType: "item",
+        TargetId:   "daily-save",
+        PeriodType: streaker.StreakPeriodTypeDaily,
     },
 })
 
-longest, err := service.GetLongestStreakByStreakTypeAndUserID(ctx, &streaker.GetLongestStreakRequest{
+best, err := streakService.GetLongestStreak(ctx, &streaker.GetLongestStreakRequest{
     StreakStatsRequest: streaker.StreakStatsRequest{
-        StreakType:  "app-streak",
-        OwnerId:     userID,
-        PeriodType:  streaker.StreakPeriodTypeDaily,
-    },
-})
-
-total, err := service.GetNumberOfStreaksByStreakTypeAndUserID(ctx, &streaker.GetNumberOfStreaksRequest{
-    StreakStatsRequest: streaker.StreakStatsRequest{
-        StreakType:  "app-streak",
-        OwnerId:     userID,
-        PeriodType:  streaker.StreakPeriodTypeDaily,
+        StreakType: "saved-items",
+        OwnerId:    userID,
+        TargetType: "item",
+        TargetId:   "daily-save",
+        PeriodType: streaker.StreakPeriodTypeDaily,
     },
 })
 ```
 
-Add `TargetType` and `TargetId` to the stats request when the screen needs the count for a specific thing, such as one course, one affirmation pack, or one task list.
+`GetCurrentCount` returns the latest recorded count for the scope. If a host
+application needs "active today" semantics, compare the response period with
+the current period.
 
-## Migrations
+## Listing History
 
-Use the package migration helpers in the consuming application's mongo migrations:
+Use `ListStreaks` for streak boards, calendars, and history views.
 
 ```go
-streakerMigrations.InitStreaksIndexesUp(db)
-streakerMigrations.InitStreaksIndexesDown(db)
+history, err := streakService.ListStreaks(ctx, &streaker.ListStreaksRequest{
+    StreakStatsRequest: streaker.StreakStatsRequest{
+        StreakType: "saved-items",
+        OwnerId:    userID,
+        TargetType: "item",
+        TargetId:   "daily-save",
+        PeriodType: streaker.StreakPeriodTypeDaily,
+    },
+    PeriodKeyFrom: "2026-05-16",
+    PeriodKeyTo:   "2026-05-22",
+    Sort:          "asc",
+    PerPage:       50,
+})
 ```
+
+For generated daily, weekly, and monthly keys, period-key ranges sort
+lexicographically because the keys are stable and zero-padded.
+
+## UMS Endpoints
+
+When Streaker is attached to User Manager, authenticated users can access:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/v1/ums/me/streaks` | List the authenticated user's streak history. |
+| `POST /api/v1/ums/me/streaks/record` | Record a streak for the authenticated user. |
+| `GET /api/v1/ums/me/streaks/current` | Get the authenticated user's current count. |
+| `GET /api/v1/ums/me/streaks/longest` | Get the authenticated user's best count. |
+| `GET /api/v1/ums/me/streaks/count` | Count streak entries for the authenticated user. |
+
+Admin/service read endpoints are also available:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/v1/ums/streaks` | List streak history, optionally filtered by `user_id`. |
+| `GET /api/v1/ums/streaks/current` | Read current count for a target user and scope. |
+| `GET /api/v1/ums/streaks/longest` | Read best count for a target user and scope. |
+| `GET /api/v1/ums/streaks/count` | Count entries for a target user and scope. |
+
+The `/me` routes always scope `owner_id` to the authenticated requester.
+Admin/service routes may use `user_id` to inspect one target user after the
+caller has passed User Manager's access checks.
+
+## Optional Integration Pattern
+
+For host application side effects:
+
+1. Log before attempting to record a streak.
+2. Skip if the service is not configured.
+3. Warn and continue if recording fails.
+
+For direct user-facing streak APIs, return a clear service-unavailable or
+skipped response when Streaker is not attached. That keeps optional
+integration behaviour visible without breaking unrelated application features.
+
+## Package README
+
+See [`external/streaker/README.md`](../../../external/streaker/README.md) for
+the package-level reference.

--- a/docs/getting-started/streaker/README.md
+++ b/docs/getting-started/streaker/README.md
@@ -23,7 +23,13 @@ Calling `RecordStreak` more than once for the same scope and period returns the
 existing entry. It does not increment the count again.
 
 For `daily`, `weekly`, and `monthly` periods, Streaker derives `period_key`
-from `occurred_at` in UTC. For `custom`, callers must provide `period_key`.
+from `occurred_at` in `period_timezone`. If no timezone is supplied, Streaker
+uses `UTC` for backward compatibility. For `custom`, callers must provide
+`period_key`.
+
+`period_timezone` must be an IANA timezone such as `Europe/London` or
+`America/New_York`. The effective timezone is stored on each entry for
+debugging and auditability, but it is not part of the uniqueness contract.
 
 ## Setup
 
@@ -62,6 +68,7 @@ res, err := streakService.RecordStreak(ctx, &streaker.RecordStreakRequest{
     TargetType:      "item",
     TargetId:        "daily-save",
     PeriodType:      streaker.StreakPeriodTypeDaily,
+    PeriodTimezone:  "Europe/London",
     CreatedByUserId: userID,
     Metadata: map[string]interface{}{
         "item_id":  itemID,
@@ -126,7 +133,8 @@ best, err := streakService.GetLongestStreak(ctx, &streaker.GetLongestStreakReque
 
 `GetCurrentCount` returns the latest recorded count for the scope. If a host
 application needs "active today" semantics, compare the response period with
-the current period.
+the current local period. Use `BuildPeriodKeyForTimezone` when deriving local
+summary windows.
 
 ## Listing History
 

--- a/docs/getting-started/streaker/README.md
+++ b/docs/getting-started/streaker/README.md
@@ -68,6 +68,11 @@ if err != nil {
 currentCount := recorded.Streak.CurrentCount
 ```
 
+With `external/starter/v0`, `starter.NewRepositories` creates the streaker
+repository and `starter.NewServices` exposes the service as `Services.Streaker`.
+Starter/v0 does not attach streaker routes; use the service from host-owned
+handlers, jobs, or product workflows.
+
 ## Stats
 
 Stats requests require `PeriodType`, because current, longest, and total counts are only meaningful inside a specific rhythm. For example, a user's daily app streak and weekly app streak can both be valid, but they answer different product questions.

--- a/docs/getting-started/user-manager/README.md
+++ b/docs/getting-started/user-manager/README.md
@@ -105,6 +105,10 @@ To use the `usermanager` service, you must initialise it and attach its routes t
 
 For a detailed guide on setting up the main application router, please see the [Router Package Getting Started documentation](../router/README.md).
 
+If the application uses `external/starter/v0`, starter creates the reminder
+service and attaches it to User Manager by default. The manual example below is
+for projects composing `usermanager` directly.
+
 **Example Initialisation:**
 
 ```go

--- a/docs/how-to/authenticating-the-app.md
+++ b/docs/how-to/authenticating-the-app.md
@@ -22,9 +22,21 @@ Browser clients should use credentialed requests:
 axios.create({
   baseURL: '/api/v1/ams/',
   withCredentials: true,
-  headers: { 'X-Platform': 'web' },
+  headers: {
+    'X-Platform': 'web',
+    'X-Timezone': Intl.DateTimeFormat().resolvedOptions().timeZone,
+  },
 });
 ```
+
+`X-Platform` is a client-surface hint. Access Manager uses `web` for browser
+logout flows that should redirect back to `/`. Native or extension clients
+should send their own platform value, such as `mobile` or `browser-extension`,
+and expect API responses rather than navigation redirects.
+
+`X-Timezone` should be an IANA timezone, such as `Europe/London`. GHATD does
+not authenticate with this value, but host applications can use it when passing
+request context into timezone-aware packages such as Streaker and Reminder.
 
 Native clients should use a persistent cookie jar. The app should not store token response values as its primary session state; GHATD sets `HttpOnly` access and refresh token cookies, and the client sends those cookies back on later requests.
 

--- a/docs/product-requirements/timezone-aware-streaks-and-reminders.md
+++ b/docs/product-requirements/timezone-aware-streaks-and-reminders.md
@@ -1,0 +1,136 @@
+# Timezone-Aware Streaks and Reminders PRD
+
+## Status
+
+Accepted for implementation on the `ghatd-x-streak-logic` branch.
+
+## Problem
+
+Streaks and reminders are user-facing time concepts. A user who opens an app at
+00:31 in `Europe/London` expects today's daily streak to be available even
+though it may still be the previous day in UTC. A user who asks for reminders at
+09:00 in their local timezone expects scheduler queries to become due at that
+local wall-clock time, not at 09:00 UTC.
+
+GHATD currently stores UTC timestamps consistently, which is still the right
+storage rule. The missing layer is explicit timezone-aware derivation for:
+
+- streak period keys such as daily, weekly, and monthly keys;
+- reminder next-due timestamps derived from local wall-clock target times;
+- first-class developer ergonomics so host applications do not each reimplement
+  subtly different timezone logic.
+
+## Goals
+
+- Let streak callers provide an optional IANA timezone such as
+  `Europe/London`, `America/New_York`, or `Pacific/Auckland`.
+- Keep all persisted event timestamps in UTC while deriving streak period keys
+  in the effective timezone.
+- Persist the effective timezone used for each streak entry for auditability and
+  debugging.
+- Let reminder callers provide local wall-clock target times with an IANA
+  timezone and have GHATD compute a UTC `next_due_at`.
+- Make reminder scheduler lookups use `next_due_at <= due_before` instead of
+  comparing raw local target-time strings.
+- Preserve backward compatibility: missing timezone defaults to `UTC`; existing
+  `BuildPeriodKey` behavior remains UTC-based.
+- Keep streak idempotency scoped to owner, streak type, target, period type, and
+  period key. Timezone must not be added to the uniqueness contract.
+
+## Non-Goals
+
+- GHATD will not own a host application's user profile UI or preference storage.
+- GHATD will not decide how notifications are dispatched. It will provide due
+  reminders and execution records for host workers.
+- GHATD will not add reminder recurrence presets. Presets remain host-level
+  product decisions that expand into one or more reminder declarations.
+- This PRD does not require a full queueing/locking worker. A host worker task
+  can build on `next_due_at` and reminder execution records separately.
+
+## Requirements
+
+### Effective Timezone Resolution
+
+- All timezone inputs must be IANA timezone names accepted by Go's
+  `time.LoadLocation`.
+- Empty timezone input resolves to `UTC`.
+- Invalid non-empty timezone input must return a typed validation error.
+- GHATD packages should embed Go timezone data so minimal containers do not
+  depend on host OS tzdata availability.
+- Host applications should resolve the effective timezone in this order:
+  persisted user preference, request/client timezone, then `UTC`.
+
+### Streaker
+
+- Add `period_timezone` to `RecordStreakRequest`.
+- Add `period_timezone` to `Streak`.
+- Add a timezone-aware helper that derives period keys from a timestamp, period
+  type, optional custom key, and effective timezone.
+- Keep `BuildPeriodKey` as a UTC-compatible helper for existing callers.
+- Daily keys remain `YYYY-MM-DD`, weekly keys remain ISO `YYYY-wWW`, and monthly
+  keys remain `YYYY-MM`.
+- Daily, weekly, and monthly keys must be derived after converting
+  `occurred_at` to the effective timezone.
+- Custom period keys still require a caller-supplied `period_key`.
+- Duplicate detection must continue to use the existing scope plus period key
+  so retrying from different clients remains idempotent.
+- Existing stats and list filters remain period-key based. Host applications
+  that show a local week should calculate local period-key boundaries with the
+  same helper.
+
+### Reminder
+
+- Treat `target_time` as a local wall-clock time for recurring reminder
+  declarations. The launch format is `HH:MM`.
+- Keep `timezone` on the reminder declaration and normalise it to the effective
+  IANA timezone.
+- Add `next_due_at`, stored as a UTC timestamp string, to reminder declarations.
+- On create, compute `next_due_at` from `target_time`, `timezone`, and the
+  current time.
+- On update, recompute `next_due_at` whenever `target_time` or `timezone`
+  changes.
+- Scheduler lookup must filter active reminders by `next_due_at <= due_before`
+  and sort by `next_due_at`.
+- Existing reminder execution records keep using `scheduled_for` as the UTC due
+  timestamp that a worker attempted.
+- A future worker can advance `next_due_at` after a successful or skipped send;
+  that worker design should account for multi-worker claiming separately.
+
+### Host Application Integration
+
+- Browser clients should send the browser IANA timezone on app-facing requests,
+  for example through an `X-Timezone` header and/or request payload.
+- Host services should pass the resolved timezone to streak recording calls.
+- Host services should calculate streak summaries using the same timezone that
+  was used for recording the user's current local period.
+- App-shell check-in endpoints should be safe to call repeatedly. GHATD
+  idempotency must prevent double-counting within one local period.
+- Reminder management surfaces should pass the selected timezone when creating
+  reminder schedules.
+
+## Acceptance Criteria
+
+- A daily streak recorded at `2026-05-22T23:31:00Z` with
+  `period_timezone=Europe/London` stores `period_key=2026-05-23`.
+- The same timestamp with `period_timezone=America/New_York` stores
+  `period_key=2026-05-22`.
+- Repeating the same daily streak action in the same local period returns the
+  existing entry rather than creating a duplicate.
+- Consecutive daily streaks across daylight-saving transitions continue to
+  increment.
+- A reminder with `target_time=09:00` and `timezone=Europe/London` stores the
+  next UTC due timestamp corresponding to the next 09:00 London occurrence.
+- Due reminder queries use `next_due_at`, not `target_time`.
+- Missing timezone inputs resolve to `UTC`.
+- Invalid non-empty timezone inputs return a typed validation error.
+
+## Rollout Notes
+
+- Existing streak records do not need migration; absent `period_timezone` means
+  the old UTC behavior.
+- Existing reminder records should be backfilled with `timezone=UTC` and a
+  computed `next_due_at` before scheduler workers rely exclusively on
+  `next_due_at`.
+- Host applications should update clients before relying on local-day summaries.
+  If clients omit timezone, launch behavior remains UTC-based rather than
+  failing requests.

--- a/external/accessmanager/handler.go
+++ b/external/accessmanager/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/ooaklee/ghatd/external/auth"
 	"github.com/ooaklee/ghatd/external/common"
@@ -605,13 +606,27 @@ func (h *Handler) RemoveCookiesWithName(w http.ResponseWriter, cookieName string
 	toolbox.RemoveCookiesWithName(w, h.Environment, cookieName, h.CookieDomain)
 }
 
-// redirectToHomeIfPlatformHeaderDetected checks the request headers for the presence of the web platform or HTMX headers.
-// If either header is present, the function redirects the user to the home page (/) and returns true.
+// redirectToHomeIfPlatformHeaderDetected checks the request headers for browser-owned
+// logout flows that expect a navigation redirect rather than an API response.
 // Otherwise, it returns false.
 func redirectToHomeIfPlatformHeaderDetected(w http.ResponseWriter, r *http.Request) bool {
-	if r.Header.Get(common.WebPlatformHttpRequestHeader) != "" || r.Header.Get(common.HtmxHttpRequestHeader) != "" {
+	if shouldRedirectToHomeForRequest(r) {
 		http.Redirect(w, r, "/", http.StatusFound)
 		return true
 	}
 	return false
+}
+
+// shouldRedirectToHomeForRequest reports whether the request expects a browser navigation redirect.
+func shouldRedirectToHomeForRequest(r *http.Request) bool {
+	if r.Header.Get(common.HtmxHttpRequestHeader) != "" {
+		return true
+	}
+
+	switch strings.ToLower(strings.TrimSpace(r.Header.Get(common.WebPlatformHttpRequestHeader))) {
+	case common.PlatformWeb:
+		return true
+	default:
+		return false
+	}
 }

--- a/external/accessmanager/handler_test.go
+++ b/external/accessmanager/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ooaklee/ghatd/external/accessmanager"
 	"github.com/ooaklee/ghatd/external/apitoken"
 	"github.com/ooaklee/ghatd/external/auth"
+	"github.com/ooaklee/ghatd/external/common"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 	"github.com/ooaklee/ghatd/external/validator"
 )
@@ -574,6 +575,72 @@ func TestHandler_RefreshToken(t *testing.T) {
 				assert.True(t, hasCookie(cookies, testCookieAuth), "expected auth cookie to be set")
 				assert.True(t, hasCookie(cookies, testCookieRefresh), "expected refresh cookie to be set")
 			}
+		})
+	}
+}
+
+func TestHandler_LogoutUserRedirectsOnlyForWebSurfaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		platformHeader string
+		htmxHeader     string
+		expectStatus   int
+		expectLocation string
+	}{
+		{
+			name:           "legacy web platform redirects home",
+			platformHeader: common.PlatformWeb,
+			expectStatus:   http.StatusFound,
+			expectLocation: "/",
+		},
+		{
+			name:           "htmx request redirects home",
+			htmxHeader:     "true",
+			expectStatus:   http.StatusFound,
+			expectLocation: "/",
+		},
+		{
+			name:           "mobile platform receives API accepted response",
+			platformHeader: common.PlatformMobile,
+			expectStatus:   http.StatusAccepted,
+		},
+		{
+			name:           "browser extension platform receives API accepted response",
+			platformHeader: common.PlatformBrowserExtension,
+			expectStatus:   http.StatusAccepted,
+		},
+		{
+			name:           "project-prefixed web platform receives API accepted response",
+			platformHeader: "project-web",
+			expectStatus:   http.StatusAccepted,
+		},
+		{
+			name:           "unknown platform receives API accepted response",
+			platformHeader: "custom-client",
+			expectStatus:   http.StatusAccepted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(&mockAccessmanagerService{})
+			req := httptest.NewRequest(http.MethodGet, "/v1/ams/logout", nil)
+			if tt.platformHeader != "" {
+				req.Header.Set(common.WebPlatformHttpRequestHeader, tt.platformHeader)
+			}
+			if tt.htmxHeader != "" {
+				req.Header.Set(common.HtmxHttpRequestHeader, tt.htmxHeader)
+			}
+			rec := httptest.NewRecorder()
+
+			h.LogoutUser(rec, req)
+
+			assert.Equal(t, tt.expectStatus, rec.Code)
+			assert.Equal(t, tt.expectLocation, rec.Header().Get("Location"))
 		})
 	}
 }

--- a/external/common/common.go
+++ b/external/common/common.go
@@ -42,6 +42,10 @@ const (
 	// is being used by the client
 	WebPlatformHttpRequestHeader string = "X-Platform"
 
+	// TimezoneHttpRequestHeader is the header used to inform the server which IANA
+	// timezone the client is currently using.
+	TimezoneHttpRequestHeader string = "X-Timezone"
+
 	// CacheSkipHttpResponseHeader is the response header used to tell server not to cache the
 	// response from the endpoint
 	CacheSkipHttpResponseHeader string = "X-Cache-Skip"
@@ -58,6 +62,17 @@ const (
 
 	AccessTokenAuthInfoCookieName  string = "access_token"
 	RefreshTokenAuthInfoCookieName string = "refresh_token"
+)
+
+const (
+	// PlatformWeb is the web app X-Platform value.
+	PlatformWeb string = "web"
+
+	// PlatformMobile is the mobile app X-Platform value.
+	PlatformMobile string = "mobile"
+
+	// PlatformBrowserExtension is the browser extension X-Platform value.
+	PlatformBrowserExtension string = "browser-extension"
 )
 
 const (

--- a/external/errormanifest/bundles/README.md
+++ b/external/errormanifest/bundles/README.md
@@ -21,6 +21,11 @@ handlers add their package-local base maps internally. For example,
 `bundles.AccessManager()` intentionally excludes
 `accessmanager.AccessmanagerErrorMap`.
 
+`bundles.UserManager()` includes cross-package maps for services surfaced
+through UMS, including `reminder.ReminderErrorMap` for the `/api/v1/ums`
+reminder endpoints. The usermanager handler still adds its own
+`UsermanagerErrorMap` internally.
+
 Middleware-level bundles are different. `bundles.AuthMiddleware()` includes
 `accessmanager.AccessmanagerErrorMap` because access middleware uses the
 provided map set directly.

--- a/external/errormanifest/bundles/bundles.go
+++ b/external/errormanifest/bundles/bundles.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ooaklee/ghatd/external/paymentprovider"
 	"github.com/ooaklee/ghatd/external/post"
 	"github.com/ooaklee/ghatd/external/pricer"
+	"github.com/ooaklee/ghatd/external/reminder"
 	"github.com/ooaklee/ghatd/external/toolbox"
 	user "github.com/ooaklee/ghatd/external/user/v2"
 	"github.com/ooaklee/reply/v2"
@@ -42,6 +43,7 @@ func UserManager() []reply.ErrorManifest {
 		toolbox.ToolboxErrorMap,
 		group.GroupErrorMap,
 		notifier.NotifierErrorMap,
+		reminder.ReminderErrorMap,
 	})
 }
 

--- a/external/errormanifest/bundles/bundles_test.go
+++ b/external/errormanifest/bundles/bundles_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ooaklee/ghatd/external/paymentprovider"
 	"github.com/ooaklee/ghatd/external/post"
 	"github.com/ooaklee/ghatd/external/pricer"
+	"github.com/ooaklee/ghatd/external/reminder"
 	"github.com/ooaklee/ghatd/external/toolbox"
 	user "github.com/ooaklee/ghatd/external/user/v2"
 	"github.com/ooaklee/reply/v2"
@@ -50,6 +51,7 @@ func TestBundles(t *testing.T) {
 				toolbox.ToolboxErrorMap,
 				group.GroupErrorMap,
 				notifier.NotifierErrorMap,
+				reminder.ReminderErrorMap,
 			},
 		},
 		{

--- a/external/middleware/cors/cors.go
+++ b/external/middleware/cors/cors.go
@@ -13,7 +13,7 @@ func NewCorsMiddleware(allowedOrigins []string) func(handler http.Handler) http.
 	return func(handler http.Handler) http.Handler {
 		return handlers.CORS(
 			handlers.AllowCredentials(),
-			handlers.AllowedHeaders([]string{common.CorrelationIdHttpHeader, "Content-Type", "Authorization", common.WebPlatformHttpRequestHeader, common.SystemWideXApiToken, common.WebPartialHttpRequestHeader, common.CacheSkipHttpResponseHeader, common.HtmxHttpCurrentUrlHeader,
+			handlers.AllowedHeaders([]string{common.CorrelationIdHttpHeader, "Content-Type", "Authorization", common.WebPlatformHttpRequestHeader, common.TimezoneHttpRequestHeader, common.SystemWideXApiToken, common.WebPartialHttpRequestHeader, common.CacheSkipHttpResponseHeader, common.HtmxHttpCurrentUrlHeader,
 				common.HtmxHttpRequestHeader,
 				common.HtmxHttpTargetHeader,
 				common.HtmxHttpTriggerHeader}),

--- a/external/middleware/cors/cors_test.go
+++ b/external/middleware/cors/cors_test.go
@@ -1,0 +1,38 @@
+package cors_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/middleware/cors"
+)
+
+func TestNewCorsMiddlewareAllowsClientContextHeaders(t *testing.T) {
+	t.Parallel()
+
+	handler := cors.NewCorsMiddleware([]string{"https://app.test"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/test", nil)
+	req.Header.Set("Origin", "https://app.test")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", strings.Join([]string{
+		common.WebPlatformHttpRequestHeader,
+		common.TimezoneHttpRequestHeader,
+	}, ", "))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	allowedHeaders := strings.ToLower(rec.Header().Get("Access-Control-Allow-Headers"))
+	assert.Contains(t, allowedHeaders, strings.ToLower(common.WebPlatformHttpRequestHeader))
+	assert.Contains(t, allowedHeaders, strings.ToLower(common.TimezoneHttpRequestHeader))
+}

--- a/external/reminder/README.md
+++ b/external/reminder/README.md
@@ -85,6 +85,13 @@ active, err := service.GetActiveRemindersForTargetTypeByUserID(ctx, &reminder.Ge
 })
 ```
 
+When using `external/starter/v0`, `starter.NewRepositories` creates the
+reminder repository and `starter.NewServices` creates `Services.Reminder`.
+Starter also attaches that service to `Services.UserManager` by default, so
+the UMS reminder endpoints are enabled when the User Manager route group is
+attached. Pass `starter.NewServicesRequest.ReminderService` only when UMS
+should use a custom reminder implementation.
+
 Use `GetRemindersForTargetTypeByUserID` when a product screen needs all
 reminders for a target. Use `GetActiveRemindersForTargetTypeByUserID` when a
 scheduler or UI only needs enabled reminders.

--- a/external/reminder/README.md
+++ b/external/reminder/README.md
@@ -17,9 +17,10 @@ Declarations live in the `reminders` collection. Execution attempts live in the
 reminder stays small and easy to update, while the system can still keep a
 history of sends, failures, skips, and notification references.
 
-All stored timestamps should be UTC. The optional `timezone` field records the
-user's local timezone so clients and admin tools can display the intended local
-time without changing the persisted UTC value.
+All stored execution timestamps and due timestamps are UTC. Reminder
+declarations keep `target_time` as the user's local wall-clock time, store the
+IANA `timezone`, and derive `next_due_at` as the UTC timestamp that scheduler
+queries should use.
 
 ## Package Structure
 
@@ -50,8 +51,9 @@ reminder/
 | `target_id` | The specific platform object ID, when there is one. |
 | `title` | The short reminder label. |
 | `description` | Optional user-facing detail. |
-| `target_time` | The UTC time the reminder is due. |
-| `timezone` | Optional user timezone for display and local-time reasoning. |
+| `target_time` | The local wall-clock time, initially `HH:MM`. |
+| `timezone` | IANA timezone used to resolve the local target time. Defaults to `UTC`. |
+| `next_due_at` | UTC timestamp for the next due occurrence. Scheduler queries use this field. |
 | `status` | `active`, `disabled`, `completed`, or `deleted`. |
 | `task_data` | Optional structured payload for product-specific context. |
 
@@ -71,7 +73,7 @@ created, err := service.CreateReminder(ctx, &reminder.CreateReminderRequest{
     TargetId:    "course-123",
     Title:       "Finish today's lesson",
     Description: "Keep your streak moving.",
-    TargetTime:  "2026-05-15T10:00:00Z",
+    TargetTime:  "09:00",
     Timezone:    "Europe/London",
 })
 if err != nil {
@@ -121,7 +123,7 @@ reminders for a set of users.
 
 ```go
 due, err := service.GetDueReminders(ctx, &reminder.GetDueRemindersRequest{
-    DueBefore: "2026-05-15T10:05:00Z",
+    DueBefore: "2026-05-15T10:05:00",
     UserIDs:   []string{"user-123", "user-456"},
     Limit:     100,
 })
@@ -135,7 +137,7 @@ for _, item := range due.Reminders {
         UserID:          item.UserID,
         TargetType:      item.TargetType,
         TargetId:        item.TargetId,
-        ScheduledFor:    item.TargetTime,
+        ScheduledFor:    item.NextDueAt,
         Status:          reminder.ReminderExecutionStatusSent,
         Attempt:         1,
         NotificationRef: "notifier-message-id",

--- a/external/reminder/const.go
+++ b/external/reminder/const.go
@@ -46,10 +46,12 @@ const (
 	ErrKeyTargetTypeIsRequired = "ReminderTargetTypeIsRequired"
 	// ErrKeyTitleIsRequired is returned when a reminder declaration has no title.
 	ErrKeyTitleIsRequired = "ReminderTitleIsRequired"
-	// ErrKeyTargetTimeIsRequired is returned when a reminder has no scheduled UTC target time.
+	// ErrKeyTargetTimeIsRequired is returned when a reminder has no scheduled target time.
 	ErrKeyTargetTimeIsRequired = "ReminderTargetTimeIsRequired"
 	// ErrKeyInvalidTargetTime is returned when a reminder target time cannot be accepted.
 	ErrKeyInvalidTargetTime = "ReminderInvalidTargetTime"
+	// ErrKeyInvalidTimezone is returned when a reminder timezone cannot be accepted.
+	ErrKeyInvalidTimezone = "ReminderInvalidTimezone"
 	// ErrKeyInvalidStatus is returned when a reminder status is not supported.
 	ErrKeyInvalidStatus = "ReminderInvalidStatus"
 	// ErrKeyResourceNotFound is returned when a reminder or execution record cannot be found.

--- a/external/reminder/errormap.go
+++ b/external/reminder/errormap.go
@@ -38,6 +38,12 @@ var ReminderErrorMap reply.ErrorManifest = reply.ErrorManifest{
 		Code:       "REM0-004",
 		Detail:     "The provided target time is invalid",
 	},
+	ErrInvalidTimezone: {
+		Title:      "Invalid Timezone",
+		StatusCode: http.StatusBadRequest,
+		Code:       "REM0-015",
+		Detail:     "Please provide a valid IANA timezone",
+	},
 	ErrInvalidStatus: {
 		Title:      "Invalid Status",
 		StatusCode: http.StatusBadRequest,

--- a/external/reminder/errors.go
+++ b/external/reminder/errors.go
@@ -19,6 +19,8 @@ var (
 	ErrTargetTimeIsRequired = errors.New(ErrKeyTargetTimeIsRequired)
 	// ErrInvalidTargetTime means a reminder target time could not be accepted.
 	ErrInvalidTargetTime = errors.New(ErrKeyInvalidTargetTime)
+	// ErrInvalidTimezone means a reminder timezone could not be accepted.
+	ErrInvalidTimezone = errors.New(ErrKeyInvalidTimezone)
 	// ErrInvalidStatus means the reminder status is not supported.
 	ErrInvalidStatus = errors.New(ErrKeyInvalidStatus)
 	// ErrResourceNotFound means the requested reminder or execution record could not be found.

--- a/external/reminder/migrations/indexes_reminders.go
+++ b/external/reminder/migrations/indexes_reminders.go
@@ -42,6 +42,14 @@ func InitRemindersIndexesUp(db *mongo.Database) error {
 		Options: options.Index().SetName("idx_reminders_user_target_time"),
 	}
 
+	userNextDueAtIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "user_id", Value: 1},
+			{Key: "next_due_at", Value: 1},
+		},
+		Options: options.Index().SetName("idx_reminders_user_next_due_at"),
+	}
+
 	userTargetStatusIndexModel := mongo.IndexModel{
 		Keys: bson.D{
 			{Key: "user_id", Value: 1},
@@ -53,12 +61,31 @@ func InitRemindersIndexesUp(db *mongo.Database) error {
 		Options: options.Index().SetName("idx_reminders_user_target_status_time"),
 	}
 
+	userTargetStatusNextDueAtIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "user_id", Value: 1},
+			{Key: "target_type", Value: 1},
+			{Key: "target_id", Value: 1},
+			{Key: "status", Value: 1},
+			{Key: "next_due_at", Value: 1},
+		},
+		Options: options.Index().SetName("idx_reminders_user_target_status_next_due_at"),
+	}
+
 	dueLookupIndexModel := mongo.IndexModel{
 		Keys: bson.D{
 			{Key: "status", Value: 1},
 			{Key: "target_time", Value: 1},
 		},
 		Options: options.Index().SetName("idx_reminders_due_lookup"),
+	}
+
+	dueLookupNextDueAtIndexModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "status", Value: 1},
+			{Key: "next_due_at", Value: 1},
+		},
+		Options: options.Index().SetName("idx_reminders_due_lookup_next_due_at"),
 	}
 
 	createdAtIndexModel := mongo.IndexModel{
@@ -72,8 +99,11 @@ func InitRemindersIndexesUp(db *mongo.Database) error {
 			nanoIDIndexModel,
 			userStatusIndexModel,
 			userTargetTimeIndexModel,
+			userNextDueAtIndexModel,
 			userTargetStatusIndexModel,
+			userTargetStatusNextDueAtIndexModel,
 			dueLookupIndexModel,
+			dueLookupNextDueAtIndexModel,
 			createdAtIndexModel,
 		},
 	)
@@ -138,8 +168,11 @@ func InitRemindersIndexesDown(db *mongo.Database) error {
 		"idx_reminders_nano_id",
 		"idx_reminders_user_status",
 		"idx_reminders_user_target_time",
+		"idx_reminders_user_next_due_at",
 		"idx_reminders_user_target_status_time",
+		"idx_reminders_user_target_status_next_due_at",
 		"idx_reminders_due_lookup",
+		"idx_reminders_due_lookup_next_due_at",
 		"idx_reminders_created_at",
 	}
 

--- a/external/reminder/model.go
+++ b/external/reminder/model.go
@@ -2,9 +2,15 @@ package reminder
 
 import (
 	"strings"
+	"time"
+	_ "time/tzdata"
 
+	"github.com/ooaklee/ghatd/external/common"
 	"github.com/ooaklee/ghatd/external/toolbox"
 )
+
+// defaultReminderTimezone defines the fallback timezone for reminders when none is provided or determined.
+const defaultReminderTimezone = "UTC"
 
 // Reminder represents a user reminder with scheduling and status information.
 type Reminder struct {
@@ -17,6 +23,7 @@ type Reminder struct {
 	Description     string                 `json:"description,omitempty" bson:"description,omitempty"`
 	TargetTime      string                 `json:"target_time" bson:"target_time"`
 	Timezone        string                 `json:"timezone,omitempty" bson:"timezone,omitempty"`
+	NextDueAt       string                 `json:"next_due_at,omitempty" bson:"next_due_at,omitempty"`
 	Status          ReminderStatus         `json:"status" bson:"status"`
 	TaskData        map[string]interface{} `json:"task_data,omitempty" bson:"task_data,omitempty"`
 	CreatedAt       string                 `json:"created_at" bson:"created_at"`
@@ -130,12 +137,10 @@ func ValidateAndNormaliseExecutionStatus(status ReminderExecutionStatus) (Remind
 	}
 }
 
-// ParseReminderTime validates that a reminder target time value is present.
+// ParseReminderTime validates that a reminder target time value is present and supported.
 func ParseReminderTime(value string) (bool, error) {
-	if strings.TrimSpace(value) == "" {
-		return false, ErrTargetTimeIsRequired
-	}
-	return true, nil
+	_, err := parseReminderTargetTime(strings.TrimSpace(value))
+	return err == nil, err
 }
 
 // FormatTime returns the provided time value or the current UTC timestamp when empty.
@@ -144,4 +149,80 @@ func FormatTime(value string) string {
 		return toolbox.TimeNowUTC()
 	}
 	return value
+}
+
+// NormaliseReminderTimezone returns the package default timezone when none is provided.
+func NormaliseReminderTimezone(value string) (string, *time.Location, error) {
+	timezone := strings.TrimSpace(value)
+	if timezone == "" {
+		timezone = defaultReminderTimezone
+	}
+
+	location, err := time.LoadLocation(timezone)
+	if err != nil {
+		return "", nil, ErrInvalidTimezone
+	}
+
+	return timezone, location, nil
+}
+
+// BuildNextDueAt calculates the next UTC due timestamp for a reminder target time.
+func BuildNextDueAt(targetTime string, timezone string, now time.Time) (string, error) {
+	parsed, err := parseReminderTargetTime(strings.TrimSpace(targetTime))
+	if err != nil {
+		return "", err
+	}
+
+	if !parsed.localWallClock {
+		return parsed.absoluteTime.UTC().Format(common.RFC3339NanoUTC), nil
+	}
+
+	_, location, err := NormaliseReminderTimezone(timezone)
+	if err != nil {
+		return "", err
+	}
+
+	nowUTC := now.UTC()
+	localNow := nowUTC.In(location)
+	nextLocal := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), parsed.hour, parsed.minute, parsed.second, 0, location)
+	if !nextLocal.After(localNow) {
+		nextLocal = nextLocal.AddDate(0, 0, 1)
+	}
+
+	return nextLocal.UTC().Format(common.RFC3339NanoUTC), nil
+}
+
+type parsedReminderTargetTime struct {
+	localWallClock bool
+	hour           int
+	minute         int
+	second         int
+	absoluteTime   time.Time
+}
+
+func parseReminderTargetTime(value string) (parsedReminderTargetTime, error) {
+	if value == "" {
+		return parsedReminderTargetTime{}, ErrTargetTimeIsRequired
+	}
+
+	for _, layout := range []string{"15:04", "15:04:05"} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsedReminderTargetTime{
+				localWallClock: true,
+				hour:           parsed.Hour(),
+				minute:         parsed.Minute(),
+				second:         parsed.Second(),
+			}, nil
+		}
+	}
+
+	for _, layout := range []string{common.RFC3339NanoUTC, time.RFC3339Nano, time.RFC3339} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsedReminderTargetTime{absoluteTime: parsed.UTC()}, nil
+		}
+	}
+
+	return parsedReminderTargetTime{}, ErrInvalidTargetTime
 }

--- a/external/reminder/model_test.go
+++ b/external/reminder/model_test.go
@@ -1,0 +1,57 @@
+package reminder_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ooaklee/ghatd/external/reminder"
+)
+
+func TestBuildNextDueAtUsesLocalTimezone(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 22, 7, 0, 0, 0, time.UTC)
+
+	nextDueAt, err := reminder.BuildNextDueAt("09:00", "Europe/London", now)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-05-22T08:00:00", nextDueAt)
+}
+
+func TestBuildNextDueAtMovesPastWallClockToNextDay(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 22, 9, 30, 0, 0, time.UTC)
+
+	nextDueAt, err := reminder.BuildNextDueAt("09:00", "Europe/London", now)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-05-23T08:00:00", nextDueAt)
+}
+
+func TestBuildNextDueAtHandlesDSTStart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 28, 23, 30, 0, 0, time.UTC)
+
+	nextDueAt, err := reminder.BuildNextDueAt("09:00", "Europe/London", now)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-03-29T08:00:00", nextDueAt)
+}
+
+func TestBuildNextDueAtSupportsLegacyAbsoluteTargetTime(t *testing.T) {
+	t.Parallel()
+
+	nextDueAt, err := reminder.BuildNextDueAt("2026-05-15T10:00:00.000000000", "", time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, "2026-05-15T10:00:00", nextDueAt)
+}
+
+func TestBuildNextDueAtValidatesTimezone(t *testing.T) {
+	t.Parallel()
+
+	_, err := reminder.BuildNextDueAt("09:00", "not-a-zone", time.Now())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, reminder.ErrInvalidTimezone)
+}

--- a/external/reminder/repository.go
+++ b/external/reminder/repository.go
@@ -232,7 +232,7 @@ func buildReminderListFilter(req *ReminderFilter) bson.M {
 	}
 
 	if req.DueBefore != "" {
-		queryFilter["target_time"] = bson.M{"$lte": req.DueBefore}
+		queryFilter["next_due_at"] = bson.M{"$lte": req.DueBefore}
 	}
 
 	return queryFilter
@@ -421,7 +421,7 @@ func (r *Repository) CountReminders(ctx context.Context, filter *ReminderFilter)
 	return count, nil
 }
 
-// GetDueReminders returns reminders whose target time is due on or before the supplied UTC timestamp.
+// GetDueReminders returns reminders whose next due time is due on or before the supplied UTC timestamp.
 func (r *Repository) GetDueReminders(ctx context.Context, filter *ReminderFilter, limit int64) ([]*Reminder, error) {
 	collection, err := r.GetReminderCollection(ctx)
 	if err != nil {
@@ -431,7 +431,7 @@ func (r *Repository) GetDueReminders(ctx context.Context, filter *ReminderFilter
 	queryFilter := buildReminderListFilter(filter)
 
 	findOptions := options.Find().
-		SetSort(bson.D{{Key: "target_time", Value: 1}})
+		SetSort(bson.D{{Key: "next_due_at", Value: 1}, {Key: "target_time", Value: 1}})
 
 	if limit > 0 {
 		findOptions.SetLimit(limit)

--- a/external/reminder/repository.go
+++ b/external/reminder/repository.go
@@ -20,8 +20,8 @@ type MongoDbStore interface {
 	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
-	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, update interface{}, opts ...*options.UpdateOptions) (*mongo.UpdateResult, error)
-	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.DeleteOptions) (*mongo.DeleteResult, error)
+	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, update interface{}, resultObjectName string) error
+	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
 
 	GetDatabase(ctx context.Context, dbName string) (*mongo.Database, error)
 	InitialiseClient(ctx context.Context) (*mongo.Client, error)
@@ -338,7 +338,7 @@ func (r *Repository) UpdateReminderByID(ctx context.Context, reminder *Reminder)
 	filter := bson.M{"_id": reminder.Id}
 	update := bson.M{"$set": reminder}
 
-	_, err = r.Store.ExecuteUpdateOneCommand(ctx, collection, filter, update)
+	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, filter, update, "reminder")
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +356,7 @@ func (r *Repository) PatchReminder(ctx context.Context, id string, update map[st
 	update["updated_at"] = toolboxTimeNow()
 
 	filter := bson.M{"_id": id}
-	_, err = r.Store.ExecuteUpdateOneCommand(ctx, collection, filter, bson.M{"$set": update})
+	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, filter, bson.M{"$set": update}, "reminder")
 	if err != nil {
 		return err
 	}
@@ -376,7 +376,7 @@ func (r *Repository) DeleteReminderByID(ctx context.Context, id string) error {
 	}
 
 	filter := bson.M{"_id": id}
-	_, err = r.Store.ExecuteDeleteOneCommand(ctx, collection, filter)
+	err = r.Store.ExecuteDeleteOneCommand(ctx, collection, filter, "reminder")
 	if err != nil {
 		return err
 	}

--- a/external/reminder/repository_test.go
+++ b/external/reminder/repository_test.go
@@ -171,7 +171,7 @@ func TestBuildReminderListFilter(t *testing.T) {
 
 	t.Run("with due before", func(t *testing.T) {
 		f := buildReminderListFilter(&ReminderFilter{DueBefore: "2026-05-10T12:00:00"})
-		assert.Equal(t, bson.M{"$lte": "2026-05-10T12:00:00"}, f["target_time"])
+		assert.Equal(t, bson.M{"$lte": "2026-05-10T12:00:00"}, f["next_due_at"])
 	})
 
 	t.Run("with user and status", func(t *testing.T) {

--- a/external/reminder/repository_test.go
+++ b/external/reminder/repository_test.go
@@ -33,12 +33,12 @@ func (m *mockMongoDbStore) ExecuteFindOneCommandDecodeResult(ctx context.Context
 	return errors.New("not implemented")
 }
 
-func (m *mockMongoDbStore) ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, update interface{}, opts ...*options.UpdateOptions) (*mongo.UpdateResult, error) {
-	return nil, errors.New("not implemented")
+func (m *mockMongoDbStore) ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, update interface{}, resultObjectName string) error {
+	return errors.New("not implemented")
 }
 
-func (m *mockMongoDbStore) ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.DeleteOptions) (*mongo.DeleteResult, error) {
-	return nil, errors.New("not implemented")
+func (m *mockMongoDbStore) ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error {
+	return errors.New("not implemented")
 }
 
 func (m *mockMongoDbStore) GetDatabase(ctx context.Context, dbName string) (*mongo.Database, error) {

--- a/external/reminder/service.go
+++ b/external/reminder/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/ghatd/external/toolbox"
@@ -62,6 +63,16 @@ func (s *Service) CreateReminder(ctx context.Context, req *CreateReminderRequest
 		return nil, ErrTargetTimeIsRequired
 	}
 
+	timezone, _, err := NormaliseReminderTimezone(req.Timezone)
+	if err != nil {
+		return nil, err
+	}
+
+	nextDueAt, err := BuildNextDueAt(targetTime, timezone, time.Now().UTC())
+	if err != nil {
+		return nil, err
+	}
+
 	status, err := ValidateAndNormaliseStatus(req.Status)
 	if err != nil {
 		return nil, err
@@ -76,7 +87,8 @@ func (s *Service) CreateReminder(ctx context.Context, req *CreateReminderRequest
 		Title:           title,
 		Description:     strings.TrimSpace(req.Description),
 		TargetTime:      targetTime,
-		Timezone:        strings.TrimSpace(req.Timezone),
+		Timezone:        timezone,
+		NextDueAt:       nextDueAt,
 		Status:          status,
 		TaskData:        req.TaskData,
 		CreatedByUserID: userID,
@@ -208,11 +220,14 @@ func (s *Service) UpdateReminderByID(ctx context.Context, req *UpdateReminderByI
 	if req.Description != nil {
 		existing.Description = strings.TrimSpace(*req.Description)
 	}
+	scheduleChanged := false
 	if req.TargetTime != nil {
 		existing.TargetTime = strings.TrimSpace(*req.TargetTime)
+		scheduleChanged = true
 	}
 	if req.Timezone != nil {
 		existing.Timezone = strings.TrimSpace(*req.Timezone)
+		scheduleChanged = true
 	}
 	if req.Status != nil {
 		newStatus, err := ValidateAndNormaliseStatus(*req.Status)
@@ -226,6 +241,18 @@ func (s *Service) UpdateReminderByID(ctx context.Context, req *UpdateReminderByI
 	}
 	if req.TaskData != nil {
 		existing.TaskData = req.TaskData
+	}
+	if scheduleChanged || strings.TrimSpace(existing.NextDueAt) == "" {
+		timezone, _, err := NormaliseReminderTimezone(existing.Timezone)
+		if err != nil {
+			return nil, err
+		}
+		nextDueAt, err := BuildNextDueAt(existing.TargetTime, timezone, time.Now().UTC())
+		if err != nil {
+			return nil, err
+		}
+		existing.Timezone = timezone
+		existing.NextDueAt = nextDueAt
 	}
 
 	existing.UpdatedByUserID = req.UserID

--- a/external/reminder/service_test.go
+++ b/external/reminder/service_test.go
@@ -134,9 +134,42 @@ func TestService_CreateReminderSuccess(t *testing.T) {
 	assert.Equal(t, "lesson-1", res.Reminder.TargetId)
 	assert.Equal(t, "Test Reminder", res.Reminder.Title)
 	assert.Equal(t, "2026-05-15T10:00:00.000000000", res.Reminder.TargetTime)
+	assert.Equal(t, "UTC", res.Reminder.Timezone)
+	assert.Equal(t, "2026-05-15T10:00:00", res.Reminder.NextDueAt)
 	assert.Equal(t, reminder.ReminderStatusActive, res.Reminder.Status)
 	assert.NotEmpty(t, res.Reminder.Id)
 	assert.NotEmpty(t, res.Reminder.NanoId)
+}
+
+func TestService_CreateReminderComputesTimezoneAwareNextDueAt(t *testing.T) {
+	t.Parallel()
+
+	var created *reminder.Reminder
+	repo := &mockReminderRepository{
+		createReminderFunc: func(ctx context.Context, r *reminder.Reminder) (*reminder.Reminder, error) {
+			created = r
+			r.Id = "generated-id"
+			r.NanoId = "generated-nano"
+			return r, nil
+		},
+	}
+	svc := reminder.NewService(repo)
+
+	res, err := svc.CreateReminder(context.Background(), &reminder.CreateReminderRequest{
+		UserID:     "user-1",
+		TargetType: "space",
+		TargetId:   "space-1",
+		Title:      "Morning reminder",
+		TargetTime: "09:00",
+		Timezone:   "Europe/London",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res.Reminder)
+	require.NotNil(t, created)
+	assert.Equal(t, "09:00", created.TargetTime)
+	assert.Equal(t, "Europe/London", created.Timezone)
+	assert.NotEmpty(t, created.NextDueAt)
 }
 
 func TestService_CreateReminderValidatesRequiredFields(t *testing.T) {
@@ -179,6 +212,18 @@ func TestService_CreateReminderValidatesRequiredFields(t *testing.T) {
 		})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, reminder.ErrTargetTimeIsRequired)
+	})
+
+	t.Run("invalid timezone", func(t *testing.T) {
+		t.Parallel()
+		_, err := svc.CreateReminder(context.Background(), &reminder.CreateReminderRequest{
+			UserID:     "user-1",
+			Title:      "Test",
+			TargetTime: "09:00",
+			Timezone:   "not-a-zone",
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, reminder.ErrInvalidTimezone)
 	})
 }
 

--- a/external/starter/v0/README.md
+++ b/external/starter/v0/README.md
@@ -10,7 +10,7 @@ a GHATD application is assembled at the `main` package level.
 **starter/v0 is NOT a replacement architecture.** It is a thin, lazy
 composition layer over the existing modular GHATD packages
 (`external/usermanager`, `external/accessmanager`, `external/billingmanager`,
-etc.). It exists to:
+`external/reminder`, `external/streaker`, etc.). It exists to:
 
 - **Reserve the shape** - show new contributors what wiring looks like before
   they learn every package.
@@ -38,7 +38,7 @@ etc.). It exists to:
 | Function               | Purpose                                      |
 |------------------------|----------------------------------------------|
 | `NewRepositories`      | Builds package repositories from a core Mongo repository, with per-repository overrides. |
-| `NewServices`          | Builds GHATD services from repositories and explicit app integrations such as Redis, email, audit, OAuth, policy, and payment providers. |
+| `NewServices`          | Builds GHATD services from repositories plus explicit app integrations such as Redis, email, audit, OAuth, policy, notifications, and payment providers. Includes reminder and streaker services. |
 | `NewHandlers`          | Builds standard GHATD handlers with default error bundles and explicit override hooks. |
 | `NewMiddleware`        | Builds the accessmanager middleware suite.   |
 | `NewStack`             | Validates config and groups already-built layers. |
@@ -88,6 +88,22 @@ For a fuller GHATD host application server-command walkthrough, see
 
 `NewStack` intentionally accepts nil layer fields so teams can adopt starter/v0
 incrementally. Treat nil layers as "not wired yet" and check them before use.
+
+## Reminder and Streaker
+
+`NewRepositories` creates `Reminder` and `Streaker` repositories from the core
+Mongo repository unless the caller supplies overrides. `NewServices` then
+creates `Services.Reminder` and `Services.Streaker`.
+
+The starter-created reminder service is attached to `Services.UserManager` by
+default, so the UMS reminder endpoints under `/api/v1/ums` are backed by a
+real reminder service when `AttachDefaultRoutes` includes
+`RouteGroupUserManager`. To attach a different implementation to UMS, pass
+`NewServicesRequest.ReminderService`.
+
+`streaker` does not have a standard starter route group in v0. Host
+applications can call `Services.Streaker` directly from jobs or custom API
+handlers, and they still own any streaker-specific route design.
 
 ## Usage
 
@@ -205,7 +221,7 @@ if err != nil {
 | `RouteGroupUser`                      | `/api/v2/users/*`                                    |
 | `RouteGroupGroup`                     | `/api/v1/groups/*`                                   |
 | `RouteGroupAccessManager`             | `/api/v1/ams/*`                                      |
-| `RouteGroupUserManager`               | `/api/v1/ums/*`                                      |
+| `RouteGroupUserManager`               | `/api/v1/ums/*`, including reminder endpoints        |
 | `RouteGroupContentManager`            | `/api/v1/cms/*`                                      |
 | `RouteGroupBillingManager`            | `/api/v1/bms/*`                                      |
 

--- a/external/starter/v0/README.md
+++ b/external/starter/v0/README.md
@@ -95,15 +95,21 @@ incrementally. Treat nil layers as "not wired yet" and check them before use.
 Mongo repository unless the caller supplies overrides. `NewServices` then
 creates `Services.Reminder` and `Services.Streaker`.
 
-The starter-created reminder service is attached to `Services.UserManager` by
-default, so the UMS reminder endpoints under `/api/v1/ums` are backed by a
-real reminder service when `AttachDefaultRoutes` includes
-`RouteGroupUserManager`. To attach a different implementation to UMS, pass
-`NewServicesRequest.ReminderService`.
+Reminder and streaker are optional starter integrations. If their repositories
+are available, `NewServices` creates `Services.Reminder` and
+`Services.Streaker`; if they are absent, the rest of the stack can still be
+constructed.
 
-`streaker` does not have a standard starter route group in v0. Host
-applications can call `Services.Streaker` directly from jobs or custom API
-handlers, and they still own any streaker-specific route design.
+The starter-created reminder and streaker services are attached to
+`Services.UserManager` by default. When `AttachDefaultRoutes` includes
+`RouteGroupUserManager`, UMS exposes reminder and streak endpoints backed by
+those services. To attach a different implementation to UMS, pass
+`NewServicesRequest.ReminderService` or `NewServicesRequest.StreakService`.
+
+`streaker` does not have a standalone starter route group in v0. Host
+applications still own product-specific streak workflows, schedulers, and
+custom API routes. Those workflows can call `Services.Streaker` directly or
+use the UMS streak endpoints for authenticated user-scoped access.
 
 ## Usage
 
@@ -221,7 +227,7 @@ if err != nil {
 | `RouteGroupUser`                      | `/api/v2/users/*`                                    |
 | `RouteGroupGroup`                     | `/api/v1/groups/*`                                   |
 | `RouteGroupAccessManager`             | `/api/v1/ams/*`                                      |
-| `RouteGroupUserManager`               | `/api/v1/ums/*`, including reminder endpoints        |
+| `RouteGroupUserManager`               | `/api/v1/ums/*`, including reminder and streak endpoints |
 | `RouteGroupContentManager`            | `/api/v1/cms/*`                                      |
 | `RouteGroupBillingManager`            | `/api/v1/bms/*`                                      |
 

--- a/external/starter/v0/repositories.go
+++ b/external/starter/v0/repositories.go
@@ -124,8 +124,6 @@ func validateRepositoriesForServices(repos *Repositories) error {
 		repos.Notifier == nil ||
 		repos.Post == nil ||
 		repos.Pricer == nil ||
-		repos.Reminder == nil ||
-		repos.Streaker == nil ||
 		repos.User == nil {
 		return ErrNilRepositories
 	}

--- a/external/starter/v0/repositories.go
+++ b/external/starter/v0/repositories.go
@@ -9,7 +9,9 @@ import (
 	"github.com/ooaklee/ghatd/external/notifier"
 	"github.com/ooaklee/ghatd/external/post"
 	"github.com/ooaklee/ghatd/external/pricer"
+	"github.com/ooaklee/ghatd/external/reminder"
 	"github.com/ooaklee/ghatd/external/repository"
+	"github.com/ooaklee/ghatd/external/streaker"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 )
 
@@ -24,6 +26,8 @@ type Repositories struct {
 	Notifier  *notifier.Repository
 	Post      *post.Repository
 	Pricer    *pricer.Repository
+	Reminder  *reminder.Repository
+	Streaker  *streaker.Repository
 	User      *userv2.Repository
 }
 
@@ -40,6 +44,8 @@ type NewRepositoriesRequest struct {
 	Notifier  *notifier.Repository
 	Post      *post.Repository
 	Pricer    *pricer.Repository
+	Reminder  *reminder.Repository
+	Streaker  *streaker.Repository
 	User      *userv2.Repository
 }
 
@@ -63,6 +69,8 @@ func NewRepositories(r *NewRepositoriesRequest) (*Repositories, error) {
 		Notifier:  r.Notifier,
 		Post:      r.Post,
 		Pricer:    r.Pricer,
+		Reminder:  r.Reminder,
+		Streaker:  r.Streaker,
 		User:      r.User,
 	}
 
@@ -90,6 +98,12 @@ func NewRepositories(r *NewRepositoriesRequest) (*Repositories, error) {
 	if repos.Pricer == nil {
 		repos.Pricer = pricer.NewRepository(r.Core)
 	}
+	if repos.Reminder == nil {
+		repos.Reminder = reminder.NewRepository(r.Core)
+	}
+	if repos.Streaker == nil {
+		repos.Streaker = streaker.NewRepository(r.Core)
+	}
 	if repos.User == nil {
 		repos.User = userv2.NewRepository(r.Core)
 	}
@@ -110,6 +124,8 @@ func validateRepositoriesForServices(repos *Repositories) error {
 		repos.Notifier == nil ||
 		repos.Post == nil ||
 		repos.Pricer == nil ||
+		repos.Reminder == nil ||
+		repos.Streaker == nil ||
 		repos.User == nil {
 		return ErrNilRepositories
 	}

--- a/external/starter/v0/services.go
+++ b/external/starter/v0/services.go
@@ -84,6 +84,9 @@ type NewServicesRequest struct {
 	// ReminderService overrides the reminder service attached to UserManager.
 	// When nil, starter attaches the Reminder service it creates from repositories.
 	ReminderService usermanager.ReminderService
+	// StreakService overrides the streaker service attached to UserManager.
+	// When nil, starter attaches the Streaker service it creates from repositories.
+	StreakService usermanager.StreakService
 
 	PolicyStore  policy.PolicyStore
 	PolicyConfig *PolicyConfig
@@ -148,8 +151,14 @@ func NewServices(r *NewServicesRequest) (*Services, error) {
 	postService := post.NewService(r.Repositories.Post, resolvePostTags(r.ValidPostTags))
 	billingService := billing.NewService(r.Repositories.Billing, r.Repositories.Billing)
 	pricerService := pricer.NewService(r.Repositories.Pricer)
-	reminderService := reminder.NewService(r.Repositories.Reminder)
-	streakerService := streaker.NewService(r.Repositories.Streaker)
+	var reminderService *reminder.Service
+	if r.Repositories.Reminder != nil {
+		reminderService = reminder.NewService(r.Repositories.Reminder)
+	}
+	var streakerService *streaker.Service
+	if r.Repositories.Streaker != nil {
+		streakerService = streaker.NewService(r.Repositories.Streaker)
+	}
 	notifierService := notifier.NewService(&notifier.NewServiceRequest{
 		Repository: r.Repositories.Notifier,
 		Senders:    r.NotifierSenders,
@@ -177,9 +186,18 @@ func NewServices(r *NewServicesRequest) (*Services, error) {
 		ApiTokenService:  apiTokenService,
 		AuditService:     auditService,
 		ContacterService: contacterService,
-	}).WithGroupService(groupService).WithNotifierService(notifierService).WithReminderService(reminderService)
+	}).WithGroupService(groupService).WithNotifierService(notifierService)
+	if reminderService != nil {
+		userManagerService.WithReminderService(reminderService)
+	}
 	if r.ReminderService != nil {
 		userManagerService.WithReminderService(r.ReminderService)
+	}
+	if streakerService != nil {
+		userManagerService.WithStreakService(streakerService)
+	}
+	if r.StreakService != nil {
+		userManagerService.WithStreakService(r.StreakService)
 	}
 
 	accessManagerService := accessmanager.NewService(&accessmanager.NewServiceRequest{

--- a/external/starter/v0/services.go
+++ b/external/starter/v0/services.go
@@ -18,6 +18,8 @@ import (
 	"github.com/ooaklee/ghatd/external/policy"
 	"github.com/ooaklee/ghatd/external/post"
 	"github.com/ooaklee/ghatd/external/pricer"
+	"github.com/ooaklee/ghatd/external/reminder"
+	"github.com/ooaklee/ghatd/external/streaker"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 	"github.com/ooaklee/ghatd/external/usermanager"
 )
@@ -37,6 +39,8 @@ type Services struct {
 	Policy                  *policy.Service
 	Post                    *post.Service
 	Pricer                  *pricer.Service
+	Reminder                *reminder.Service
+	Streaker                *streaker.Service
 	User                    *userv2.Service
 	UserManager             *usermanager.Service
 	EphemeralStore          accessmanager.EphemeralStore
@@ -77,6 +81,8 @@ type NewServicesRequest struct {
 	ValidPostTags []string
 
 	NotifierSenders []notifier.ChannelSender
+	// ReminderService overrides the reminder service attached to UserManager.
+	// When nil, starter attaches the Reminder service it creates from repositories.
 	ReminderService usermanager.ReminderService
 
 	PolicyStore  policy.PolicyStore
@@ -142,6 +148,8 @@ func NewServices(r *NewServicesRequest) (*Services, error) {
 	postService := post.NewService(r.Repositories.Post, resolvePostTags(r.ValidPostTags))
 	billingService := billing.NewService(r.Repositories.Billing, r.Repositories.Billing)
 	pricerService := pricer.NewService(r.Repositories.Pricer)
+	reminderService := reminder.NewService(r.Repositories.Reminder)
+	streakerService := streaker.NewService(r.Repositories.Streaker)
 	notifierService := notifier.NewService(&notifier.NewServiceRequest{
 		Repository: r.Repositories.Notifier,
 		Senders:    r.NotifierSenders,
@@ -169,7 +177,7 @@ func NewServices(r *NewServicesRequest) (*Services, error) {
 		ApiTokenService:  apiTokenService,
 		AuditService:     auditService,
 		ContacterService: contacterService,
-	}).WithGroupService(groupService).WithNotifierService(notifierService)
+	}).WithGroupService(groupService).WithNotifierService(notifierService).WithReminderService(reminderService)
 	if r.ReminderService != nil {
 		userManagerService.WithReminderService(r.ReminderService)
 	}
@@ -203,6 +211,8 @@ func NewServices(r *NewServicesRequest) (*Services, error) {
 		Policy:                  policyService,
 		Post:                    postService,
 		Pricer:                  pricerService,
+		Reminder:                reminderService,
+		Streaker:                streakerService,
 		User:                    userService,
 		UserManager:             userManagerService,
 		EphemeralStore:          r.EphemeralStore,

--- a/external/starter/v0/starter_test.go
+++ b/external/starter/v0/starter_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/ooaklee/ghatd/external/paymentprovider"
 	"github.com/ooaklee/ghatd/external/policy"
 	"github.com/ooaklee/ghatd/external/post"
+	"github.com/ooaklee/ghatd/external/reminder"
 	"github.com/ooaklee/ghatd/external/repository"
+	"github.com/ooaklee/ghatd/external/streaker"
 	"github.com/ooaklee/reply/v2"
 )
 
@@ -195,6 +197,8 @@ func TestNewStack(t *testing.T) {
 func TestNewRepositories(t *testing.T) {
 	core := &repository.MongoDbRepository{}
 	overrideAudit := audit.NewRepository(core)
+	overrideReminder := reminder.NewRepository(core)
+	overrideStreaker := streaker.NewRepository(core)
 
 	tests := []struct {
 		name    string
@@ -224,21 +228,30 @@ func TestNewRepositories(t *testing.T) {
 				}
 				if got.APIToken == nil || got.Audit == nil || got.Billing == nil ||
 					got.Contacter == nil || got.Group == nil || got.Notifier == nil ||
-					got.Post == nil || got.Pricer == nil || got.User == nil {
+					got.Post == nil || got.Pricer == nil || got.Reminder == nil ||
+					got.Streaker == nil || got.User == nil {
 					t.Fatalf("expected all repositories to be populated: %#v", got)
 				}
 			},
 		},
 		{
-			name: "Success - explicit repository override is preserved",
+			name: "Success - explicit repository overrides are preserved",
 			request: &NewRepositoriesRequest{
-				Core:  core,
-				Audit: overrideAudit,
+				Core:     core,
+				Audit:    overrideAudit,
+				Reminder: overrideReminder,
+				Streaker: overrideStreaker,
 			},
 			assert: func(t *testing.T, got *Repositories) {
 				t.Helper()
 				if got.Audit != overrideAudit {
 					t.Fatalf("expected audit override to be preserved")
+				}
+				if got.Reminder != overrideReminder {
+					t.Fatalf("expected reminder override to be preserved")
+				}
+				if got.Streaker != overrideStreaker {
+					t.Fatalf("expected streaker override to be preserved")
 				}
 			},
 		},
@@ -269,6 +282,7 @@ func TestNewRepositories(t *testing.T) {
 func TestNewServices(t *testing.T) {
 	customPaymentProviderRegistry := paymentprovider.NewProviderRegistry()
 	customAuditService := audit.NewService(validRepositories(t).Audit)
+	customReminderService := reminder.NewService(validRepositories(t).Reminder)
 
 	tests := []struct {
 		name    string
@@ -380,7 +394,8 @@ func TestNewServices(t *testing.T) {
 					got.Auth == nil || got.Billing == nil || got.BillingManager == nil ||
 					got.Contacter == nil || got.ContentManager == nil || got.Group == nil ||
 					got.Notifier == nil || got.Policy == nil || got.Post == nil ||
-					got.Pricer == nil || got.User == nil || got.UserManager == nil {
+					got.Pricer == nil || got.Reminder == nil || got.Streaker == nil ||
+					got.User == nil || got.UserManager == nil {
 					t.Fatalf("expected all services to be populated: %#v", got)
 				}
 				if got.AccessManager.GroupService != got.Group {
@@ -394,6 +409,9 @@ func TestNewServices(t *testing.T) {
 				}
 				if got.UserManager.NotifierService != got.Notifier {
 					t.Fatalf("expected user manager to receive notifier service")
+				}
+				if got.UserManager.ReminderService != got.Reminder {
+					t.Fatalf("expected user manager to receive starter reminder service")
 				}
 			},
 		},
@@ -450,6 +468,23 @@ func TestNewServices(t *testing.T) {
 				}
 				if got.AccessManager.AuditService != customAuditService {
 					t.Fatalf("expected access manager to receive custom audit service")
+				}
+			},
+		},
+		{
+			name: "Success - custom usermanager reminder service is preserved",
+			request: func(t *testing.T) *NewServicesRequest {
+				req := validServicesRequest(t)
+				req.ReminderService = customReminderService
+				return req
+			},
+			assert: func(t *testing.T, got *Services) {
+				t.Helper()
+				if got.Reminder == nil {
+					t.Fatalf("expected starter reminder service to still be created")
+				}
+				if got.UserManager.ReminderService != customReminderService {
+					t.Fatalf("expected user manager to receive custom reminder service")
 				}
 			},
 		},
@@ -1091,6 +1126,16 @@ func TestValidateRepositoriesForServices(t *testing.T) {
 			wantErr: ErrNilRepositories,
 		},
 		{
+			name:    "FAILURE - nil Reminder",
+			mutate:  func(r *Repositories) { r.Reminder = nil },
+			wantErr: ErrNilRepositories,
+		},
+		{
+			name:    "FAILURE - nil Streaker",
+			mutate:  func(r *Repositories) { r.Streaker = nil },
+			wantErr: ErrNilRepositories,
+		},
+		{
 			name:    "FAILURE - nil User",
 			mutate:  func(r *Repositories) { r.User = nil },
 			wantErr: ErrNilRepositories,
@@ -1109,6 +1154,8 @@ func TestValidateRepositoriesForServices(t *testing.T) {
 				Notifier:  fullRepos.Notifier,
 				Post:      fullRepos.Post,
 				Pricer:    fullRepos.Pricer,
+				Reminder:  fullRepos.Reminder,
+				Streaker:  fullRepos.Streaker,
 				User:      fullRepos.User,
 			}
 			if tt.name == "FAILURE - nil repositories" {

--- a/external/starter/v0/starter_test.go
+++ b/external/starter/v0/starter_test.go
@@ -413,6 +413,33 @@ func TestNewServices(t *testing.T) {
 				if got.UserManager.ReminderService != got.Reminder {
 					t.Fatalf("expected user manager to receive starter reminder service")
 				}
+				if got.UserManager.StreakService != got.Streaker {
+					t.Fatalf("expected user manager to receive starter streak service")
+				}
+			},
+		},
+		{
+			name: "Success - optional reminder and streaker services may be absent",
+			request: func(t *testing.T) *NewServicesRequest {
+				req := validServicesRequest(t)
+				req.Repositories.Reminder = nil
+				req.Repositories.Streaker = nil
+				return req
+			},
+			assert: func(t *testing.T, got *Services) {
+				t.Helper()
+				if got.Reminder != nil {
+					t.Fatalf("expected reminder service to be omitted")
+				}
+				if got.Streaker != nil {
+					t.Fatalf("expected streaker service to be omitted")
+				}
+				if got.UserManager.ReminderService != nil {
+					t.Fatalf("expected user manager reminder service to be omitted")
+				}
+				if got.UserManager.StreakService != nil {
+					t.Fatalf("expected user manager streak service to be omitted")
+				}
 			},
 		},
 		{
@@ -1126,14 +1153,12 @@ func TestValidateRepositoriesForServices(t *testing.T) {
 			wantErr: ErrNilRepositories,
 		},
 		{
-			name:    "FAILURE - nil Reminder",
-			mutate:  func(r *Repositories) { r.Reminder = nil },
-			wantErr: ErrNilRepositories,
+			name:   "SUCCESS - nil Reminder",
+			mutate: func(r *Repositories) { r.Reminder = nil },
 		},
 		{
-			name:    "FAILURE - nil Streaker",
-			mutate:  func(r *Repositories) { r.Streaker = nil },
-			wantErr: ErrNilRepositories,
+			name:   "SUCCESS - nil Streaker",
+			mutate: func(r *Repositories) { r.Streaker = nil },
 		},
 		{
 			name:    "FAILURE - nil User",

--- a/external/streaker/README.md
+++ b/external/streaker/README.md
@@ -29,7 +29,13 @@ Supported period types are:
 - `custom`
 
 For `daily`, `weekly`, and `monthly`, Streaker derives `period_key` from
-`occurred_at` in UTC. For `custom`, callers must provide `period_key`.
+`occurred_at` in `period_timezone`. If `period_timezone` is omitted, Streaker
+uses `UTC` for backward compatibility. For `custom`, callers must provide
+`period_key`.
+
+`period_timezone` must be an IANA timezone such as `Europe/London` or
+`America/New_York`. Streaker stores the effective timezone on each entry so host
+applications can audit which local boundary created the period key.
 
 ## Service Setup
 
@@ -72,6 +78,7 @@ res, err := svc.RecordStreak(ctx, &streaker.RecordStreakRequest{
     TargetType:      "item",
     TargetId:        "daily-save",
     PeriodType:      streaker.StreakPeriodTypeDaily,
+    PeriodTimezone:  "Europe/London",
     CreatedByUserId: "<user-id>",
     Metadata: map[string]interface{}{
         "item_id":  "<item-id>",
@@ -115,7 +122,9 @@ best, err := svc.GetLongestStreak(ctx, &streaker.GetLongestStreakRequest{
 
 `GetCurrentCount` returns the latest recorded count for the scope. If a host
 application needs "active today" semantics, compare the returned `period_key`
-with today and the immediately preceding period.
+with the current local period and the immediately preceding period. Use
+`BuildPeriodKeyForTimezone` to derive local period keys consistently with
+recording.
 
 ## Listing History
 

--- a/external/streaker/README.md
+++ b/external/streaker/README.md
@@ -1,0 +1,173 @@
+# GHATD Streaker
+
+`external/streaker` records idempotent streak completions for host applications.
+It is intentionally generic: the package does not know what an app check-in,
+lesson completion, saved item, or playback means. Host applications define those
+domain events and pass a stable streak scope into Streaker.
+
+## Core Concepts
+
+A streak entry is unique per:
+
+- `streak_type`
+- `owner_id`
+- `target_type`
+- `target_id`
+- `period_type`
+- `period_key`
+
+Calling `RecordStreak` more than once for the same scope and period returns the
+existing entry instead of incrementing the count again. When the previous entry
+is in the immediately preceding period, the new entry increments
+`current_count`; otherwise the count resets to `1`.
+
+Supported period types are:
+
+- `daily`
+- `weekly`
+- `monthly`
+- `custom`
+
+For `daily`, `weekly`, and `monthly`, Streaker derives `period_key` from
+`occurred_at` in UTC. For `custom`, callers must provide `period_key`.
+
+## Service Setup
+
+```go
+repo := streaker.NewRepository(coreRepository)
+svc := streaker.NewService(repo)
+```
+
+When using `external/starter/v0`, the starter creates `Services.Streaker` when
+`Repositories.Streaker` is configured. Streaker is optional: host applications
+may omit the repository/service and keep the rest of GHATD running.
+
+```go
+services, err := starter.NewServices(&starter.NewServicesRequest{
+    Repositories: repos,
+    // other required starter fields...
+})
+if err != nil {
+    return err
+}
+
+if services.Streaker != nil {
+    // Attach to your host application manager or call it directly.
+}
+```
+
+Starter also attaches Streaker to User Manager when available, enabling the UMS
+streak endpoints.
+
+## Recording A Streak
+
+Use stable target IDs for aggregate action streaks. Put event-specific resource
+IDs in `metadata`.
+
+```go
+res, err := svc.RecordStreak(ctx, &streaker.RecordStreakRequest{
+    StreakName:      "Daily saved item",
+    StreakType:      "saved-items",
+    OwnerId:         "<user-id>",
+    TargetType:      "item",
+    TargetId:        "daily-save",
+    PeriodType:      streaker.StreakPeriodTypeDaily,
+    CreatedByUserId: "<user-id>",
+    Metadata: map[string]interface{}{
+        "item_id":  "<item-id>",
+        "platform": "web",
+    },
+})
+```
+
+Avoid using a changing resource ID as `target_id` when the product goal is
+"do this once per day across any resource." A changing `target_id` creates a
+separate counter per resource.
+
+Host applications should call `RecordStreak` only after they have decided that
+the user action is valid. For example, an app can record an explicit play-button
+intent, save action, lesson completion, or check-in, but Streaker does not
+validate playback readiness, content ownership, or product workflow rules.
+
+## Reading Stats
+
+```go
+current, err := svc.GetCurrentCount(ctx, &streaker.GetCurrentCountRequest{
+    StreakStatsRequest: streaker.StreakStatsRequest{
+        StreakType: "saved-items",
+        OwnerId:    "<user-id>",
+        TargetType: "item",
+        TargetId:   "daily-save",
+        PeriodType: streaker.StreakPeriodTypeDaily,
+    },
+})
+
+best, err := svc.GetLongestStreak(ctx, &streaker.GetLongestStreakRequest{
+    StreakStatsRequest: streaker.StreakStatsRequest{
+        StreakType: "saved-items",
+        OwnerId:    "<user-id>",
+        TargetType: "item",
+        TargetId:   "daily-save",
+        PeriodType: streaker.StreakPeriodTypeDaily,
+    },
+})
+```
+
+`GetCurrentCount` returns the latest recorded count for the scope. If a host
+application needs "active today" semantics, compare the returned `period_key`
+with today and the immediately preceding period.
+
+## Listing History
+
+Use `ListStreaks` for streak boards, calendars, and history views.
+
+```go
+history, err := svc.ListStreaks(ctx, &streaker.ListStreaksRequest{
+    StreakStatsRequest: streaker.StreakStatsRequest{
+        StreakType: "saved-items",
+        OwnerId:    "<user-id>",
+        TargetType: "item",
+        TargetId:   "daily-save",
+        PeriodType: streaker.StreakPeriodTypeDaily,
+    },
+    PeriodKeyFrom: "2026-05-16",
+    PeriodKeyTo:   "2026-05-22",
+    Sort:          "asc",
+    PerPage:       50,
+})
+```
+
+For `daily`, `weekly`, and `monthly` periods, period-key ranges are
+lexicographically sortable because the generated keys are zero-padded.
+
+## User Manager Endpoints
+
+When Streaker is attached to User Manager, authenticated users can access:
+
+- `GET /api/v1/ums/me/streaks`
+- `POST /api/v1/ums/me/streaks/record`
+- `GET /api/v1/ums/me/streaks/current`
+- `GET /api/v1/ums/me/streaks/longest`
+- `GET /api/v1/ums/me/streaks/count`
+
+Admin/service routes are also available for read operations:
+
+- `GET /api/v1/ums/streaks`
+- `GET /api/v1/ums/streaks/current`
+- `GET /api/v1/ums/streaks/longest`
+- `GET /api/v1/ums/streaks/count`
+
+The `/me` routes always scope `owner_id` to the authenticated requester.
+Admin/service routes may pass `user_id` as a query parameter when querying a
+target user.
+
+## Optional Integration Guidance
+
+For host application side effects, treat Streaker as optional:
+
+- log before attempting to record a streak
+- skip if the service is not configured
+- warn and continue if recording fails
+
+For direct user-facing streak APIs, return a clear service-unavailable response
+when Streaker is not attached.

--- a/external/streaker/const.go
+++ b/external/streaker/const.go
@@ -4,13 +4,13 @@ package streaker
 type StreakPeriodType string
 
 const (
-	// StreakPeriodTypeDaily represents one streak period per UTC day.
+	// StreakPeriodTypeDaily represents one streak period per day.
 	StreakPeriodTypeDaily StreakPeriodType = "daily"
 
-	// StreakPeriodTypeWeekly represents one streak period per UTC ISO week.
+	// StreakPeriodTypeWeekly represents one streak period per ISO week.
 	StreakPeriodTypeWeekly StreakPeriodType = "weekly"
 
-	// StreakPeriodTypeMonthly represents one streak period per UTC month.
+	// StreakPeriodTypeMonthly represents one streak period per month.
 	StreakPeriodTypeMonthly StreakPeriodType = "monthly"
 
 	// StreakPeriodTypeCustom allows callers to provide their own period key.
@@ -32,6 +32,7 @@ const (
 	ErrKeyPeriodTypeIsRequired       = "StreakPeriodTypeIsRequired"
 	ErrKeyInvalidPeriodType          = "StreakInvalidPeriodType"
 	ErrKeyInvalidOccurredAt          = "StreakInvalidOccurredAt"
+	ErrKeyInvalidPeriodTimezone      = "StreakInvalidPeriodTimezone"
 	ErrKeyPeriodKeyIsRequired        = "StreakPeriodKeyIsRequired"
 	ErrKeyResourceNotFound           = "StreakResourceNotFound"
 	ErrKeyResourceConflict           = "StreakResourceConflict"

--- a/external/streaker/errormap.go
+++ b/external/streaker/errormap.go
@@ -50,6 +50,12 @@ var StreakErrorMap reply.ErrorManifest = reply.ErrorManifest{
 		Code:       "STR0-007",
 		Detail:     "The provided occurred_at value is invalid",
 	},
+	ErrInvalidPeriodTimezone: {
+		Title:      "Invalid Period Timezone",
+		StatusCode: http.StatusBadRequest,
+		Code:       "STR0-018",
+		Detail:     "Please provide a valid IANA timezone",
+	},
 	ErrPeriodKeyIsRequired: {
 		Title:      "Missing Period Key",
 		StatusCode: http.StatusBadRequest,

--- a/external/streaker/errors.go
+++ b/external/streaker/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrIdIsRequired               = errors.New(ErrKeyIdIsRequired)
 	ErrInvalidCurrentCount        = errors.New(ErrKeyInvalidCurrentCount)
 	ErrInvalidOccurredAt          = errors.New(ErrKeyInvalidOccurredAt)
+	ErrInvalidPeriodTimezone      = errors.New(ErrKeyInvalidPeriodTimezone)
 	ErrInvalidPeriodType          = errors.New(ErrKeyInvalidPeriodType)
 	ErrNanoIdIsRequired           = errors.New(ErrKeyNanoIdIsRequired)
 	ErrOwnerIdIsRequired          = errors.New(ErrKeyOwnerIdIsRequired)

--- a/external/streaker/model.go
+++ b/external/streaker/model.go
@@ -5,10 +5,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/ooaklee/ghatd/external/common"
 	"github.com/ooaklee/ghatd/external/toolbox"
 )
+
+const defaultPeriodTimezone = "UTC"
 
 // StreakScope identifies the entity and target a streak belongs to.
 type StreakScope struct {
@@ -21,12 +24,13 @@ type StreakScope struct {
 // PreviousStreakEntry is stored on each streak entry when a related previous
 // entry exists. It gives consumers a cheap chain back through the streak.
 type PreviousStreakEntry struct {
-	Id           string `json:"id" bson:"id"`
-	NanoId       string `json:"nano_id,omitempty" bson:"_nano_id,omitempty"`
-	PeriodKey    string `json:"period_key" bson:"period_key"`
-	OccurredAt   string `json:"occurred_at" bson:"occurred_at"`
-	CurrentCount int    `json:"current_count" bson:"current_count"`
-	CreatedAt    string `json:"created_at" bson:"created_at"`
+	Id             string `json:"id" bson:"id"`
+	NanoId         string `json:"nano_id,omitempty" bson:"_nano_id,omitempty"`
+	PeriodKey      string `json:"period_key" bson:"period_key"`
+	PeriodTimezone string `json:"period_timezone,omitempty" bson:"period_timezone,omitempty"`
+	OccurredAt     string `json:"occurred_at" bson:"occurred_at"`
+	CurrentCount   int    `json:"current_count" bson:"current_count"`
+	CreatedAt      string `json:"created_at" bson:"created_at"`
 }
 
 // Streak represents a single qualifying completion for a streak scope.
@@ -40,9 +44,10 @@ type Streak struct {
 	TargetType string `json:"target_type" bson:"target_type"`
 	TargetId   string `json:"target_id" bson:"target_id"`
 
-	PeriodType StreakPeriodType `json:"period_type" bson:"period_type"`
-	PeriodKey  string           `json:"period_key" bson:"period_key"`
-	OccurredAt string           `json:"occurred_at" bson:"occurred_at"`
+	PeriodType     StreakPeriodType `json:"period_type" bson:"period_type"`
+	PeriodKey      string           `json:"period_key" bson:"period_key"`
+	PeriodTimezone string           `json:"period_timezone,omitempty" bson:"period_timezone,omitempty"`
+	OccurredAt     string           `json:"occurred_at" bson:"occurred_at"`
 
 	CurrentCount int                    `json:"current_count" bson:"current_count"`
 	Previous     *PreviousStreakEntry   `json:"previous,omitempty" bson:"previous,omitempty"`
@@ -109,12 +114,13 @@ func (s *Streak) ToPreviousEntry() *PreviousStreakEntry {
 	}
 
 	return &PreviousStreakEntry{
-		Id:           s.Id,
-		NanoId:       s.NanoId,
-		PeriodKey:    s.PeriodKey,
-		OccurredAt:   s.OccurredAt,
-		CurrentCount: s.CurrentCount,
-		CreatedAt:    s.CreatedAt,
+		Id:             s.Id,
+		NanoId:         s.NanoId,
+		PeriodKey:      s.PeriodKey,
+		PeriodTimezone: s.PeriodTimezone,
+		OccurredAt:     s.OccurredAt,
+		CurrentCount:   s.CurrentCount,
+		CreatedAt:      s.CreatedAt,
 	}
 }
 
@@ -164,18 +170,43 @@ func NormalisePeriodType(periodType StreakPeriodType) (StreakPeriodType, error) 
 	}
 }
 
-// BuildPeriodKey converts a timestamp and period type into a stable key.
+// NormalisePeriodTimezone returns the package default timezone when none is provided.
+func NormalisePeriodTimezone(value string) (string, *time.Location, error) {
+	timezone := strings.TrimSpace(value)
+	if timezone == "" {
+		timezone = defaultPeriodTimezone
+	}
+
+	location, err := time.LoadLocation(timezone)
+	if err != nil {
+		return "", nil, ErrInvalidPeriodTimezone
+	}
+
+	return timezone, location, nil
+}
+
+// BuildPeriodKey converts a timestamp and period type into a stable UTC key.
 func BuildPeriodKey(value time.Time, periodType StreakPeriodType, providedPeriodKey string) (string, error) {
-	value = value.UTC()
+	return BuildPeriodKeyForTimezone(value, periodType, providedPeriodKey, defaultPeriodTimezone)
+}
+
+// BuildPeriodKeyForTimezone converts a timestamp and period type into a stable
+// key after first resolving the timestamp in the provided IANA timezone.
+func BuildPeriodKeyForTimezone(value time.Time, periodType StreakPeriodType, providedPeriodKey string, periodTimezone string) (string, error) {
+	_, location, err := NormalisePeriodTimezone(periodTimezone)
+	if err != nil {
+		return "", err
+	}
+	localValue := value.In(location)
 	providedPeriodKey = strings.TrimSpace(providedPeriodKey)
 
 	switch periodType {
 	case StreakPeriodTypeDaily:
-		return value.Format("2006-01-02"), nil
+		return localValue.Format("2006-01-02"), nil
 	case StreakPeriodTypeWeekly:
-		return buildWeekPeriodKey(value), nil
+		return buildWeekPeriodKeyForLocation(value, location), nil
 	case StreakPeriodTypeMonthly:
-		return value.Format("2006-01"), nil
+		return localValue.Format("2006-01"), nil
 	case StreakPeriodTypeCustom:
 		if providedPeriodKey == "" {
 			return "", ErrPeriodKeyIsRequired
@@ -241,6 +272,14 @@ func parsePeriodKey(periodKey string, periodType StreakPeriodType) (time.Time, b
 
 func buildWeekPeriodKey(value time.Time) string {
 	year, week := value.UTC().ISOWeek()
+	return strconv.Itoa(year) + "-w" + leftPadInt(week, 2)
+}
+
+func buildWeekPeriodKeyForLocation(value time.Time, location *time.Location) string {
+	if location == nil {
+		location = time.UTC
+	}
+	year, week := value.In(location).ISOWeek()
 	return strconv.Itoa(year) + "-w" + leftPadInt(week, 2)
 }
 

--- a/external/streaker/model_test.go
+++ b/external/streaker/model_test.go
@@ -1,0 +1,43 @@
+package streaker_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ooaklee/ghatd/external/streaker"
+)
+
+func TestBuildPeriodKeyForTimezoneDailyUsesLocalDate(t *testing.T) {
+	t.Parallel()
+
+	occurredAt := time.Date(2026, 5, 22, 23, 31, 0, 0, time.UTC)
+
+	londonKey, err := streaker.BuildPeriodKeyForTimezone(occurredAt, streaker.StreakPeriodTypeDaily, "", "Europe/London")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-05-23", londonKey)
+
+	newYorkKey, err := streaker.BuildPeriodKeyForTimezone(occurredAt, streaker.StreakPeriodTypeDaily, "", "America/New_York")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-05-22", newYorkKey)
+}
+
+func TestBuildPeriodKeyForTimezoneValidatesTimezone(t *testing.T) {
+	t.Parallel()
+
+	_, err := streaker.BuildPeriodKeyForTimezone(time.Now(), streaker.StreakPeriodTypeDaily, "", "not-a-zone")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, streaker.ErrInvalidPeriodTimezone)
+}
+
+func TestBuildPeriodKeyKeepsUTCSemantics(t *testing.T) {
+	t.Parallel()
+
+	occurredAt := time.Date(2026, 5, 22, 23, 31, 0, 0, time.UTC)
+
+	key, err := streaker.BuildPeriodKey(occurredAt, streaker.StreakPeriodTypeDaily, "")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-05-22", key)
+}

--- a/external/streaker/repository.go
+++ b/external/streaker/repository.go
@@ -215,6 +215,58 @@ func (r *Repository) GetTotalStreaks(ctx context.Context, req *GetNumberOfStreak
 	return r.Store.ExecuteCountDocuments(ctx, collection, queryFilter)
 }
 
+// ListStreaks retrieves streak entries matching the provided filters.
+func (r *Repository) ListStreaks(ctx context.Context, req *ListStreaksRequest) ([]*Streak, error) {
+	collection, err := r.GetStreakCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	queryFilter := buildStreakQueryFilter(&req.StreakStatsRequest)
+	addStreakListFilter(queryFilter, req)
+
+	sortDirection := -1
+	if strings.EqualFold(req.Sort, "asc") || strings.EqualFold(req.Sort, "ascending") {
+		sortDirection = 1
+	}
+
+	page := req.Page
+	if page <= 0 {
+		page = 1
+	}
+	perPage := req.PerPage
+	if perPage <= 0 {
+		perPage = 100
+	}
+
+	findOptions := options.Find().
+		SetSort(bson.D{
+			{Key: "occurred_at", Value: sortDirection},
+			{Key: "created_at", Value: sortDirection},
+		}).
+		SetSkip(int64((page - 1) * perPage)).
+		SetLimit(int64(perPage))
+
+	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, queryFilter, findOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	var streaks []*Streak
+	if err = r.Store.MapAllInCursorToResult(ctx, cursor, &streaks, "streaks"); err != nil {
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "no-documents-found") {
+			return []*Streak{}, nil
+		}
+		return nil, err
+	}
+
+	if streaks == nil {
+		streaks = []*Streak{}
+	}
+
+	return streaks, nil
+}
+
 func buildStreakQueryFilter(req *StreakStatsRequest) bson.M {
 	queryFilter := bson.M{"_id": bson.M{"$exists": true}}
 
@@ -243,4 +295,37 @@ func buildStreakQueryFilter(req *StreakStatsRequest) bson.M {
 	}
 
 	return queryFilter
+}
+
+func addStreakListFilter(queryFilter bson.M, req *ListStreaksRequest) {
+	if req == nil {
+		return
+	}
+
+	if req.PeriodKey != "" {
+		queryFilter["period_key"] = req.PeriodKey
+		return
+	}
+
+	periodKeyRange := bson.M{}
+	if req.PeriodKeyFrom != "" {
+		periodKeyRange["$gte"] = req.PeriodKeyFrom
+	}
+	if req.PeriodKeyTo != "" {
+		periodKeyRange["$lte"] = req.PeriodKeyTo
+	}
+	if len(periodKeyRange) > 0 {
+		queryFilter["period_key"] = periodKeyRange
+	}
+
+	occurredAtRange := bson.M{}
+	if req.OccurredAtFrom != "" {
+		occurredAtRange["$gte"] = req.OccurredAtFrom
+	}
+	if req.OccurredAtTo != "" {
+		occurredAtRange["$lte"] = req.OccurredAtTo
+	}
+	if len(occurredAtRange) > 0 {
+		queryFilter["occurred_at"] = occurredAtRange
+	}
 }

--- a/external/streaker/repository_test.go
+++ b/external/streaker/repository_test.go
@@ -15,6 +15,8 @@ import (
 type mockMongoDbStore struct {
 	initialiseClientFunc func(ctx context.Context) (*mongo.Client, error)
 	getDatabaseFunc      func(ctx context.Context, dbName string) (*mongo.Database, error)
+	executeFindFunc      func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	mapAllFunc           func(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error
 }
 
 func (m *mockMongoDbStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
@@ -22,6 +24,9 @@ func (m *mockMongoDbStore) ExecuteCountDocuments(ctx context.Context, collection
 }
 
 func (m *mockMongoDbStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+	if m.executeFindFunc != nil {
+		return m.executeFindFunc(ctx, collection, filter, opts...)
+	}
 	return nil, errors.New("not implemented")
 }
 
@@ -52,6 +57,9 @@ func (m *mockMongoDbStore) InitialiseClient(ctx context.Context) (*mongo.Client,
 }
 
 func (m *mockMongoDbStore) MapAllInCursorToResult(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error {
+	if m.mapAllFunc != nil {
+		return m.mapAllFunc(ctx, cursor, result, resultObjectName)
+	}
 	return errors.New("not implemented")
 }
 
@@ -130,4 +138,56 @@ func TestRepository_WithCollectionInitMaxAttemptsLimitOverridesDefault(t *testin
 	assert.Nil(t, collection)
 	assert.Equal(t, 2, initialiseAttempts)
 	assert.Contains(t, err.Error(), "after 2 attempts")
+}
+
+func TestRepository_ListStreaksBuildsHistoryFilter(t *testing.T) {
+	t.Parallel()
+
+	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	require.NoError(t, err)
+
+	var capturedFilter bson.M
+	var capturedOptions *options.FindOptions
+	store := &mockMongoDbStore{
+		executeFindFunc: func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+			capturedFilter = filter.(bson.M)
+			require.Len(t, opts, 1)
+			capturedOptions = opts[0]
+			return nil, nil
+		},
+		mapAllFunc: func(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error {
+			streaks := result.(*[]*Streak)
+			*streaks = []*Streak{{Id: "streak-1", PeriodKey: "2026-05-21"}}
+			return nil
+		},
+	}
+	repo := NewRepository(store)
+	repo.collection = client.Database("streaker_test").Collection(StreakCollection)
+
+	res, err := repo.ListStreaks(context.Background(), &ListStreaksRequest{
+		StreakStatsRequest: StreakStatsRequest{
+			StreakType: "wms-saved-words",
+			OwnerId:    "user-1",
+			TargetType: "affirmation",
+			TargetId:   "saved-words",
+			PeriodType: StreakPeriodTypeDaily,
+		},
+		PeriodKeyFrom: "2026-05-20",
+		PeriodKeyTo:   "2026-05-22",
+		Page:          2,
+		PerPage:       25,
+		Sort:          "asc",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	assert.Equal(t, "wms-saved-words", capturedFilter["streak_type"])
+	assert.Equal(t, "user-1", capturedFilter["owner_id"])
+	assert.Equal(t, "affirmation", capturedFilter["target_type"])
+	assert.Equal(t, "saved-words", capturedFilter["target_id"])
+	assert.Equal(t, StreakPeriodTypeDaily, capturedFilter["period_type"])
+	assert.Equal(t, bson.M{"$gte": "2026-05-20", "$lte": "2026-05-22"}, capturedFilter["period_key"])
+	require.NotNil(t, capturedOptions)
+	assert.Equal(t, int64(25), *capturedOptions.Limit)
+	assert.Equal(t, int64(25), *capturedOptions.Skip)
 }

--- a/external/streaker/request.go
+++ b/external/streaker/request.go
@@ -10,7 +10,9 @@ type RecordStreakRequest struct {
 
 	PeriodType StreakPeriodType `json:"period_type,omitempty"`
 	PeriodKey  string           `json:"period_key,omitempty"`
-	OccurredAt string           `json:"occurred_at,omitempty"`
+	// PeriodTimezone is the IANA timezone used to derive daily, weekly, and monthly period keys.
+	PeriodTimezone string `json:"period_timezone,omitempty"`
+	OccurredAt     string `json:"occurred_at,omitempty"`
 
 	CreatedByUserId string                 `json:"created_by_user_id" validate:"required"`
 	Metadata        map[string]interface{} `json:"metadata,omitempty"`

--- a/external/streaker/request.go
+++ b/external/streaker/request.go
@@ -24,11 +24,11 @@ type CreateRawStreakRequest struct {
 
 // StreakStatsRequest holds shared filters used for streak stats.
 type StreakStatsRequest struct {
-	StreakType string
-	OwnerId    string
-	TargetType string
-	TargetId   string
-	PeriodType StreakPeriodType
+	StreakType string           `json:"streak_type,omitempty" query:"streak_type"`
+	OwnerId    string           `json:"owner_id,omitempty" query:"owner_id"`
+	TargetType string           `json:"target_type,omitempty" query:"target_type"`
+	TargetId   string           `json:"target_id,omitempty" query:"target_id"`
+	PeriodType StreakPeriodType `json:"period_type,omitempty" query:"period_type"`
 }
 
 // GetLatestStreakRequest holds filters used to retrieve the latest entry.
@@ -50,4 +50,21 @@ type GetCurrentCountRequest struct {
 // GetNumberOfStreaksRequest holds filters used to count streak entries.
 type GetNumberOfStreaksRequest struct {
 	StreakStatsRequest
+}
+
+// ListStreaksRequest holds filters used to list streak entries for history
+// and board views.
+type ListStreaksRequest struct {
+	StreakStatsRequest
+
+	PeriodKey     string `json:"period_key,omitempty" query:"period_key"`
+	PeriodKeyFrom string `json:"period_key_from,omitempty" query:"period_key_from"`
+	PeriodKeyTo   string `json:"period_key_to,omitempty" query:"period_key_to"`
+
+	OccurredAtFrom string `json:"occurred_at_from,omitempty" query:"occurred_at_from"`
+	OccurredAtTo   string `json:"occurred_at_to,omitempty" query:"occurred_at_to"`
+
+	Page    int    `json:"page,omitempty" query:"page"`
+	PerPage int    `json:"per_page,omitempty" query:"per_page"`
+	Sort    string `json:"sort,omitempty" query:"sort"`
 }

--- a/external/streaker/response.go
+++ b/external/streaker/response.go
@@ -21,3 +21,8 @@ type GetCurrentCountResponse struct {
 type GetNumberOfStreaksResponse struct {
 	Total int64 `json:"total"`
 }
+
+// ListStreaksResponse returns streak entries matching the requested filters.
+type ListStreaksResponse struct {
+	Streaks []*Streak `json:"streaks"`
+}

--- a/external/streaker/service.go
+++ b/external/streaker/service.go
@@ -26,6 +26,15 @@ type Service struct {
 	StreakRepository StreakRepository
 }
 
+type resolvedRecordStreakRequest struct {
+	scope           StreakScope
+	createdByUserId string
+	occurredAt      time.Time
+	periodType      StreakPeriodType
+	periodKey       string
+	statsReq        StreakStatsRequest
+}
+
 // NewService returns a new instance of the streaker service.
 func NewService(streakRepository StreakRepository) *Service {
 	return &Service{
@@ -33,13 +42,51 @@ func NewService(streakRepository StreakRepository) *Service {
 	}
 }
 
+// GetStreakByScopeAndPeriodOrCreate returns the streak entry for the resolved
+// scope and period, creating it when it does not already exist.
+func (s *Service) GetStreakByScopeAndPeriodOrCreate(ctx context.Context, req *RecordStreakRequest) (*RecordStreakResponse, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	log.Debug("initiating-get-streak-by-scope-and-period-or-create-request", zap.Any("request", req))
+
+	resolvedReq, existingRes, err := s.getStreakByScopeAndPeriodFromRecordRequest(ctx, req, log)
+	if err != nil || existingRes != nil {
+		return existingRes, err
+	}
+
+	createdRes, err := s.createResolvedStreak(ctx, req, resolvedReq, log)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug("get-streak-by-scope-and-period-or-create-request-successful", zap.Any("request", req), zap.Any("created-streak", createdRes.Streak))
+	return createdRes, nil
+}
+
 // RecordStreak records a completion and computes the streak count for its scope.
 func (s *Service) RecordStreak(ctx context.Context, req *RecordStreakRequest) (*RecordStreakResponse, error) {
 	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
 	log.Debug("initiating-record-streak-request", zap.Any("request", req))
 
+	resolvedReq, existingRes, err := s.getStreakByScopeAndPeriodFromRecordRequest(ctx, req, log)
+	if err != nil || existingRes != nil {
+		return existingRes, err
+	}
+
+	createdRes, err := s.createResolvedStreak(ctx, req, resolvedReq, log)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug("record-streak-request-successful", zap.Any("request", req), zap.Any("created-streak", createdRes.Streak))
+	return createdRes, nil
+}
+
+// getStreakByScopeAndPeriodFromRecordRequest validates and resolves a record
+// request, returning an existing streak response when the period was already
+// recorded.
+func (s *Service) getStreakByScopeAndPeriodFromRecordRequest(ctx context.Context, req *RecordStreakRequest, log *zap.Logger) (*resolvedRecordStreakRequest, *RecordStreakResponse, error) {
 	if req == nil {
-		return nil, ErrStreakTypeIsRequired
+		return nil, nil, ErrStreakTypeIsRequired
 	}
 
 	scope := NormaliseScope(StreakScope{
@@ -50,30 +97,30 @@ func (s *Service) RecordStreak(ctx context.Context, req *RecordStreakRequest) (*
 	})
 
 	if err := validateRequiredScope(scope); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	createdByUserId := strings.TrimSpace(req.CreatedByUserId)
 	if createdByUserId == "" {
-		return nil, ErrCreatedByUserIdIsRequired
+		return nil, nil, ErrCreatedByUserIdIsRequired
 	}
 
 	periodType, err := NormalisePeriodType(req.PeriodType)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	occurredAt := time.Now().UTC()
 	if strings.TrimSpace(req.OccurredAt) != "" {
 		occurredAt, err = ParseStreakTime(req.OccurredAt)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	periodKey, err := BuildPeriodKey(occurredAt, periodType, req.PeriodKey)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	statsReq := StreakStatsRequest{
@@ -84,43 +131,59 @@ func (s *Service) RecordStreak(ctx context.Context, req *RecordStreakRequest) (*
 		PeriodType: periodType,
 	}
 
+	resolvedReq := &resolvedRecordStreakRequest{
+		scope:           scope,
+		createdByUserId: createdByUserId,
+		occurredAt:      occurredAt,
+		periodType:      periodType,
+		periodKey:       periodKey,
+		statsReq:        statsReq,
+	}
+
 	existing, err := s.StreakRepository.GetStreakByScopeAndPeriod(ctx, &GetLatestStreakRequest{
 		StreakStatsRequest: statsReq,
 		PeriodKey:          periodKey,
 	})
 	if err == nil && existing != nil {
-		return &RecordStreakResponse{Streak: existing}, nil
+		return resolvedReq, &RecordStreakResponse{Streak: existing}, nil
 	}
 	if err != nil && !errors.Is(err, ErrResourceNotFound) {
-		log.Error("failed-to-record-streak-error-checking-period", zap.Any("request", req), zap.Error(err))
-		return nil, err
+		log.Error("failed-to-resolve-streak-error-checking-period", zap.Any("request", req), zap.Error(err))
+		return nil, nil, err
 	}
 
+	return resolvedReq, nil, nil
+}
+
+// createResolvedStreak creates a streak from a previously validated and
+// resolved record request, carrying forward consecutive count and previous
+// streak metadata when available.
+func (s *Service) createResolvedStreak(ctx context.Context, req *RecordStreakRequest, resolvedReq *resolvedRecordStreakRequest, log *zap.Logger) (*RecordStreakResponse, error) {
 	var previous *Streak
-	previous, err = s.StreakRepository.GetLatestStreak(ctx, &GetLatestStreakRequest{
-		StreakStatsRequest: statsReq,
+	previous, err := s.StreakRepository.GetLatestStreak(ctx, &GetLatestStreakRequest{
+		StreakStatsRequest: resolvedReq.statsReq,
 	})
 	if err != nil && !errors.Is(err, ErrResourceNotFound) {
-		log.Error("failed-to-record-streak-error-getting-latest-streak", zap.Any("request", req), zap.Error(err))
+		log.Error("failed-to-create-streak-error-getting-latest-streak", zap.Any("request", req), zap.Error(err))
 		return nil, err
 	}
 
 	currentCount := 1
-	if previous != nil && IsConsecutivePeriod(previous.PeriodKey, periodKey, periodType) {
+	if previous != nil && IsConsecutivePeriod(previous.PeriodKey, resolvedReq.periodKey, resolvedReq.periodType) {
 		currentCount = previous.CurrentCount + 1
 	}
 
 	newStreak := &Streak{
 		StreakName:      strings.TrimSpace(req.StreakName),
-		StreakType:      scope.StreakType,
-		OwnerId:         scope.OwnerId,
-		TargetType:      scope.TargetType,
-		TargetId:        scope.TargetId,
-		PeriodType:      periodType,
-		PeriodKey:       periodKey,
-		OccurredAt:      FormatStreakTime(occurredAt),
+		StreakType:      resolvedReq.scope.StreakType,
+		OwnerId:         resolvedReq.scope.OwnerId,
+		TargetType:      resolvedReq.scope.TargetType,
+		TargetId:        resolvedReq.scope.TargetId,
+		PeriodType:      resolvedReq.periodType,
+		PeriodKey:       resolvedReq.periodKey,
+		OccurredAt:      FormatStreakTime(resolvedReq.occurredAt),
 		CurrentCount:    currentCount,
-		CreatedByUserId: createdByUserId,
+		CreatedByUserId: resolvedReq.createdByUserId,
 		Metadata:        req.Metadata,
 	}
 
@@ -130,11 +193,10 @@ func (s *Service) RecordStreak(ctx context.Context, req *RecordStreakRequest) (*
 
 	createdStreak, err := s.StreakRepository.CreateStreak(ctx, newStreak)
 	if err != nil {
-		log.Error("failed-to-record-streak-error-creating-streak", zap.Any("request", req), zap.Any("new-streak", newStreak), zap.Error(err))
+		log.Error("failed-to-create-streak-error-creating-streak", zap.Any("request", req), zap.Any("new-streak", newStreak), zap.Error(err))
 		return nil, err
 	}
 
-	log.Debug("record-streak-request-successful", zap.Any("request", req), zap.Any("created-streak", createdStreak))
 	return &RecordStreakResponse{Streak: createdStreak}, nil
 }
 
@@ -253,6 +315,8 @@ func (s *Service) GetNumberOfStreaksByStreakTypeAndUserID(ctx context.Context, r
 	return s.GetNumberOfStreaks(ctx, req)
 }
 
+// normaliseStatsRequest validates and standardises a stats request before it is
+// passed to the repository layer.
 func normaliseStatsRequest(req *StreakStatsRequest) (*StreakStatsRequest, error) {
 	if req == nil {
 		return nil, ErrStreakTypeIsRequired
@@ -295,6 +359,8 @@ func normaliseStatsRequest(req *StreakStatsRequest) (*StreakStatsRequest, error)
 	}, nil
 }
 
+// validateRequiredScope returns the first missing required field for a fully
+// qualified streak scope.
 func validateRequiredScope(scope StreakScope) error {
 	if scope.StreakType == "" {
 		return ErrStreakTypeIsRequired
@@ -312,6 +378,8 @@ func validateRequiredScope(scope StreakScope) error {
 	return nil
 }
 
+// normaliseStreakType trims and converts a streak type value into the canonical
+// kebab-case representation.
 func normaliseStreakType(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {

--- a/external/streaker/service.go
+++ b/external/streaker/service.go
@@ -33,6 +33,7 @@ type resolvedRecordStreakRequest struct {
 	occurredAt      time.Time
 	periodType      StreakPeriodType
 	periodKey       string
+	periodTimezone  string
 	statsReq        StreakStatsRequest
 }
 
@@ -119,7 +120,12 @@ func (s *Service) getStreakByScopeAndPeriodFromRecordRequest(ctx context.Context
 		}
 	}
 
-	periodKey, err := BuildPeriodKey(occurredAt, periodType, req.PeriodKey)
+	periodTimezone, _, err := NormalisePeriodTimezone(req.PeriodTimezone)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	periodKey, err := BuildPeriodKeyForTimezone(occurredAt, periodType, req.PeriodKey, periodTimezone)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,6 +144,7 @@ func (s *Service) getStreakByScopeAndPeriodFromRecordRequest(ctx context.Context
 		occurredAt:      occurredAt,
 		periodType:      periodType,
 		periodKey:       periodKey,
+		periodTimezone:  periodTimezone,
 		statsReq:        statsReq,
 	}
 
@@ -182,6 +189,7 @@ func (s *Service) createResolvedStreak(ctx context.Context, req *RecordStreakReq
 		TargetId:        resolvedReq.scope.TargetId,
 		PeriodType:      resolvedReq.periodType,
 		PeriodKey:       resolvedReq.periodKey,
+		PeriodTimezone:  resolvedReq.periodTimezone,
 		OccurredAt:      FormatStreakTime(resolvedReq.occurredAt),
 		CurrentCount:    currentCount,
 		CreatedByUserId: resolvedReq.createdByUserId,

--- a/external/streaker/service.go
+++ b/external/streaker/service.go
@@ -19,6 +19,7 @@ type StreakRepository interface {
 	GetLatestStreak(ctx context.Context, req *GetLatestStreakRequest) (*Streak, error)
 	GetLongestStreak(ctx context.Context, req *GetLongestStreakRequest) (*Streak, error)
 	GetTotalStreaks(ctx context.Context, req *GetNumberOfStreaksRequest) (int64, error)
+	ListStreaks(ctx context.Context, req *ListStreaksRequest) ([]*Streak, error)
 }
 
 // Service represents the streaker service.
@@ -315,6 +316,27 @@ func (s *Service) GetNumberOfStreaksByStreakTypeAndUserID(ctx context.Context, r
 	return s.GetNumberOfStreaks(ctx, req)
 }
 
+// ListStreaks lists streak entries matching the provided filters.
+func (s *Service) ListStreaks(ctx context.Context, req *ListStreaksRequest) (*ListStreaksResponse, error) {
+	listReq, err := normaliseListStreaksRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	streaks, err := s.StreakRepository.ListStreaks(ctx, listReq)
+	if err != nil && errors.Is(err, ErrResourceNotFound) {
+		return &ListStreaksResponse{Streaks: []*Streak{}}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if streaks == nil {
+		streaks = []*Streak{}
+	}
+
+	return &ListStreaksResponse{Streaks: streaks}, nil
+}
+
 // normaliseStatsRequest validates and standardises a stats request before it is
 // passed to the repository layer.
 func normaliseStatsRequest(req *StreakStatsRequest) (*StreakStatsRequest, error) {
@@ -356,6 +378,60 @@ func normaliseStatsRequest(req *StreakStatsRequest) (*StreakStatsRequest, error)
 		TargetType: scope.TargetType,
 		TargetId:   scope.TargetId,
 		PeriodType: periodType,
+	}, nil
+}
+
+func normaliseListStreaksRequest(req *ListStreaksRequest) (*ListStreaksRequest, error) {
+	if req == nil {
+		return nil, ErrOwnerIdIsRequired
+	}
+
+	scope := NormaliseScope(StreakScope{
+		StreakType: normaliseStreakType(req.StreakType),
+		OwnerId:    req.OwnerId,
+		TargetType: normaliseStreakType(req.TargetType),
+		TargetId:   req.TargetId,
+	})
+	if scope.OwnerId == "" {
+		return nil, ErrOwnerIdIsRequired
+	}
+	if req.PeriodType == "" {
+		return nil, ErrPeriodTypeIsRequired
+	}
+
+	periodType, err := NormalisePeriodType(req.PeriodType)
+	if err != nil {
+		return nil, err
+	}
+
+	page := req.Page
+	if page <= 0 {
+		page = 1
+	}
+	perPage := req.PerPage
+	if perPage <= 0 {
+		perPage = 100
+	}
+	if perPage > 200 {
+		perPage = 200
+	}
+
+	return &ListStreaksRequest{
+		StreakStatsRequest: StreakStatsRequest{
+			StreakType: scope.StreakType,
+			OwnerId:    scope.OwnerId,
+			TargetType: scope.TargetType,
+			TargetId:   scope.TargetId,
+			PeriodType: periodType,
+		},
+		PeriodKey:      strings.TrimSpace(req.PeriodKey),
+		PeriodKeyFrom:  strings.TrimSpace(req.PeriodKeyFrom),
+		PeriodKeyTo:    strings.TrimSpace(req.PeriodKeyTo),
+		OccurredAtFrom: strings.TrimSpace(req.OccurredAtFrom),
+		OccurredAtTo:   strings.TrimSpace(req.OccurredAtTo),
+		Page:           page,
+		PerPage:        perPage,
+		Sort:           strings.TrimSpace(req.Sort),
 	}, nil
 }
 

--- a/external/streaker/service_test.go
+++ b/external/streaker/service_test.go
@@ -17,6 +17,7 @@ type mockStreakRepository struct {
 	getLatestStreakFunc           func(ctx context.Context, req *streaker.GetLatestStreakRequest) (*streaker.Streak, error)
 	getLongestStreakFunc          func(ctx context.Context, req *streaker.GetLongestStreakRequest) (*streaker.Streak, error)
 	getTotalStreaksFunc           func(ctx context.Context, req *streaker.GetNumberOfStreaksRequest) (int64, error)
+	listStreaksFunc               func(ctx context.Context, req *streaker.ListStreaksRequest) ([]*streaker.Streak, error)
 }
 
 func (m *mockStreakRepository) CreateStreak(ctx context.Context, st *streaker.Streak) (*streaker.Streak, error) {
@@ -59,6 +60,13 @@ func (m *mockStreakRepository) GetTotalStreaks(ctx context.Context, req *streake
 		return m.getTotalStreaksFunc(ctx, req)
 	}
 	return 0, nil
+}
+
+func (m *mockStreakRepository) ListStreaks(ctx context.Context, req *streaker.ListStreaksRequest) ([]*streaker.Streak, error) {
+	if m.listStreaksFunc != nil {
+		return m.listStreaksFunc(ctx, req)
+	}
+	return []*streaker.Streak{}, nil
 }
 
 func TestService_RecordStreakCreatesFirstEntry(t *testing.T) {
@@ -498,4 +506,43 @@ func TestService_GetStatsRequiresPeriodType(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, streaker.ErrPeriodTypeIsRequired)
+}
+
+func TestService_ListStreaksNormalisesFilters(t *testing.T) {
+	t.Parallel()
+
+	expected := []*streaker.Streak{
+		{Id: "streak-1", PeriodKey: "2026-05-20"},
+		{Id: "streak-2", PeriodKey: "2026-05-21"},
+	}
+	repo := &mockStreakRepository{
+		listStreaksFunc: func(ctx context.Context, req *streaker.ListStreaksRequest) ([]*streaker.Streak, error) {
+			assert.Equal(t, "saved-words", req.StreakType)
+			assert.Equal(t, "user-1", req.OwnerId)
+			assert.Equal(t, "affirmation", req.TargetType)
+			assert.Equal(t, "saved-words", req.TargetId)
+			assert.Equal(t, streaker.StreakPeriodTypeDaily, req.PeriodType)
+			assert.Equal(t, "2026-05-20", req.PeriodKeyFrom)
+			assert.Equal(t, "2026-05-22", req.PeriodKeyTo)
+			assert.Equal(t, 1, req.Page)
+			assert.Equal(t, 100, req.PerPage)
+			return expected, nil
+		},
+	}
+	svc := streaker.NewService(repo)
+
+	res, err := svc.ListStreaks(context.Background(), &streaker.ListStreaksRequest{
+		StreakStatsRequest: streaker.StreakStatsRequest{
+			StreakType: "Saved Words",
+			OwnerId:    "user-1",
+			TargetType: "Affirmation",
+			TargetId:   "saved-words",
+			PeriodType: streaker.StreakPeriodTypeDaily,
+		},
+		PeriodKeyFrom: "2026-05-20",
+		PeriodKeyTo:   "2026-05-22",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, res.Streaks)
 }

--- a/external/streaker/service_test.go
+++ b/external/streaker/service_test.go
@@ -100,8 +100,42 @@ func TestService_RecordStreakCreatesFirstEntry(t *testing.T) {
 	assert.Equal(t, "app", created.TargetType)
 	assert.Equal(t, streaker.StreakPeriodTypeDaily, created.PeriodType)
 	assert.Equal(t, "2026-05-08", created.PeriodKey)
+	assert.Equal(t, "UTC", created.PeriodTimezone)
 	assert.Equal(t, 1, created.CurrentCount)
 	assert.Nil(t, created.Previous)
+}
+
+func TestService_RecordStreakUsesPeriodTimezone(t *testing.T) {
+	t.Parallel()
+
+	var created *streaker.Streak
+	repo := &mockStreakRepository{
+		getStreakByScopeAndPeriodFunc: func(ctx context.Context, req *streaker.GetLatestStreakRequest) (*streaker.Streak, error) {
+			assert.Equal(t, "2026-05-23", req.PeriodKey)
+			return nil, streaker.ErrResourceNotFound
+		},
+		createStreakFunc: func(ctx context.Context, st *streaker.Streak) (*streaker.Streak, error) {
+			created = st
+			return st, nil
+		},
+	}
+	svc := streaker.NewService(repo)
+
+	res, err := svc.RecordStreak(context.Background(), &streaker.RecordStreakRequest{
+		StreakType:      "app streak",
+		OwnerId:         "user-1",
+		TargetType:      "app",
+		TargetId:        "platform",
+		OccurredAt:      "2026-05-22T23:31:00",
+		PeriodTimezone:  "Europe/London",
+		CreatedByUserId: "user-1",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res.Streak)
+	require.NotNil(t, created)
+	assert.Equal(t, "2026-05-23", created.PeriodKey)
+	assert.Equal(t, "Europe/London", created.PeriodTimezone)
 }
 
 func TestService_RecordStreakIncrementsConsecutiveEntry(t *testing.T) {

--- a/external/streaker/service_test.go
+++ b/external/streaker/service_test.go
@@ -222,6 +222,90 @@ func TestService_RecordStreakReturnsExistingPeriodEntry(t *testing.T) {
 	assert.Equal(t, existing, res.Streak)
 }
 
+func TestService_GetStreakByScopeAndPeriodOrCreateReturnsExistingEntry(t *testing.T) {
+	t.Parallel()
+
+	existing := &streaker.Streak{
+		Id:           "existing-id",
+		StreakName:   "App Streak",
+		StreakType:   "app-streak",
+		OwnerId:      "user-1",
+		TargetType:   "app",
+		TargetId:     "platform",
+		PeriodType:   streaker.StreakPeriodTypeDaily,
+		PeriodKey:    "2026-05-08",
+		CurrentCount: 4,
+	}
+	createCalled := false
+
+	repo := &mockStreakRepository{
+		getStreakByScopeAndPeriodFunc: func(ctx context.Context, req *streaker.GetLatestStreakRequest) (*streaker.Streak, error) {
+			assert.Equal(t, "app-streak", req.StreakType)
+			assert.Equal(t, "user-1", req.OwnerId)
+			assert.Equal(t, "app", req.TargetType)
+			assert.Equal(t, "platform", req.TargetId)
+			assert.Equal(t, streaker.StreakPeriodTypeDaily, req.PeriodType)
+			assert.Equal(t, "2026-05-08", req.PeriodKey)
+			return existing, nil
+		},
+		createStreakFunc: func(ctx context.Context, st *streaker.Streak) (*streaker.Streak, error) {
+			createCalled = true
+			return st, nil
+		},
+	}
+	svc := streaker.NewService(repo)
+
+	res, err := svc.GetStreakByScopeAndPeriodOrCreate(context.Background(), &streaker.RecordStreakRequest{
+		StreakName:      "App Streak",
+		StreakType:      "App Streak",
+		OwnerId:         "user-1",
+		TargetType:      "App",
+		TargetId:        "platform",
+		OccurredAt:      "2026-05-08T09:00:00",
+		CreatedByUserId: "user-1",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, createCalled)
+	assert.Equal(t, existing, res.Streak)
+}
+
+func TestService_GetStreakByScopeAndPeriodOrCreateCreatesMissingEntry(t *testing.T) {
+	t.Parallel()
+
+	var created *streaker.Streak
+	repo := &mockStreakRepository{
+		createStreakFunc: func(ctx context.Context, st *streaker.Streak) (*streaker.Streak, error) {
+			created = st
+			st.Id = "created-id"
+			st.NanoId = "created-nano"
+			return st, nil
+		},
+	}
+	svc := streaker.NewService(repo)
+
+	res, err := svc.GetStreakByScopeAndPeriodOrCreate(context.Background(), &streaker.RecordStreakRequest{
+		StreakName:      "App Streak",
+		StreakType:      "App Streak",
+		OwnerId:         "user-1",
+		TargetType:      "App",
+		TargetId:        "platform",
+		OccurredAt:      "2026-05-08T09:00:00",
+		CreatedByUserId: "user-1",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, created)
+	assert.Equal(t, "created-id", res.Streak.Id)
+	assert.Equal(t, "App Streak", created.StreakName)
+	assert.Equal(t, "app-streak", created.StreakType)
+	assert.Equal(t, "app", created.TargetType)
+	assert.Equal(t, streaker.StreakPeriodTypeDaily, created.PeriodType)
+	assert.Equal(t, "2026-05-08", created.PeriodKey)
+	assert.Equal(t, 1, created.CurrentCount)
+}
+
 func TestService_RecordStreakPeriodExamples(t *testing.T) {
 	t.Parallel()
 

--- a/external/usermanager/const.go
+++ b/external/usermanager/const.go
@@ -83,4 +83,7 @@ const (
 const (
 	// ErrKeyReminderServiceNotEnabled is returned when reminder features are requested but ReminderService is not configured
 	ErrKeyReminderServiceNotEnabled = "ReminderServiceNotEnabled"
+
+	// ErrKeyStreakServiceNotEnabled is returned when streak features are requested but StreakService is not configured
+	ErrKeyStreakServiceNotEnabled = "StreakServiceNotEnabled"
 )

--- a/external/usermanager/errormap.go
+++ b/external/usermanager/errormap.go
@@ -27,6 +27,7 @@ var UsermanagerErrorMap reply.ErrorManifest = reply.ErrorManifest{
 	ErrInvalidMemberID:             {Title: "Bad Request", Detail: "A valid member ID must be provided.", StatusCode: 400, Code: "USM00-015"},
 	ErrNotifierServiceNotEnabled:   {Title: "Service Unavailable", Detail: "Notification features have not been enabled for this service.", StatusCode: 503, Code: "USM00-018"},
 	ErrReminderServiceNotEnabled:   {Title: "Service Unavailable", Detail: "Reminder features have not been enabled for this service.", StatusCode: 503, Code: "USM00-019"},
+	ErrStreakServiceNotEnabled:     {Title: "Service Unavailable", Detail: "Streak features have not been enabled for this service.", StatusCode: 503, Code: "USM00-020"},
 	ErrFailedToResolveGroupAccessMap: {
 		Title:      "Internal Error",
 		Detail:     "Failed to resolve user access for the requested group. Please try again.",

--- a/external/usermanager/errors.go
+++ b/external/usermanager/errors.go
@@ -23,4 +23,6 @@ var (
 	ErrUserNotFound                  = errors.New(ErrKeyUserNotFound)
 	// ErrReminderServiceNotEnabled means reminder features were requested but no reminder service is configured.
 	ErrReminderServiceNotEnabled = errors.New(ErrKeyReminderServiceNotEnabled)
+	// ErrStreakServiceNotEnabled means streak features were requested but no streak service is configured.
+	ErrStreakServiceNotEnabled = errors.New(ErrKeyStreakServiceNotEnabled)
 )

--- a/external/usermanager/fender.go
+++ b/external/usermanager/fender.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/ghatd/external/notifier"
 	"github.com/ooaklee/ghatd/external/reminder"
+	"github.com/ooaklee/ghatd/external/streaker"
 	"github.com/ooaklee/ghatd/external/toolbox"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 	"github.com/ritwickdey/querydecoder"
@@ -1315,6 +1316,126 @@ func MapRequestToGetDueRemindersRequest(r *http.Request, validator UsermanagerVa
 
 	if parsedRequest.Limit <= 0 {
 		parsedRequest.Limit = 100
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToRecordStreakRequest maps incoming record-streak request to the correct struct.
+func MapRequestToRecordStreakRequest(r *http.Request, validator UsermanagerValidator) (*RecordStreakRequest, error) {
+	var parsedRequest RecordStreakRequest
+	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	userID := accessmanagerhelpers.AcquireFrom(r.Context())
+	if userID == "" {
+		log.Error("unable-get-user-id")
+		return nil, ErrUnableToIdentifyUser
+	}
+
+	baseRequest := streaker.RecordStreakRequest{}
+	if err := toolbox.DecodeRequestBody(r, &baseRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	baseRequest.OwnerId = userID
+	baseRequest.CreatedByUserId = userID
+
+	parsedRequest.UserID = userID
+	parsedRequest.RecordStreakRequest = &baseRequest
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToListStreaksRequest maps incoming list-streaks request to the correct struct.
+func MapRequestToListStreaksRequest(r *http.Request, validator UsermanagerValidator) (*ListStreaksRequest, error) {
+	parsedRequest := ListStreaksRequest{ListStreaksRequest: &streaker.ListStreaksRequest{}}
+	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
+	if parsedRequest.UserID == "" {
+		log.Error("unable-get-user-id")
+		return nil, ErrUnableToIdentifyUser
+	}
+
+	if err := querydecoder.New(r.URL.Query()).Decode(&parsedRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if err := querydecoder.New(r.URL.Query()).Decode(parsedRequest.ListStreaksRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if parsedRequest.PeriodType == "" {
+		parsedRequest.PeriodType = streaker.StreakPeriodTypeDaily
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToGetCurrentStreakRequest maps incoming current-streak request to the correct struct.
+func MapRequestToGetCurrentStreakRequest(r *http.Request, validator UsermanagerValidator) (*GetCurrentStreakRequest, error) {
+	parsedRequest := GetCurrentStreakRequest{GetCurrentCountRequest: &streaker.GetCurrentCountRequest{}}
+	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
+	if parsedRequest.UserID == "" {
+		log.Error("unable-get-user-id")
+		return nil, ErrUnableToIdentifyUser
+	}
+
+	if err := querydecoder.New(r.URL.Query()).Decode(&parsedRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if err := querydecoder.New(r.URL.Query()).Decode(parsedRequest.GetCurrentCountRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if parsedRequest.PeriodType == "" {
+		parsedRequest.PeriodType = streaker.StreakPeriodTypeDaily
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToGetLongestStreakRequest maps incoming longest-streak request to the correct struct.
+func MapRequestToGetLongestStreakRequest(r *http.Request, validator UsermanagerValidator) (*GetLongestStreakRequest, error) {
+	parsedRequest := GetLongestStreakRequest{GetLongestStreakRequest: &streaker.GetLongestStreakRequest{}}
+	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
+	if parsedRequest.UserID == "" {
+		log.Error("unable-get-user-id")
+		return nil, ErrUnableToIdentifyUser
+	}
+
+	if err := querydecoder.New(r.URL.Query()).Decode(&parsedRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if err := querydecoder.New(r.URL.Query()).Decode(parsedRequest.GetLongestStreakRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if parsedRequest.PeriodType == "" {
+		parsedRequest.PeriodType = streaker.StreakPeriodTypeDaily
+	}
+
+	return &parsedRequest, nil
+}
+
+// MapRequestToGetNumberOfStreaksRequest maps incoming streak-count request to the correct struct.
+func MapRequestToGetNumberOfStreaksRequest(r *http.Request, validator UsermanagerValidator) (*GetNumberOfStreaksRequest, error) {
+	parsedRequest := GetNumberOfStreaksRequest{GetNumberOfStreaksRequest: &streaker.GetNumberOfStreaksRequest{}}
+	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+
+	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
+	if parsedRequest.UserID == "" {
+		log.Error("unable-get-user-id")
+		return nil, ErrUnableToIdentifyUser
+	}
+
+	if err := querydecoder.New(r.URL.Query()).Decode(&parsedRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if err := querydecoder.New(r.URL.Query()).Decode(parsedRequest.GetNumberOfStreaksRequest); err != nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if parsedRequest.PeriodType == "" {
+		parsedRequest.PeriodType = streaker.StreakPeriodTypeDaily
 	}
 
 	return &parsedRequest, nil

--- a/external/usermanager/handler.go
+++ b/external/usermanager/handler.go
@@ -62,6 +62,12 @@ type UsermanagerService interface {
 	DisableReminderByID(ctx context.Context, r *DisableReminderByIDRequest) (*UpdateReminderByIDResponse, error)
 	GetReminderStats(ctx context.Context, r *GetReminderStatsRequest) (*GetReminderStatsResponse, error)
 	GetDueReminders(ctx context.Context, r *GetDueRemindersRequest) (*GetDueRemindersResponse, error)
+	// Streak methods
+	RecordStreak(ctx context.Context, r *RecordStreakRequest) (*RecordStreakResponse, error)
+	ListStreaks(ctx context.Context, r *ListStreaksRequest) (*ListStreaksResponse, error)
+	GetCurrentStreak(ctx context.Context, r *GetCurrentStreakRequest) (*GetCurrentStreakResponse, error)
+	GetLongestStreak(ctx context.Context, r *GetLongestStreakRequest) (*GetLongestStreakResponse, error)
+	GetNumberOfStreaks(ctx context.Context, r *GetNumberOfStreaksRequest) (*GetNumberOfStreaksResponse, error)
 }
 
 // UsermanagerValidator expected methods of a valid
@@ -1018,6 +1024,91 @@ func (h *Handler) GetDueReminders(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Reminders)
+}
+
+// RecordStreak handles the request to record a streak.
+func (h *Handler) RecordStreak(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToRecordStreakRequest(r, h.Validator)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.RecordStreak(r.Context(), request)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusCreated, response.Streak)
+}
+
+// ListStreaks handles the request to list streaks.
+func (h *Handler) ListStreaks(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToListStreaksRequest(r, h.Validator)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.ListStreaks(r.Context(), request)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Streaks)
+}
+
+// GetCurrentStreak handles the request to get the current streak count.
+func (h *Handler) GetCurrentStreak(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetCurrentStreakRequest(r, h.Validator)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetCurrentStreak(r.Context(), request)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.GetCurrentCountResponse)
+}
+
+// GetLongestStreak handles the request to get the longest streak count.
+func (h *Handler) GetLongestStreak(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetLongestStreakRequest(r, h.Validator)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetLongestStreak(r.Context(), request)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.GetLongestStreakResponse)
+}
+
+// GetNumberOfStreaks handles the request to count streak entries.
+func (h *Handler) GetNumberOfStreaks(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetNumberOfStreaksRequest(r, h.Validator)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.Service.GetNumberOfStreaks(r.Context(), request)
+	if err != nil {
+		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	h.GetBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.GetNumberOfStreaksResponse)
 }
 
 // GetBaseResponseHandler returns response handler configured with auth error map

--- a/external/usermanager/handler_notifier_test.go
+++ b/external/usermanager/handler_notifier_test.go
@@ -218,6 +218,21 @@ func (m *mockUmsService) GetReminderStats(ctx context.Context, r *usermanager.Ge
 func (m *mockUmsService) GetDueReminders(ctx context.Context, r *usermanager.GetDueRemindersRequest) (*usermanager.GetDueRemindersResponse, error) {
 	return nil, stubErr
 }
+func (m *mockUmsService) RecordStreak(ctx context.Context, r *usermanager.RecordStreakRequest) (*usermanager.RecordStreakResponse, error) {
+	return nil, stubErr
+}
+func (m *mockUmsService) ListStreaks(ctx context.Context, r *usermanager.ListStreaksRequest) (*usermanager.ListStreaksResponse, error) {
+	return nil, stubErr
+}
+func (m *mockUmsService) GetCurrentStreak(ctx context.Context, r *usermanager.GetCurrentStreakRequest) (*usermanager.GetCurrentStreakResponse, error) {
+	return nil, stubErr
+}
+func (m *mockUmsService) GetLongestStreak(ctx context.Context, r *usermanager.GetLongestStreakRequest) (*usermanager.GetLongestStreakResponse, error) {
+	return nil, stubErr
+}
+func (m *mockUmsService) GetNumberOfStreaks(ctx context.Context, r *usermanager.GetNumberOfStreaksRequest) (*usermanager.GetNumberOfStreaksResponse, error) {
+	return nil, stubErr
+}
 
 // mockValidator wraps [validator.Validate] so tests can force validation failures.
 type mockValidator struct {

--- a/external/usermanager/request.go
+++ b/external/usermanager/request.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ooaklee/ghatd/external/group"
 	"github.com/ooaklee/ghatd/external/notifier"
 	"github.com/ooaklee/ghatd/external/reminder"
+	"github.com/ooaklee/ghatd/external/streaker"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 )
 
@@ -556,6 +557,63 @@ type GetReminderStatsRequest struct {
 
 	// FilterUserIDs optionally filters reminder stats by multiple target users.
 	FilterUserIDs []string `query:"user_ids"`
+}
+
+// RecordStreakRequest holds the data needed to record a streak for the current user.
+type RecordStreakRequest struct {
+	// UserID is the authenticated requester recording the streak.
+	UserID string
+
+	// RecordStreakRequest carries the underlying streak creation payload.
+	*streaker.RecordStreakRequest
+}
+
+// ListStreaksRequest holds the data needed to list streak history.
+type ListStreaksRequest struct {
+	// UserID is the authenticated requester listing streaks.
+	UserID string
+
+	// FilterUserID optionally filters streaks by a target user on admin/service routes.
+	FilterUserID string `query:"user_id"`
+
+	// ListStreaksRequest carries the underlying streak history filters.
+	*streaker.ListStreaksRequest
+}
+
+// GetCurrentStreakRequest holds filters used to get the current streak count.
+type GetCurrentStreakRequest struct {
+	// UserID is the authenticated requester getting streak stats.
+	UserID string
+
+	// FilterUserID optionally filters streaks by a target user on admin/service routes.
+	FilterUserID string `query:"user_id"`
+
+	// GetCurrentCountRequest carries the underlying streak stats filters.
+	*streaker.GetCurrentCountRequest
+}
+
+// GetLongestStreakRequest holds filters used to get the personal best streak.
+type GetLongestStreakRequest struct {
+	// UserID is the authenticated requester getting streak stats.
+	UserID string
+
+	// FilterUserID optionally filters streaks by a target user on admin/service routes.
+	FilterUserID string `query:"user_id"`
+
+	// GetLongestStreakRequest carries the underlying streak stats filters.
+	*streaker.GetLongestStreakRequest
+}
+
+// GetNumberOfStreaksRequest holds filters used to count streak entries.
+type GetNumberOfStreaksRequest struct {
+	// UserID is the authenticated requester getting streak stats.
+	UserID string
+
+	// FilterUserID optionally filters streaks by a target user on admin/service routes.
+	FilterUserID string `query:"user_id"`
+
+	// GetNumberOfStreaksRequest carries the underlying streak stats filters.
+	*streaker.GetNumberOfStreaksRequest
 }
 
 // UpdateGroupOwnerRequest holds the data needed to update group ownership

--- a/external/usermanager/response.go
+++ b/external/usermanager/response.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ooaklee/ghatd/external/group"
 	"github.com/ooaklee/ghatd/external/notifier"
 	"github.com/ooaklee/ghatd/external/reminder"
+	"github.com/ooaklee/ghatd/external/streaker"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 )
 
@@ -337,6 +338,31 @@ type GetReminderStatsResponse struct {
 // GetDueRemindersResponse holds the response for getting due reminders.
 type GetDueRemindersResponse struct {
 	*reminder.GetDueRemindersResponse
+}
+
+// RecordStreakResponse holds the response for recording a streak.
+type RecordStreakResponse struct {
+	*streaker.RecordStreakResponse
+}
+
+// ListStreaksResponse holds the response for listing streaks.
+type ListStreaksResponse struct {
+	*streaker.ListStreaksResponse
+}
+
+// GetCurrentStreakResponse holds the current streak count response.
+type GetCurrentStreakResponse struct {
+	*streaker.GetCurrentCountResponse
+}
+
+// GetLongestStreakResponse holds the longest streak response.
+type GetLongestStreakResponse struct {
+	*streaker.GetLongestStreakResponse
+}
+
+// GetNumberOfStreaksResponse holds the streak count response.
+type GetNumberOfStreaksResponse struct {
+	*streaker.GetNumberOfStreaksResponse
 }
 
 // UpdateGroupOwnerResponse holds the response for updating group ownership

--- a/external/usermanager/routes.go
+++ b/external/usermanager/routes.go
@@ -59,6 +59,12 @@ type UsermanagerHandler interface {
 	DisableReminderByID(w http.ResponseWriter, r *http.Request)
 	GetReminderStats(w http.ResponseWriter, r *http.Request)
 	GetDueReminders(w http.ResponseWriter, r *http.Request)
+	// Streak methods
+	RecordStreak(w http.ResponseWriter, r *http.Request)
+	ListStreaks(w http.ResponseWriter, r *http.Request)
+	GetCurrentStreak(w http.ResponseWriter, r *http.Request)
+	GetLongestStreak(w http.ResponseWriter, r *http.Request)
+	GetNumberOfStreaks(w http.ResponseWriter, r *http.Request)
 }
 
 const (
@@ -148,6 +154,11 @@ func AttachRoutes(request *AttachRoutesRequest) {
 	usermanagerAuthenticatedRoutes.HandleFunc("/me/reminders/{reminderID}", request.Handler.UpdateReminderByID).Methods(http.MethodPatch, http.MethodOptions)
 	usermanagerAuthenticatedRoutes.HandleFunc("/me/reminders/{reminderID}", request.Handler.DeleteReminderByID).Methods(http.MethodDelete, http.MethodOptions)
 	usermanagerAuthenticatedRoutes.HandleFunc("/me/reminders/{reminderID}/disable", request.Handler.DisableReminderByID).Methods(http.MethodPost, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/me/streaks", request.Handler.ListStreaks).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/me/streaks/record", request.Handler.RecordStreak).Methods(http.MethodPost, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/me/streaks/current", request.Handler.GetCurrentStreak).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/me/streaks/longest", request.Handler.GetLongestStreak).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAuthenticatedRoutes.HandleFunc("/me/streaks/count", request.Handler.GetNumberOfStreaks).Methods(http.MethodGet, http.MethodOptions)
 	usermanagerAuthenticatedRoutes.HandleFunc("/me/notifications/latest", request.Handler.GetLatestNotificationOverviews).Methods(http.MethodGet, http.MethodOptions)
 	usermanagerAuthenticatedRoutes.HandleFunc("/me/notifications/config", request.Handler.GetNotifierConfig).Methods(http.MethodGet, http.MethodOptions)
 	usermanagerAuthenticatedRoutes.HandleFunc("/me/notifications/addresses", request.Handler.ListNotificationAddresses).Methods(http.MethodGet, http.MethodOptions)
@@ -190,6 +201,10 @@ func AttachRoutes(request *AttachRoutesRequest) {
 	usermanagerAdminServiceRoutes.HandleFunc("/reminders", request.Handler.ListReminders).Methods(http.MethodGet, http.MethodOptions)
 	usermanagerAdminServiceRoutes.HandleFunc("/reminders/stats", request.Handler.GetReminderStats).Methods(http.MethodGet, http.MethodOptions)
 	usermanagerAdminServiceRoutes.HandleFunc("/reminders/due", request.Handler.GetDueReminders).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAdminServiceRoutes.HandleFunc("/streaks", request.Handler.ListStreaks).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAdminServiceRoutes.HandleFunc("/streaks/current", request.Handler.GetCurrentStreak).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAdminServiceRoutes.HandleFunc("/streaks/longest", request.Handler.GetLongestStreak).Methods(http.MethodGet, http.MethodOptions)
+	usermanagerAdminServiceRoutes.HandleFunc("/streaks/count", request.Handler.GetNumberOfStreaks).Methods(http.MethodGet, http.MethodOptions)
 	if request.AdminApiTokenOrJWTMiddleware != nil {
 		usermanagerAdminServiceRoutes.Use(request.AdminApiTokenOrJWTMiddleware)
 	} else if request.AdminOnlyMiddleware != nil {

--- a/external/usermanager/service.go
+++ b/external/usermanager/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/ghatd/external/notifier"
 	"github.com/ooaklee/ghatd/external/reminder"
+	"github.com/ooaklee/ghatd/external/streaker"
 	userv2 "github.com/ooaklee/ghatd/external/user/v2"
 	"go.uber.org/zap"
 )
@@ -88,6 +89,15 @@ type ReminderService interface {
 	GetDueReminders(ctx context.Context, r *reminder.GetDueRemindersRequest) (*reminder.GetDueRemindersResponse, error)
 }
 
+// StreakService expected methods of a valid streaker service.
+type StreakService interface {
+	RecordStreak(ctx context.Context, r *streaker.RecordStreakRequest) (*streaker.RecordStreakResponse, error)
+	GetCurrentCount(ctx context.Context, r *streaker.GetCurrentCountRequest) (*streaker.GetCurrentCountResponse, error)
+	GetLongestStreak(ctx context.Context, r *streaker.GetLongestStreakRequest) (*streaker.GetLongestStreakResponse, error)
+	GetNumberOfStreaks(ctx context.Context, r *streaker.GetNumberOfStreaksRequest) (*streaker.GetNumberOfStreaksResponse, error)
+	ListStreaks(ctx context.Context, r *streaker.ListStreaksRequest) (*streaker.ListStreaksResponse, error)
+}
+
 // NotifierService expected methods of a valid notifier service.
 type NotifierService interface {
 	RegisterAddress(ctx context.Context, r *notifier.RegisterAddressRequest) (*notifier.RegisterAddressResponse, error)
@@ -111,6 +121,7 @@ type Service struct {
 	GroupService     GroupService
 	NotifierService  NotifierService
 	ReminderService  ReminderService
+	StreakService    StreakService
 }
 
 // NewServiceRequest holds all expected dependencies for an usermanager service
@@ -148,6 +159,12 @@ func (s *Service) WithGroupService(groupSvc GroupService) *Service {
 // WithReminderService adds reminder service integration.
 func (s *Service) WithReminderService(reminderSvc ReminderService) *Service {
 	s.ReminderService = reminderSvc
+	return s
+}
+
+// WithStreakService adds streaker service integration.
+func (s *Service) WithStreakService(streakSvc StreakService) *Service {
+	s.StreakService = streakSvc
 	return s
 }
 

--- a/external/usermanager/service.streak.go
+++ b/external/usermanager/service.streak.go
@@ -1,0 +1,190 @@
+package usermanager
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"github.com/ooaklee/ghatd/external/streaker"
+	userv2 "github.com/ooaklee/ghatd/external/user/v2"
+	"go.uber.org/zap"
+)
+
+// RecordStreak records a streak for the currently authenticated user.
+func (s *Service) RecordStreak(ctx context.Context, r *RecordStreakRequest) (*RecordStreakResponse, error) {
+	if err := s.ensureStreakService(); err != nil {
+		return nil, err
+	}
+	if r == nil || r.RecordStreakRequest == nil {
+		return nil, ErrRequestFailedValidation
+	}
+	if _, _, err := s.validateStreakRequester(ctx, r.UserID); err != nil {
+		return nil, err
+	}
+
+	baseRequest := *r.RecordStreakRequest
+	baseRequest.OwnerId = strings.TrimSpace(r.UserID)
+	baseRequest.CreatedByUserId = strings.TrimSpace(r.UserID)
+
+	response, err := s.StreakService.RecordStreak(ctx, &baseRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RecordStreakResponse{RecordStreakResponse: response}, nil
+}
+
+// ListStreaks returns streak entries for the authenticated user.
+func (s *Service) ListStreaks(ctx context.Context, r *ListStreaksRequest) (*ListStreaksResponse, error) {
+	if err := s.ensureStreakService(); err != nil {
+		return nil, err
+	}
+	if r == nil || r.ListStreaksRequest == nil {
+		return nil, ErrRequestFailedValidation
+	}
+
+	requestingUserID := strings.TrimSpace(r.UserID)
+	_, isAdmin, err := s.validateStreakRequester(ctx, requestingUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	baseRequest := *r.ListStreaksRequest
+	baseRequest.OwnerId = streakOwnerScopeForRequester(requestingUserID, isAdmin, r.FilterUserID)
+	if baseRequest.PeriodType == "" {
+		baseRequest.PeriodType = streaker.StreakPeriodTypeDaily
+	}
+
+	response, err := s.StreakService.ListStreaks(ctx, &baseRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListStreaksResponse{ListStreaksResponse: response}, nil
+}
+
+// GetCurrentStreak returns the current streak count for the authenticated user.
+func (s *Service) GetCurrentStreak(ctx context.Context, r *GetCurrentStreakRequest) (*GetCurrentStreakResponse, error) {
+	if err := s.ensureStreakService(); err != nil {
+		return nil, err
+	}
+	if r == nil || r.GetCurrentCountRequest == nil {
+		return nil, ErrRequestFailedValidation
+	}
+
+	requestingUserID := strings.TrimSpace(r.UserID)
+	_, isAdmin, err := s.validateStreakRequester(ctx, requestingUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	baseRequest := *r.GetCurrentCountRequest
+	baseRequest.OwnerId = streakOwnerScopeForRequester(requestingUserID, isAdmin, r.FilterUserID)
+	if baseRequest.PeriodType == "" {
+		baseRequest.PeriodType = streaker.StreakPeriodTypeDaily
+	}
+
+	response, err := s.StreakService.GetCurrentCount(ctx, &baseRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetCurrentStreakResponse{GetCurrentCountResponse: response}, nil
+}
+
+// GetLongestStreak returns the personal best streak for the authenticated user.
+func (s *Service) GetLongestStreak(ctx context.Context, r *GetLongestStreakRequest) (*GetLongestStreakResponse, error) {
+	if err := s.ensureStreakService(); err != nil {
+		return nil, err
+	}
+	if r == nil || r.GetLongestStreakRequest == nil {
+		return nil, ErrRequestFailedValidation
+	}
+
+	requestingUserID := strings.TrimSpace(r.UserID)
+	_, isAdmin, err := s.validateStreakRequester(ctx, requestingUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	baseRequest := *r.GetLongestStreakRequest
+	baseRequest.OwnerId = streakOwnerScopeForRequester(requestingUserID, isAdmin, r.FilterUserID)
+	if baseRequest.PeriodType == "" {
+		baseRequest.PeriodType = streaker.StreakPeriodTypeDaily
+	}
+
+	response, err := s.StreakService.GetLongestStreak(ctx, &baseRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetLongestStreakResponse{GetLongestStreakResponse: response}, nil
+}
+
+// GetNumberOfStreaks returns the number of streak entries matching the filters.
+func (s *Service) GetNumberOfStreaks(ctx context.Context, r *GetNumberOfStreaksRequest) (*GetNumberOfStreaksResponse, error) {
+	if err := s.ensureStreakService(); err != nil {
+		return nil, err
+	}
+	if r == nil || r.GetNumberOfStreaksRequest == nil {
+		return nil, ErrRequestFailedValidation
+	}
+
+	requestingUserID := strings.TrimSpace(r.UserID)
+	_, isAdmin, err := s.validateStreakRequester(ctx, requestingUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	baseRequest := *r.GetNumberOfStreaksRequest
+	baseRequest.OwnerId = streakOwnerScopeForRequester(requestingUserID, isAdmin, r.FilterUserID)
+	if baseRequest.PeriodType == "" {
+		baseRequest.PeriodType = streaker.StreakPeriodTypeDaily
+	}
+
+	response, err := s.StreakService.GetNumberOfStreaks(ctx, &baseRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetNumberOfStreaksResponse{GetNumberOfStreaksResponse: response}, nil
+}
+
+func (s *Service) ensureStreakService() error {
+	if s.StreakService == nil {
+		return ErrStreakServiceNotEnabled
+	}
+	return nil
+}
+
+func (s *Service) validateStreakRequester(ctx context.Context, userID string) (*userv2.UniversalUser, bool, error) {
+	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	requestingUserID := strings.TrimSpace(userID)
+	if requestingUserID == "" {
+		log.Warn("streak-request-with-empty-requesting-user-id")
+		return nil, false, ErrUnableToIdentifyUser
+	}
+	if s.UserService == nil {
+		log.Warn("streak-request-without-user-service", zap.String("user-id", requestingUserID))
+		return nil, false, ErrUserManagerError
+	}
+
+	requestingUser, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: requestingUserID})
+	if err != nil {
+		log.Warn("unable-to-resolve-streak-requester", zap.String("user-id", requestingUserID), zap.Error(err))
+		return nil, false, err
+	}
+	if requestingUser == nil || requestingUser.User == nil {
+		log.Warn("streak-requester-not-found", zap.String("user-id", requestingUserID))
+		return nil, false, ErrUserNotFound
+	}
+
+	return requestingUser.User, requestingUser.User.IsAdmin(), nil
+}
+
+func streakOwnerScopeForRequester(requestingUserID string, isAdmin bool, filterUserID string) string {
+	if isAdmin && strings.TrimSpace(filterUserID) != "" {
+		return strings.TrimSpace(filterUserID)
+	}
+	return strings.TrimSpace(requestingUserID)
+}

--- a/external/usermanager/service_streak_test.go
+++ b/external/usermanager/service_streak_test.go
@@ -1,0 +1,156 @@
+package usermanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ooaklee/ghatd/external/streaker"
+	userv2 "github.com/ooaklee/ghatd/external/user/v2"
+	"github.com/ooaklee/ghatd/external/usermanager"
+)
+
+type mockStreakService struct {
+	recordRequest  *streaker.RecordStreakRequest
+	listRequest    *streaker.ListStreaksRequest
+	currentRequest *streaker.GetCurrentCountRequest
+	longestRequest *streaker.GetLongestStreakRequest
+	countRequest   *streaker.GetNumberOfStreaksRequest
+}
+
+func (m *mockStreakService) RecordStreak(ctx context.Context, r *streaker.RecordStreakRequest) (*streaker.RecordStreakResponse, error) {
+	m.recordRequest = r
+	return &streaker.RecordStreakResponse{Streak: &streaker.Streak{Id: "streak-1", CurrentCount: 3}}, nil
+}
+
+func (m *mockStreakService) GetCurrentCount(ctx context.Context, r *streaker.GetCurrentCountRequest) (*streaker.GetCurrentCountResponse, error) {
+	m.currentRequest = r
+	return &streaker.GetCurrentCountResponse{CurrentCount: 3}, nil
+}
+
+func (m *mockStreakService) GetLongestStreak(ctx context.Context, r *streaker.GetLongestStreakRequest) (*streaker.GetLongestStreakResponse, error) {
+	m.longestRequest = r
+	return &streaker.GetLongestStreakResponse{LongestCount: 8}, nil
+}
+
+func (m *mockStreakService) GetNumberOfStreaks(ctx context.Context, r *streaker.GetNumberOfStreaksRequest) (*streaker.GetNumberOfStreaksResponse, error) {
+	m.countRequest = r
+	return &streaker.GetNumberOfStreaksResponse{Total: 12}, nil
+}
+
+func (m *mockStreakService) ListStreaks(ctx context.Context, r *streaker.ListStreaksRequest) (*streaker.ListStreaksResponse, error) {
+	m.listRequest = r
+	return &streaker.ListStreaksResponse{Streaks: []*streaker.Streak{{Id: "streak-1"}}}, nil
+}
+
+func TestServiceRecordStreakScopesToRequester(t *testing.T) {
+	t.Parallel()
+
+	streakSvc := &mockStreakService{}
+	svc := &usermanager.Service{
+		UserService: &mockReminderUserService{
+			users: map[string]*userv2.UniversalUser{
+				"user-1": {ID: "user-1"},
+			},
+		},
+		StreakService: streakSvc,
+	}
+
+	res, err := svc.RecordStreak(context.Background(), &usermanager.RecordStreakRequest{
+		UserID: "user-1",
+		RecordStreakRequest: &streaker.RecordStreakRequest{
+			StreakType:      "wms-app-check-in",
+			OwnerId:         "user-2",
+			TargetType:      "app",
+			TargetId:        "astr",
+			CreatedByUserId: "user-2",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, streakSvc.recordRequest)
+	assert.Equal(t, "user-1", streakSvc.recordRequest.OwnerId)
+	assert.Equal(t, "user-1", streakSvc.recordRequest.CreatedByUserId)
+}
+
+func TestServiceListStreaksLocksNonAdminToOwnUserID(t *testing.T) {
+	t.Parallel()
+
+	streakSvc := &mockStreakService{}
+	svc := &usermanager.Service{
+		UserService: &mockReminderUserService{
+			users: map[string]*userv2.UniversalUser{
+				"user-1": {ID: "user-1"},
+			},
+		},
+		StreakService: streakSvc,
+	}
+
+	res, err := svc.ListStreaks(context.Background(), &usermanager.ListStreaksRequest{
+		UserID:       "user-1",
+		FilterUserID: "user-2",
+		ListStreaksRequest: &streaker.ListStreaksRequest{
+			StreakStatsRequest: streaker.StreakStatsRequest{PeriodType: streaker.StreakPeriodTypeDaily},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, streakSvc.listRequest)
+	assert.Equal(t, "user-1", streakSvc.listRequest.OwnerId)
+}
+
+func TestServiceGetCurrentStreakAllowsAdminTargetUserScope(t *testing.T) {
+	t.Parallel()
+
+	streakSvc := &mockStreakService{}
+	svc := &usermanager.Service{
+		UserService: &mockReminderUserService{
+			users: map[string]*userv2.UniversalUser{
+				"admin-1": {ID: "admin-1", Roles: []string{"ADMIN"}},
+			},
+		},
+		StreakService: streakSvc,
+	}
+
+	res, err := svc.GetCurrentStreak(context.Background(), &usermanager.GetCurrentStreakRequest{
+		UserID:       "admin-1",
+		FilterUserID: "user-2",
+		GetCurrentCountRequest: &streaker.GetCurrentCountRequest{
+			StreakStatsRequest: streaker.StreakStatsRequest{
+				StreakType: "wms-app-check-in",
+				PeriodType: streaker.StreakPeriodTypeDaily,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, streakSvc.currentRequest)
+	assert.Equal(t, "user-2", streakSvc.currentRequest.OwnerId)
+	assert.Equal(t, 3, res.CurrentCount)
+}
+
+func TestServiceStreakReturnsServiceDisabledWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	svc := &usermanager.Service{
+		UserService: &mockReminderUserService{
+			users: map[string]*userv2.UniversalUser{
+				"user-1": {ID: "user-1"},
+			},
+		},
+	}
+
+	_, err := svc.GetNumberOfStreaks(context.Background(), &usermanager.GetNumberOfStreaksRequest{
+		UserID:                    "user-1",
+		GetNumberOfStreaksRequest: &streaker.GetNumberOfStreaksRequest{},
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, usermanager.ErrStreakServiceNotEnabled))
+}


### PR DESCRIPTION
## Summary

This PR makes streak tracking and reminder scheduling usable from the standard starter/user-manager stack while preserving host-application control over whether those integrations are enabled.

Streaks and reminders now support client-local time context:

- streak period keys can be resolved against an IANA timezone instead of only UTC, and
- reminders can store a computed `next_due_at` timestamp from either a wall-clock target time or an absolute timestamp.

Before this change, starter v0 did not construct the reminder/streaker repositories and services as first-class optional dependencies for UserManager, and UMS did not expose authenticated/admin streak endpoints.

## Changes

- Add optional Reminder and Streaker repositories/services to starter v0, with override hooks for host applications.
- Add UserManager streak methods and routes for recording, listing, current count, longest count, and total count.
- Scope user streak operations to the authenticated user, while allowing admin/service lookups to filter by target user.
- Add timezone-aware streak period key generation and persist `period_timezone` on streak entries and previous-entry metadata.
- Add streak listing support at repository/service level.
- Add reminder `next_due_at` computation from local wall-clock target times or absolute timestamps, with IANA timezone validation and UTC storage.
- Move due reminder lookup to `next_due_at` and add Mongo indexes for due/reminder queries.
- Add `X-Timezone` and supported platform constants, allow `X-Timezone` through CORS, and restrict logout redirect behaviour to browser-owned requests.
- Extend error maps, docs, ADRs, and getting-started guides for the new streak/reminder integration model.

## Why

Daily streaks and reminders are user-local concepts. A completion just after midnight or a scheduled 09:00 reminder should be interpreted in the user's IANA timezone, not necessarily in UTC. This change gives GHATD reusable framework support for that behavior without making host-application assumptions.

This also makes `starter/v0` a more complete composition layer: host applications get the default wiring when they want it, but can still replace the Reminder or Streaker service when their deployment needs custom behavior.

## Tests

- `asdf exec go test ./...`
- `git diff --check origin/main...HEAD`
- Public docs leakage scan for private names, local paths, and secrets; only placeholder token examples were found.