### PR TITLE
[GHATD-X] Set no-cache headers for SPA service workers

### DIFF
--- a/external/spa/bootstrap_test.go
+++ b/external/spa/bootstrap_test.go
@@ -150,6 +150,76 @@ func TestBootstrapAttachRoutesServesBypassedFileName(t *testing.T) {
 	}
 }
 
+func TestBootstrapAttachRoutesServesServiceWorkerWithNoCacheHeaders(t *testing.T) {
+	bootstrap, err := NewBootstrap(&BootstrapRequest{
+		EmbeddedContent: fstest.MapFS{
+			"dist/index.html":        {Data: []byte("<h1>hello</h1>")},
+			"dist/service-worker.js": {Data: []byte("self.addEventListener('install', () => {})")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBootstrap() error = %v", err)
+	}
+
+	if err := bootstrap.AttachRoutes(); err != nil {
+		t.Fatalf("AttachRoutes() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/service-worker.js", nil)
+	rec := httptest.NewRecorder()
+
+	bootstrap.Router.GetRouter().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "self.addEventListener('install', () => {})" {
+		t.Fatalf("body = %q, want service worker body", body)
+	}
+	if cacheControl := rec.Header().Get("Cache-Control"); cacheControl != serviceWorkerCacheControl {
+		t.Fatalf("Cache-Control = %q, want %q", cacheControl, serviceWorkerCacheControl)
+	}
+	if pragma := rec.Header().Get("Pragma"); pragma != "no-cache" {
+		t.Fatalf("Pragma = %q, want no-cache", pragma)
+	}
+	if expires := rec.Header().Get("Expires"); expires != "0" {
+		t.Fatalf("Expires = %q, want 0", expires)
+	}
+}
+
+func TestBootstrapAttachRoutesDoesNotSetNoCacheHeadersForOrdinaryAssets(t *testing.T) {
+	bootstrap, err := NewBootstrap(&BootstrapRequest{
+		EmbeddedContent: fstest.MapFS{
+			"dist/index.html":       {Data: []byte("<h1>hello</h1>")},
+			"dist/assets/app.js":    {Data: []byte("console.log('hello')")},
+			"dist/assets/app.css":   {Data: []byte("body{}")},
+			"dist/site.webmanifest": {Data: []byte(`{"name":"Example"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBootstrap() error = %v", err)
+	}
+
+	if err := bootstrap.AttachRoutes(); err != nil {
+		t.Fatalf("AttachRoutes() error = %v", err)
+	}
+
+	for _, targetPath := range []string{"/assets/app.js", "/assets/app.css", "/site.webmanifest"} {
+		req := httptest.NewRequest(http.MethodGet, targetPath, nil)
+		rec := httptest.NewRecorder()
+
+		bootstrap.Router.GetRouter().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d", targetPath, rec.Code, http.StatusOK)
+		}
+		if cacheControl := rec.Header().Get("Cache-Control"); cacheControl != "" {
+			t.Fatalf("%s Cache-Control = %q, want empty", targetPath, cacheControl)
+		}
+		if pragma := rec.Header().Get("Pragma"); pragma != "" {
+			t.Fatalf("%s Pragma = %q, want empty", targetPath, pragma)
+		}
+	}
+}
+
 func TestBootstrapAttachRoutesErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/external/spa/bootstrap_test.go
+++ b/external/spa/bootstrap_test.go
@@ -181,8 +181,8 @@ func TestBootstrapAttachRoutesServesServiceWorkerWithNoCacheHeaders(t *testing.T
 	if pragma := rec.Header().Get("Pragma"); pragma != "no-cache" {
 		t.Fatalf("Pragma = %q, want no-cache", pragma)
 	}
-	if expires := rec.Header().Get("Expires"); expires != "0" {
-		t.Fatalf("Expires = %q, want 0", expires)
+	if expires := rec.Header().Get("Expires"); expires != expiredHTTPDate {
+		t.Fatalf("Expires = %q, want %q", expires, expiredHTTPDate)
 	}
 }
 
@@ -216,6 +216,9 @@ func TestBootstrapAttachRoutesDoesNotSetNoCacheHeadersForOrdinaryAssets(t *testi
 		}
 		if pragma := rec.Header().Get("Pragma"); pragma != "" {
 			t.Fatalf("%s Pragma = %q, want empty", targetPath, pragma)
+		}
+		if expires := rec.Header().Get("Expires"); expires != "" {
+			t.Fatalf("%s Expires = %q, want empty", targetPath, expires)
 		}
 	}
 }

--- a/external/spa/cache_headers.go
+++ b/external/spa/cache_headers.go
@@ -1,0 +1,33 @@
+package spa
+
+import (
+	"net/http"
+	"path"
+	"strings"
+)
+
+const (
+	serviceWorkerFileName     = "service-worker.js"
+	serviceWorkerCacheControl = "no-cache, no-store, must-revalidate"
+)
+
+// applyStaticAssetCachePolicy sets cache headers for SPA assets that must be revalidated.
+func applyStaticAssetCachePolicy(w http.ResponseWriter, r *http.Request) {
+	if !isRootServiceWorkerRequest(r) {
+		return
+	}
+
+	w.Header().Set("Cache-Control", serviceWorkerCacheControl)
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+}
+
+// isRootServiceWorkerRequest reports whether the request targets the root service-worker script.
+func isRootServiceWorkerRequest(r *http.Request) bool {
+	if r == nil || r.URL == nil {
+		return false
+	}
+
+	requestPath := path.Clean("/" + strings.TrimLeft(r.URL.Path, "/"))
+	return requestPath == "/"+serviceWorkerFileName
+}

--- a/external/spa/cache_headers.go
+++ b/external/spa/cache_headers.go
@@ -12,7 +12,7 @@ const (
 	expiredHTTPDate           = "Thu, 01 Jan 1970 00:00:00 GMT"
 )
 
-// applyStaticAssetCachePolicy sets cache headers for SPA assets that must be revalidated.
+// applyStaticAssetCachePolicy sets cache headers for service-worker scripts that must be revalidated.
 func applyStaticAssetCachePolicy(w http.ResponseWriter, r *http.Request) {
 	if !isRootServiceWorkerRequest(r) {
 		return

--- a/external/spa/cache_headers.go
+++ b/external/spa/cache_headers.go
@@ -9,6 +9,7 @@ import (
 const (
 	serviceWorkerFileName     = "service-worker.js"
 	serviceWorkerCacheControl = "no-cache, no-store, must-revalidate"
+	expiredHTTPDate           = "Thu, 01 Jan 1970 00:00:00 GMT"
 )
 
 // applyStaticAssetCachePolicy sets cache headers for SPA assets that must be revalidated.
@@ -19,7 +20,7 @@ func applyStaticAssetCachePolicy(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Cache-Control", serviceWorkerCacheControl)
 	w.Header().Set("Pragma", "no-cache")
-	w.Header().Set("Expires", "0")
+	w.Header().Set("Expires", expiredHTTPDate)
 }
 
 // isRootServiceWorkerRequest reports whether the request targets the root service-worker script.

--- a/external/spa/handler.go
+++ b/external/spa/handler.go
@@ -60,6 +60,7 @@ func (h *Handler) GetResourceNotFoundError(w http.ResponseWriter, r *http.Reques
 
 	// Reset the request URL path to the root ("/") to
 	// serve the default index page for non-existent resources
+	applyStaticAssetCachePolicy(w, r)
 	r = h.spaUpdatePathToIndexFunc(r)
 
 	http.FileServer(http.FS(distDirFS)).ServeHTTP(w, r)

--- a/external/spa/handler.go
+++ b/external/spa/handler.go
@@ -60,7 +60,6 @@ func (h *Handler) GetResourceNotFoundError(w http.ResponseWriter, r *http.Reques
 
 	// Reset the request URL path to the root ("/") to
 	// serve the default index page for non-existent resources
-	applyStaticAssetCachePolicy(w, r)
 	r = h.spaUpdatePathToIndexFunc(r)
 
 	http.FileServer(http.FS(distDirFS)).ServeHTTP(w, r)

--- a/external/spa/routes.go
+++ b/external/spa/routes.go
@@ -76,6 +76,7 @@ func AttachRoutes(request *AttachRoutesRequest) error {
 			// if the r.URL.Path does not have a suffix such as .js,
 			// .css, .png, .jpg, .jpeg, .gif, .svg, or .ico then we
 			// should update path to go to /
+			applyStaticAssetCachePolicy(w, r)
 			r = handleUpdatePathToIndexFunc(r)
 
 			fileServer.ServeHTTP(w, r)


### PR DESCRIPTION
### Context

Service-worker scripts are part of the browser's update mechanism. They should be revalidated on each update check instead of being served from a stale browser, CDN, or origin response cache.

GHATD's SPA helper serves static files for host applications, including root-level service-worker scripts generated by PWA tooling. When a host application also has generic static-response caching in front of the SPA handler, `/service-worker.js` can inherit a cache policy intended for ordinary static assets. That can delay service-worker updates and leave clients seeing repeated update prompts or reload churn after a deployment.

### What Changed

- Added a SPA static-asset cache policy for normalized root `/service-worker.js` requests handled by the normal SPA route attachment path.
- Set `Cache-Control: no-cache, no-store, must-revalidate`, `Pragma: no-cache`, and an already-expired HTTP `Expires` date on root service-worker responses.
- Kept ordinary static assets and web manifests on their existing cache behavior.
- Added SPA bootstrap tests covering the service-worker no-cache headers and verifying ordinary assets do not receive those headers.
- Clarified the service-worker cache helper comment so future readers do not mistake it for a broader static-asset cache policy.

### Why

Service workers are not like hashed JavaScript or CSS assets. A stale service-worker script can cause clients to compare or activate the wrong worker version, especially around deployments. By making the root worker script explicitly non-cacheable at GHATD's SPA layer, host applications get safer PWA update behavior by default without disabling service-worker registration, offline support, or Web Push.

This uses the strict `no-store` policy intentionally. The worker script is small, and correctness around update checks is more important here than reusing a cached worker response.

### Scope Notes

This policy targets the normalized root service-worker script path: `/service-worker.js`. Host applications that serve workers from another path should add their own route or cache policy for that path.

### How To Test

Requires a Go 1.25-compatible toolchain. The repo includes `.tool-versions` for asdf users.

- `asdf exec go test ./external/spa/...`

Equivalent with an already configured Go 1.25+ toolchain:

- `go test ./external/spa/...`

For a host application that serves a root `service-worker.js` through GHATD SPA routes, verify the response headers with:

```sh
curl -sD - -o /dev/null http://localhost:<port>/service-worker.js | grep -E '^(Cache-Control|Pragma|Expires):'
```

Expected headers:

```text
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Expires: Thu, 01 Jan 1970 00:00:00 GMT
```

Also verify ordinary static assets, such as `/assets/app.js`, do not receive these service-worker-specific no-cache headers from this GHATD policy.

### Rollout Notes

Host applications should still review any additional CDN or reverse-proxy cache rules for service-worker scripts. This change makes GHATD's SPA response explicit, but an outer cache layer may still need a purge or rule update if it has already cached an older worker response.