### PR TITLE
[GHATD-X] Add SPA filename bypass option

### DIFF
--- a/external/spa/README.md
+++ b/external/spa/README.md
@@ -64,10 +64,17 @@ customHandleUpdatePath := spa.NewHandleUpdatePathToIndex(
 	spa.BypassWithFileExtension(".webp"),
 	spa.IgnoreFileExtension("txt"),
 )
+
+// Bypass specific files by name. The match is against the path filename segment, not the full route.
+// This is independent of extension bypass rules.
+beaconHandleUpdatePath := spa.NewHandleUpdatePathToIndex(
+	spa.BypassWithFileName("beacon-loader.js"),
+	spa.BypassWithFileName("beacon-example.html"),
+)
 ```
 
 ### How it works
 
-- `NewHandleUpdatePathToIndex` builds a function that rewrites request paths to `/` unless the URL has a bypassed extension (defaults include `.js`, `.css`, images, fonts, etc.). This keeps SPA deep links working while letting static assets be served directly.
+- `NewHandleUpdatePathToIndex` builds a function that rewrites request paths to `/` unless the URL has a bypassed extension (defaults include `.js`, `.css`, images, fonts, etc.) or a bypassed filename. This keeps SPA deep links working while letting static assets be served directly.
 - `NewSpaHandler` uses that function inside `GetResourceNotFoundError` to serve the embedded `/dist/index.html` for non-API 404s.
 - `AttachRoutes` wires the same updater into a catch-all route so browser requests without a known asset extension are rewritten and served by the SPA bundle.

--- a/external/spa/README.md
+++ b/external/spa/README.md
@@ -71,10 +71,15 @@ beaconHandleUpdatePath := spa.NewHandleUpdatePathToIndex(
 	spa.BypassWithFileName("beacon-loader.js"),
 	spa.BypassWithFileName("beacon-example.html"),
 )
+
+// Force one specific file name to rewrite to "/" even when its extension would normally bypass.
+legacyHandleUpdatePath := spa.NewHandleUpdatePathToIndex(
+	spa.IgnoreFileName("legacy-loader.js"),
+)
 ```
 
 ### How it works
 
-- `NewHandleUpdatePathToIndex` builds a function that rewrites request paths to `/` unless the URL has a bypassed extension (defaults include `.js`, `.css`, images, fonts, etc.) or a bypassed filename. This keeps SPA deep links working while letting static assets be served directly.
+- `NewHandleUpdatePathToIndex` builds a function that rewrites request paths to `/` unless the URL has a bypassed extension (defaults include `.js`, `.css`, images, fonts, etc.) or a bypassed filename. Exact filename ignore rules take precedence over both filename and extension bypasses. This keeps SPA deep links working while letting static assets be served directly.
 - `NewSpaHandler` uses that function inside `GetResourceNotFoundError` to serve the embedded `/dist/index.html` for non-API 404s.
 - `AttachRoutes` wires the same updater into a catch-all route so browser requests without a known asset extension are rewritten and served by the SPA bundle.

--- a/external/spa/bootstrap_test.go
+++ b/external/spa/bootstrap_test.go
@@ -108,6 +108,48 @@ func TestBootstrapAttachRoutesServesWebManifest(t *testing.T) {
 	}
 }
 
+func TestBootstrapAttachRoutesServesBypassedFileName(t *testing.T) {
+	bootstrap, err := NewBootstrap(&BootstrapRequest{
+		EmbeddedContent: fstest.MapFS{
+			"dist/index.html":           {Data: []byte("<h1>index</h1>")},
+			"dist/beacon-example.html":  {Data: []byte("<h1>beacon</h1>")},
+			"dist/another-example.html": {Data: []byte("<h1>another</h1>")},
+		},
+		HandleUpdatePathToIndexFunc: NewHandleUpdatePathToIndex(
+			BypassWithFileName("beacon-example.html"),
+		),
+	})
+	if err != nil {
+		t.Fatalf("NewBootstrap() error = %v", err)
+	}
+
+	if err := bootstrap.AttachRoutes(); err != nil {
+		t.Fatalf("AttachRoutes() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/beacon-example.html", nil)
+	rec := httptest.NewRecorder()
+
+	bootstrap.Router.GetRouter().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "<h1>beacon</h1>" {
+		t.Fatalf("body = %q, want beacon body", body)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/another-example.html", nil)
+	rec = httptest.NewRecorder()
+
+	bootstrap.Router.GetRouter().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "<h1>index</h1>" {
+		t.Fatalf("body = %q, want index body", body)
+	}
+}
+
 func TestBootstrapAttachRoutesErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/external/spa/utils.go
+++ b/external/spa/utils.go
@@ -13,6 +13,7 @@ type PathOption func(*PathUpdateOptions)
 // PathUpdateOptions defines options for NewHandleUpdatePathToIndex.
 type PathUpdateOptions struct {
 	bypassFileExtensions map[string]struct{}
+	bypassFileNames      map[string]struct{}
 }
 
 // DefaultBypassExtensions defines the default file extensions that bypass SPA index rewriting.
@@ -20,12 +21,13 @@ var DefaultBypassExtensions = []string{".js", ".css", ".png", ".jpg", ".jpeg", "
 
 // DefaultPathUpdateOptions returns the default options for NewHandleUpdatePathToIndex
 func DefaultPathUpdateOptions() *PathUpdateOptions {
-
-	result := &PathUpdateOptions{bypassFileExtensions: map[string]struct{}{}}
+	result := &PathUpdateOptions{
+		bypassFileExtensions: map[string]struct{}{},
+		bypassFileNames:      map[string]struct{}{},
+	}
 	for _, extension := range DefaultBypassExtensions {
 		result.bypassFileExtensions[extension] = struct{}{}
 	}
-
 	return result
 }
 
@@ -67,6 +69,33 @@ func IgnoreFileExtension(fileExtension string) PathOption {
 	}
 }
 
+func normaliseFileName(fileName string) string {
+	fileName = strings.TrimSpace(fileName)
+	if fileName == "" {
+		return ""
+	}
+
+	fileName = path.Base(fileName)
+	if fileName == "." || fileName == "/" {
+		return ""
+	}
+
+	return fileName
+}
+
+// BypassWithFileName allows a file name to bypass SPA index rewriting.
+// It matches against the URL path filename segment only, not the full route path.
+func BypassWithFileName(fileName string) PathOption {
+	normalisedFileName := normaliseFileName(fileName)
+
+	return func(options *PathUpdateOptions) {
+		if normalisedFileName == "" {
+			return
+		}
+		options.bypassFileNames[normalisedFileName] = struct{}{}
+	}
+}
+
 // IgnoreDefaultFileExtensions removes all default bypass extensions from the
 // path update options.
 //
@@ -90,7 +119,8 @@ func IgnoreDefaultFileExtensions() PathOption {
 // By default, common static file extensions are bypassed so those requests are
 // not rewritten to "/". Additional rules can be added with PathOption, for
 // example BypassWithFileExtension("webp") to allow an extension through
-// or IgnoreFileExtension("js") to force rewriting that extension to "/".
+// or BypassWithFileName("beacon-example.html") to allow one specific file
+// through without bypassing every file with the same extension.
 //
 // Option order matters for default extensions:
 //
@@ -103,6 +133,9 @@ func NewHandleUpdatePathToIndex(options ...PathOption) func(r *http.Request) *ht
 	}
 
 	return func(r *http.Request) *http.Request {
+		if _, fileNameBypass := pathOptions.bypassFileNames[path.Base(r.URL.Path)]; fileNameBypass {
+			return r
+		}
 		if _, exists := pathOptions.bypassFileExtensions[path.Ext(r.URL.Path)]; !exists {
 			r.URL.Path = "/"
 		}

--- a/external/spa/utils.go
+++ b/external/spa/utils.go
@@ -71,6 +71,7 @@ func IgnoreFileExtension(fileExtension string) PathOption {
 	}
 }
 
+// normaliseFileName trims file name input and keeps only the final path segment.
 func normaliseFileName(fileName string) string {
 	fileName = strings.TrimSpace(fileName)
 	if fileName == "" {

--- a/external/spa/utils.go
+++ b/external/spa/utils.go
@@ -14,6 +14,7 @@ type PathOption func(*PathUpdateOptions)
 type PathUpdateOptions struct {
 	bypassFileExtensions map[string]struct{}
 	bypassFileNames      map[string]struct{}
+	ignoredFileNames     map[string]struct{}
 }
 
 // DefaultBypassExtensions defines the default file extensions that bypass SPA index rewriting.
@@ -24,6 +25,7 @@ func DefaultPathUpdateOptions() *PathUpdateOptions {
 	result := &PathUpdateOptions{
 		bypassFileExtensions: map[string]struct{}{},
 		bypassFileNames:      map[string]struct{}{},
+		ignoredFileNames:     map[string]struct{}{},
 	}
 	for _, extension := range DefaultBypassExtensions {
 		result.bypassFileExtensions[extension] = struct{}{}
@@ -92,7 +94,23 @@ func BypassWithFileName(fileName string) PathOption {
 		if normalisedFileName == "" {
 			return
 		}
+		delete(options.ignoredFileNames, normalisedFileName)
 		options.bypassFileNames[normalisedFileName] = struct{}{}
+	}
+}
+
+// IgnoreFileName ensures a file name is ignored for bypassing SPA index rewriting,
+// meaning requests with this file name will be rewritten to "/".
+// It matches against the URL path filename segment only, not the full route path.
+func IgnoreFileName(fileName string) PathOption {
+	normalisedFileName := normaliseFileName(fileName)
+
+	return func(options *PathUpdateOptions) {
+		if normalisedFileName == "" {
+			return
+		}
+		delete(options.bypassFileNames, normalisedFileName)
+		options.ignoredFileNames[normalisedFileName] = struct{}{}
 	}
 }
 
@@ -120,12 +138,15 @@ func IgnoreDefaultFileExtensions() PathOption {
 // not rewritten to "/". Additional rules can be added with PathOption, for
 // example BypassWithFileExtension("webp") to allow an extension through
 // or BypassWithFileName("beacon-example.html") to allow one specific file
-// through without bypassing every file with the same extension.
+// through without bypassing every file with the same extension. IgnoreFileName
+// can force one specific file to be rewritten even when its extension bypasses.
 //
 // Option order matters for default extensions:
 //
 // - IgnoreDefaultFileExtensions() then BypassWithFileExtension("js"): ".js" is added back and bypassed.
 // - BypassWithFileExtension("js") then IgnoreDefaultFileExtensions(): ".js" is removed again and rewritten.
+// - IgnoreFileName("loader.js") then BypassWithFileName("loader.js"): "loader.js" is added back and bypassed.
+// - BypassWithFileName("loader.js") then IgnoreFileName("loader.js"): "loader.js" is removed again and rewritten.
 func NewHandleUpdatePathToIndex(options ...PathOption) func(r *http.Request) *http.Request {
 	pathOptions := DefaultPathUpdateOptions()
 	for _, option := range options {
@@ -133,7 +154,12 @@ func NewHandleUpdatePathToIndex(options ...PathOption) func(r *http.Request) *ht
 	}
 
 	return func(r *http.Request) *http.Request {
-		if _, fileNameBypass := pathOptions.bypassFileNames[path.Base(r.URL.Path)]; fileNameBypass {
+		fileName := path.Base(r.URL.Path)
+		if _, fileNameIgnored := pathOptions.ignoredFileNames[fileName]; fileNameIgnored {
+			r.URL.Path = "/"
+			return r
+		}
+		if _, fileNameBypass := pathOptions.bypassFileNames[fileName]; fileNameBypass {
 			return r
 		}
 		if _, exists := pathOptions.bypassFileExtensions[path.Ext(r.URL.Path)]; !exists {

--- a/external/spa/utils_test.go
+++ b/external/spa/utils_test.go
@@ -26,3 +26,52 @@ func TestNewHandleUpdatePathToIndexRewritesSpaRoute(t *testing.T) {
 		t.Fatalf("path = %q, want /", got.URL.Path)
 	}
 }
+
+func TestNewHandleUpdatePathToIndexBypassesNamedFileButRewritesOtherHtml(t *testing.T) {
+	updatePath := NewHandleUpdatePathToIndex(
+		BypassWithFileName("beacon-example.html"),
+	)
+
+	beaconReq := httptest.NewRequest("GET", "/beacon-example.html", nil)
+	beaconGot := updatePath(beaconReq)
+	if beaconGot.URL.Path != "/beacon-example.html" {
+		t.Fatalf("path = %q, want /beacon-example.html", beaconGot.URL.Path)
+	}
+
+	anotherReq := httptest.NewRequest("GET", "/another.html", nil)
+	anotherGot := updatePath(anotherReq)
+	if anotherGot.URL.Path != "/" {
+		t.Fatalf("path = %q, want /", anotherGot.URL.Path)
+	}
+}
+
+func TestNewHandleUpdatePathToIndexBypassesNamedFileFromNestedRoute(t *testing.T) {
+	updatePath := NewHandleUpdatePathToIndex(
+		BypassWithFileName("/public/beacon-example.html"),
+	)
+
+	req := httptest.NewRequest("GET", "/nested/beacon-example.html", nil)
+	got := updatePath(req)
+	if got.URL.Path != "/nested/beacon-example.html" {
+		t.Fatalf("path = %q, want /nested/beacon-example.html", got.URL.Path)
+	}
+}
+
+func TestNewHandleUpdatePathToIndexFileNameBypassesWhenExtensionIgnored(t *testing.T) {
+	updatePath := NewHandleUpdatePathToIndex(
+		IgnoreFileExtension(".js"),
+		BypassWithFileName("beacon-loader.js"),
+	)
+
+	loaderReq := httptest.NewRequest("GET", "/beacon-loader.js", nil)
+	loaderGot := updatePath(loaderReq)
+	if loaderGot.URL.Path != "/beacon-loader.js" {
+		t.Fatalf("path = %q, want /beacon-loader.js", loaderGot.URL.Path)
+	}
+
+	otherJsReq := httptest.NewRequest("GET", "/other.js", nil)
+	otherJsGot := updatePath(otherJsReq)
+	if otherJsGot.URL.Path != "/" {
+		t.Fatalf("path = %q, want /", otherJsGot.URL.Path)
+	}
+}

--- a/external/spa/utils_test.go
+++ b/external/spa/utils_test.go
@@ -75,3 +75,41 @@ func TestNewHandleUpdatePathToIndexFileNameBypassesWhenExtensionIgnored(t *testi
 		t.Fatalf("path = %q, want /", otherJsGot.URL.Path)
 	}
 }
+
+func TestNewHandleUpdatePathToIndexIgnoreFileNameRewritesNamedFile(t *testing.T) {
+	updatePath := NewHandleUpdatePathToIndex(
+		BypassWithFileName("beacon-example.html"),
+		IgnoreFileName("beacon-example.html"),
+	)
+
+	req := httptest.NewRequest("GET", "/beacon-example.html", nil)
+	got := updatePath(req)
+	if got.URL.Path != "/" {
+		t.Fatalf("path = %q, want /", got.URL.Path)
+	}
+}
+
+func TestNewHandleUpdatePathToIndexIgnoreFileNameOverridesExtensionBypass(t *testing.T) {
+	updatePath := NewHandleUpdatePathToIndex(
+		IgnoreFileName("beacon-loader.js"),
+	)
+
+	req := httptest.NewRequest("GET", "/beacon-loader.js", nil)
+	got := updatePath(req)
+	if got.URL.Path != "/" {
+		t.Fatalf("path = %q, want /", got.URL.Path)
+	}
+}
+
+func TestNewHandleUpdatePathToIndexLaterBypassFileNameOverridesIgnoreFileName(t *testing.T) {
+	updatePath := NewHandleUpdatePathToIndex(
+		IgnoreFileName("beacon-loader.js"),
+		BypassWithFileName("beacon-loader.js"),
+	)
+
+	req := httptest.NewRequest("GET", "/beacon-loader.js", nil)
+	got := updatePath(req)
+	if got.URL.Path != "/beacon-loader.js" {
+		t.Fatalf("path = %q, want /beacon-loader.js", got.URL.Path)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds filename-specific controls to the SPA path updater so host applications can allow or deny individual static files without widening extension-based routing rules.

SPA index rewriting can now distinguish a specific filename from all files sharing the same extension. For example, a host application can serve `beacon-example.html` directly without allowing every `.html` request to bypass the SPA fallback.

Before this change, SPA bypass rules only worked by extension. That made exact-file cases too broad or awkward: allowing `.html` would serve any HTML asset directly, while passing a full filename to extension logic did not match how `path.Ext` resolves request paths.

## Changes

- Add `BypassWithFileName(...)` for exact filename bypasses based on the URL path filename segment.
- Add `IgnoreFileName(...)` as the filename-level counterpart to `IgnoreFileExtension(...)`.
- Preserve existing default extension bypass behaviour.
- Apply filename ignores before filename and extension bypasses, while preserving option-order behaviour for filename bypass/ignore options.
- Normalise filename option inputs to their final path segment.
- Add tests for named `.html` bypasses, non-named `.html` fallback, filename bypass with ignored extensions, filename ignore overrides, and route-level serving through SPA bootstrap.
- Update the SPA package README with filename bypass/ignore examples.

## Why

Some host applications need to serve one or two well-known files from the SPA asset bundle without making the entire extension bypass the SPA router. This is especially important for `.html`, where bypassing the whole extension would stop normal SPA routes from falling back to the index.

Filename-level options keep the existing extension defaults intact while giving host applications a precise opt-in/opt-out surface.

## Tests

- `asdf exec go test ./external/spa/... -v`
- `asdf exec go test ./...`
- `git diff --check origin/main...HEAD`
- Public docs leakage scan for private names, local paths, and secrets; only existing placeholder token examples were found.