### PR TITLE
[GHATD-X] Add structured package logging

### DIFF
--- a/docs/adr/adr013-structured-package-logging.md
+++ b/docs/adr/adr013-structured-package-logging.md
@@ -1,0 +1,127 @@
+---
+id: adrs-adr013
+title: 'ADR013: Structured GHATD Package Logging'
+# prettier-ignore
+description: >
+  Architecture Decision Record (ADR) for adding consistent GHATD package
+  attribution, operation fields, and sensitive-data rules to framework logs.
+date: 2026-05-27
+status: proposed
+---
+
+## Status
+
+Proposed.
+
+## Context
+
+GHATD packages run inside host applications and usually reuse the host request
+logger. That gives every package access to host fields such as `component`,
+`environment`, and `correlation-id`, but it also means GHATD package logs can be
+hard to distinguish from host application logs.
+
+This became painful during a notification dispatch failure where the only
+visible log line was the host request middleware summary for a `500` response.
+The summary included request metadata and a correlation ID, but not the GHATD
+package, delivery channel, sender path, target user, or concrete package error.
+
+GHATD also has several package layers that need consistent diagnostics:
+handlers and fenders, services, repository helpers, third-party providers,
+background cleanup flows, and starter composition helpers. These logs must be
+useful in production without exposing secrets or payload values.
+
+## Decision
+
+GHATD package code will acquire loggers from `context.Context` and add stable
+framework attribution fields before writing package logs.
+
+The canonical helpers are:
+
+```go
+logger := logger.AcquirePackageFrom(ctx, "external/notifier")
+logger := logger.AcquireOperationFrom(ctx, "external/notifier", "notify-user")
+```
+
+These helpers preserve the host logger and add:
+
+- `source=ghatd`
+- `ghatd-package=<package-path>`
+- `operation=<operation-name>` when the operation is known
+
+They also apply `zap.AddStacktrace(zap.DPanicLevel)` consistently, so package
+call sites do not need to repeat that option.
+
+Package authors should use the narrowest logger that matches the current flow:
+
+- Use `AcquireOperationFrom` for service methods, repository operations,
+  handler/fender mappings, third-party provider calls, and background jobs.
+- Use `AcquirePackageFrom` when the operation is already clear from the log
+  message or when a helper is shared by multiple operations.
+- Use the request context for HTTP handlers and middleware.
+- Use an explicit context for startup, shutdown, cleanup, and CLI flows.
+- Leave pure value helpers unlogged unless they are called from a logged flow.
+- Name the acquired local logger `logger`. Do not introduce aliases such as
+  `log`, `loggr`, `logr`, `structuredLog`, or `zapLogger` for GHATD package
+  logging.
+
+The log level convention is:
+
+- `Debug`: routine branch decisions, counts, pagination, cache hits, and
+  non-essential success details.
+- `Info`: lifecycle boundaries, completed work, dispatch summaries, and
+  expected high-level state transitions.
+- `Warn`: recoverable or expected failures such as validation misses, skipped
+  senders, missing optional dependencies, or no-op cleanup paths.
+- `Error`: failed dependencies, persistence failures, third-party call failures,
+  and errors returned to callers.
+
+GHATD logs must not include secrets or raw payload values. Do not log raw
+tokens, cookies, authorization headers, passwords, private keys, webhook
+signatures, push endpoints, FCM tokens, request bodies, provider payloads, or
+arbitrary notification data values. Prefer IDs, counts, booleans, data keys,
+channel names, provider names, event IDs, status enums, hashes already stored
+by GHATD, and redacted lengths.
+
+When an existing log needs request or model context, package code should pass
+the value through `logger.SafeValue` or `logger.SafeAny`, or use an equivalent
+package-specific helper. These helpers reduce structs to operational fields and
+summarise maps and slices without serialising raw payload values.
+
+Host application fields remain intact. For example, a log can contain both
+`component=<host-component>` and `source=ghatd`; the GHATD fields identify the
+framework package while the host fields identify the running application.
+
+## Consequences
+
+GHATD package logs become filterable by `source=ghatd` and by
+`ghatd-package`, while still retaining request correlation from the host logger.
+
+Operational failures can now identify the package and operation responsible for
+the error. Notification sends, repository helper failures, payment provider
+verification, SPA fallback behavior, and cleanup flows can be debugged without
+guessing which layer emitted a log line.
+
+The convention adds more debug-level events. Host applications should keep
+production log levels at `info` or higher unless debugging a specific issue.
+
+Package authors must avoid raw request and payload logging. Existing or future
+logs that need request context should log selected safe fields rather than
+serialising entire request structs or payloads.
+
+Applications that query logs by field names should add filters for
+`source=ghatd`, `ghatd-package`, and `operation`.
+
+## Rollout
+
+The initial GHATD rollout introduces the package helpers and migrates existing
+package logger acquisition to include GHATD attribution. It also adds targeted
+logs for previously quiet package paths such as HTTP server lifecycle, SPA
+fallbacks, repository connection helpers, blueprint, cleanup, and CLI clone
+flows. HTTP handlers and context-bearing service methods should emit at least a
+debug-level operation boundary so host applications can trace a request through
+GHATD even when the failure happens in a downstream dependency.
+
+After this ADR is accepted and the GHATD changes are released, host
+applications should update to the released GHATD version, verify that request
+middleware still propagates the logger through context, and review log queries
+or dashboards for the new fields.

--- a/docs/adr/adr014-local-email-inbox-for-development.md
+++ b/docs/adr/adr014-local-email-inbox-for-development.md
@@ -1,0 +1,121 @@
+---
+id: adrs-adr014
+title: 'ADR014: Local Email Inbox for Development'
+# prettier-ignore
+description: >
+  Architecture Decision Record (ADR) for capturing local EmailManager output in
+  an opt-in development inbox instead of writing raw rendered email bodies to
+  structured logs.
+date: 2026-05-27
+status: proposed
+---
+
+## Status
+
+Proposed.
+
+## Context
+
+GHATD host applications need usable local email flows. During development,
+login emails, verification emails, and custom transactional emails often
+contain magic links or security codes that developers must open or copy in
+order to complete the flow under test.
+
+Before this decision, the local email provider wrote enough email content to
+logs that developers could recover those links and codes. That conflicted with
+the structured logging strategy in ADR013, because rendered email bodies can
+contain tokens, codes, personal data, and arbitrary host application content.
+Those values should not appear in structured logs or log shipping systems.
+
+At the same time, simply redacting the email body from logs would make local
+development worse. Developers would no longer be able to sign in, verify
+accounts, inspect templates, or debug outbound email content without wiring a
+real provider or adding ad hoc host application code.
+
+## Decision
+
+GHATD will keep raw rendered email bodies out of structured logs and provide a
+separate local email inbox for development.
+
+`emailprovider.LoggingEmailProvider` will be the local output provider. It will
+capture full local emails in a bounded in-memory `LocalEmailStore` and continue
+to log only safe metadata such as provider, message ID, address domains, body
+presence, subject length, and local inbox count.
+
+The local inbox routes are opt-in through:
+
+```go
+err := emailprovider.AttachLocalInboxRoutes(&emailprovider.AttachLocalInboxRoutesRequest{
+    Router:   ghatdRouter,
+    Provider: localEmailProvider,
+})
+```
+
+The default route prefix is `/_ghatd/local/emails`. Host applications can set a
+custom `Prefix` when they need a different local route.
+
+The inbox will expose:
+
+- an HTML list of captured emails;
+- an HTML detail page with metadata, rendered preview, raw HTML, optional text
+  body, and extracted web links;
+- a raw rendered-email endpoint for opening the email in a browser;
+- a JSON summary endpoint for local tools;
+- a clear action for resetting the in-memory inbox.
+
+The routes are local-development surfaces and must not be enabled in production
+or untrusted environments. By default, the route middleware rejects non-loopback
+clients. `AllowRemote` exists only for trusted local proxy setups where another
+local layer controls access.
+
+Rendered email previews must be constrained. The detail page renders email HTML
+inside a sandboxed iframe. The raw rendered-email endpoint sets a CSP sandbox
+policy. Extracted shortcut links are limited to `http`, `https`, and local
+relative web URLs so magic-link flows remain convenient without exposing
+non-web schemes as action buttons.
+
+`emailmanager.EmailManager` will treat local output providers specially when
+`ShouldSendEmail` is false. For those providers, both templated email paths and
+the pre-rendered `SendEmail` path may still call `Send` so the local inbox is
+populated. For non-local providers, `ShouldSendEmail=false` continues to prevent
+real provider sends.
+
+## Consequences
+
+Local developers can test login, verification, and custom-email flows without
+using a real provider allowance and without searching raw HTML in logs.
+
+Structured logs remain safe for host applications to ship and retain. They
+identify that email was captured locally and provide operational metadata, but
+they do not contain rendered email bodies, tokens, security codes, or full email
+addresses.
+
+The inbox is intentionally in-memory. It is simple to operate, resets on
+process restart, and avoids adding storage dependencies to local development.
+Developers who need persistence can build a host application integration around
+the provider/store API.
+
+Host applications must explicitly attach the local inbox routes. This keeps
+production deployments from receiving the route by default, but it does mean
+local startup code needs a small integration step.
+
+Because captured emails may contain sensitive local credentials, host
+applications should only attach the routes for trusted local development and
+should avoid exposing them through public tunnels unless an additional trusted
+access layer protects the route.
+
+## Rollout
+
+GHATD will document the local inbox workflow in the Email Manager guide and
+examples. Host applications that currently rely on raw local email logs should
+switch to `LoggingEmailProvider`, set real provider sending to disabled in local
+development, attach `AttachLocalInboxRoutes`, and open
+`/_ghatd/local/emails` while testing local email flows.
+
+After adopting this change, host applications should verify:
+
+- local login and verification emails appear in the inbox;
+- magic links can be opened from the inbox;
+- security codes can be copied from rendered or raw email content;
+- structured logs only contain safe email metadata;
+- inbox routes are not attached in production or untrusted environments.

--- a/docs/getting-started/email-manager/README.md
+++ b/docs/getting-started/email-manager/README.md
@@ -187,6 +187,8 @@ if err != nil {
 
 By default, the local inbox is available at `/_ghatd/local/emails` and rejects non-loopback clients. Set a custom `Prefix` or `AllowRemote` only when another trusted local proxy protects the route.
 
+This local inbox workflow is described in [ADR014](../../adr/adr014-local-email-inbox-for-development.md).
+
 > **Note on Environments:** The `emailtemplater` is also **environment-aware**; for example, setting the `Environment` config to `"staging"` will add `[staging]` to the email subject line.
 
 ## Advanced Use Cases

--- a/docs/getting-started/email-manager/README.md
+++ b/docs/getting-started/email-manager/README.md
@@ -159,24 +159,33 @@ The email templates use Handlebars (`{{FieldName}}`) for variable substitution. 
 
 ### 3. Development Environment Setup
 
-If you don't want to use your email provider's allowance when running your code locally, you can use the `LoggingEmailProvider` to log the email content instead of sending it.
+If you don't want to use your email provider's allowance when running your code locally, use the `LoggingEmailProvider` to capture emails in memory and attach the local inbox routes. The inbox lets you open rendered emails, click magic links, and copy login or verification codes without writing raw email HTML to structured logs.
 
 ```go
-// Use logging provider to see emails in logs instead of sending
-provider := emailprovider.NewLoggingEmailProvider(&emailprovider.LoggingEmailProviderConfig{
-    DisableFullHtmlBodyPreview: false, // The login and verification token by default contain the token/magic link URL for you to sign in
-}) 
+localEmailProvider := emailprovider.NewLoggingEmailProvider(&emailprovider.LoggingEmailProviderConfig{
+    MaxStoredEmails: 50,
+})
 
 manager := emailmanager.NewEmailManager(
     emailtemplater.NewEmailTemplater(templaterConfig),
-    provider,
+    localEmailProvider,
     auditService,
     &emailmanager.Config{
-        ShouldSendEmail:    true, // The LoggingProvider logs despite this being true
+        ShouldSendEmail:    false,
         EnableAuditLogging: true,
     },
 )
+
+err := emailprovider.AttachLocalInboxRoutes(&emailprovider.AttachLocalInboxRoutesRequest{
+    Router:   ghatdRouter,
+    Provider: localEmailProvider,
+})
+if err != nil {
+    return err
+}
 ```
+
+By default, the local inbox is available at `/_ghatd/local/emails` and rejects non-loopback clients. Set a custom `Prefix` or `AllowRemote` only when another trusted local proxy protects the route.
 
 > **Note on Environments:** The `emailtemplater` is also **environment-aware**; for example, setting the `Environment` config to `"staging"` will add `[staging]` to the email subject line.
 

--- a/external/accessmanager/fender.go
+++ b/external/accessmanager/fender.go
@@ -20,27 +20,25 @@ import (
 // MapRequestToUpdateUserEmailRequest maps incoming UpdateUserEmail request to correct struct.
 func MapRequestToUpdateUserEmailRequest(request *http.Request, cookiePrefixAuthToken, cookiePrefixRefreshToken string, validator AccessmanagerValidator) (*UpdateUserEmailRequest, error) {
 	var (
-		log *zap.Logger = logger.AcquireFrom(request.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger        *zap.Logger             = logger.AcquirePackageFrom(request.Context(), "external/accessmanager")
 		parsedRequest *UpdateUserEmailRequest = &UpdateUserEmailRequest{}
 		err           error
 	)
 
 	if err := toolbox.DecodeRequestBody(request, parsedRequest); err != nil {
-		log.Error("unable-decode-request-body-for-updating-user-email")
+		logger.Error("unable-decode-request-body-for-updating-user-email")
 		return nil, ErrInvalidUserEmail
 	}
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(request.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-requestor-user-id")
+		logger.Error("unable-get-requestor-user-id")
 		return nil, ErrUnauthorizedUnableToAttainRequestorID
 	}
 
 	parsedRequest.TargetUserId, err = getUserIDFromURI(request)
 	if err != nil {
-		log.Error("unable-get-target-user-id")
+		logger.Error("unable-get-target-user-id")
 		return nil, err
 	}
 
@@ -48,7 +46,7 @@ func MapRequestToUpdateUserEmailRequest(request *http.Request, cookiePrefixAuthT
 	// check to see if request is coming with cookies
 	cookie, aTokenErr := request.Cookie(cookiePrefixAuthToken)
 	if aTokenErr != nil {
-		log.Error("unable-get-access-token-from-cookie", zap.String("user-id", parsedRequest.UserId), zap.String("target-user-id", parsedRequest.TargetUserId))
+		logger.Error("unable-get-access-token-from-cookie", zap.String("user-id", parsedRequest.UserId), zap.String("target-user-id", parsedRequest.TargetUserId))
 		return nil, aTokenErr
 	}
 
@@ -56,7 +54,7 @@ func MapRequestToUpdateUserEmailRequest(request *http.Request, cookiePrefixAuthT
 
 	refreshTokenCookie, rAuthErr := request.Cookie(cookiePrefixRefreshToken)
 	if rAuthErr != nil {
-		log.Error("unable-get-access-token-from-cookie", zap.String("user-id", parsedRequest.UserId), zap.String("target-user-id", parsedRequest.TargetUserId))
+		logger.Error("unable-get-access-token-from-cookie", zap.String("user-id", parsedRequest.UserId), zap.String("target-user-id", parsedRequest.TargetUserId))
 		return nil, rAuthErr
 	}
 
@@ -67,7 +65,7 @@ func MapRequestToUpdateUserEmailRequest(request *http.Request, cookiePrefixAuthT
 
 	err = validator.Validate(parsedRequest)
 	if err != nil {
-		log.Error("unable-validate-request-for-updating-user-email")
+		logger.Error("unable-validate-request-for-updating-user-email")
 		return nil, ErrBadRequest
 	}
 
@@ -77,9 +75,7 @@ func MapRequestToUpdateUserEmailRequest(request *http.Request, cookiePrefixAuthT
 // MapRequestToLogoutUserOthersRequest maps incoming LogOutUserOthers request to correct struct.
 func MapRequestToLogoutUserOthersRequest(request *http.Request, validator AccessmanagerValidator, authCookiePrefix, refreshCookiePrefix string) (*LogoutUserOthersRequest, error) {
 	var (
-		log *zap.Logger = logger.AcquireFrom(request.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(request.Context(), "external/accessmanager")
 
 		parsedRequest *LogoutUserOthersRequest = &LogoutUserOthersRequest{}
 	)
@@ -88,13 +84,13 @@ func MapRequestToLogoutUserOthersRequest(request *http.Request, validator Access
 
 	authTokenCookie, err := request.Cookie(authCookiePrefix)
 	if err != nil {
-		log.Error("unable-to-get-auth-token-cookie", zap.String("user-id", parsedRequest.UserId))
+		logger.Error("unable-to-get-auth-token-cookie", zap.String("user-id", parsedRequest.UserId))
 		return nil, ErrInvalidAuthToken
 	}
 
 	refreshTokenCookie, err := request.Cookie(refreshCookiePrefix)
 	if err != nil {
-		log.Error("unable-to-get-refresh-token-cookie", zap.String("user-id", parsedRequest.UserId))
+		logger.Error("unable-to-get-refresh-token-cookie", zap.String("user-id", parsedRequest.UserId))
 		return nil, ErrInvalidRefreshToken
 	}
 
@@ -106,7 +102,7 @@ func MapRequestToLogoutUserOthersRequest(request *http.Request, validator Access
 	}
 
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrInvalidUserID
 	}
 
@@ -138,9 +134,7 @@ func MapRequestToOauthCallbackRequest(request *http.Request, validator Accessman
 // MapRequestToOauthLoginRequest maps incoming OauthLogin request to correct struct
 func MapRequestToOauthLoginRequest(request *http.Request, validator AccessmanagerValidator) (*OauthLoginRequest, error) {
 	var (
-		log *zap.Logger = logger.AcquireFrom(request.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(request.Context(), "external/accessmanager")
 
 		parsedRequest OauthLoginRequest = OauthLoginRequest{}
 	)
@@ -158,11 +152,11 @@ func MapRequestToOauthLoginRequest(request *http.Request, validator Accessmanage
 
 		decodedUriValue, err := url.PathUnescape(parsedRequest.RequestUrl)
 		if err != nil {
-			log.Warn("failed-to-decode-request-url-uri-for-sso-login", zap.String("encoded-request-url", parsedRequest.RequestUrl))
+			logger.Warn("failed-to-decode-request-url-uri-for-sso-login", zap.String("encoded-request-url", parsedRequest.RequestUrl))
 		}
 
 		if err == nil {
-			log.Info("request-url-uri-decoded-for-sso-login", zap.String("encoded-request-url", parsedRequest.RequestUrl))
+			logger.Info("request-url-uri-decoded-for-sso-login", zap.String("encoded-request-url", parsedRequest.RequestUrl))
 			parsedRequest.RequestUrl = decodedUriValue
 		}
 	}
@@ -363,9 +357,7 @@ func MapRequestToDeleteUserAPITokenRequest(request *http.Request, validator Acce
 func MapRequestToCreateUserAPITokenRequest(request *http.Request, validator AccessmanagerValidator) (*CreateUserAPITokenRequest, error) {
 
 	var (
-		log *zap.Logger = logger.AcquireFrom(request.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(request.Context(), "external/accessmanager")
 
 		parsedRequest *CreateUserAPITokenRequest = &CreateUserAPITokenRequest{}
 		err           error
@@ -383,11 +375,11 @@ func MapRequestToCreateUserAPITokenRequest(request *http.Request, validator Acce
 	if err != nil {
 		bodyBytes, err := ioutil.ReadAll(request.Body)
 		if err != nil {
-			log.Error("unable-to-decode-create-user-api-token-request")
+			logger.Error("unable-to-decode-create-user-api-token-request")
 		}
 
 		if err == nil {
-			log.Error("unable-to-decode-create-user-api-token-request", zap.Any("request-body", bodyBytes))
+			logger.Error("unable-to-decode-create-user-api-token-request", zap.Int("request-body-bytes", len(bodyBytes)))
 		}
 		return nil, ErrInvalidCreateUserAPITokenBody
 	}
@@ -451,9 +443,7 @@ func MapRequestToRefreshTokenRequest(request *http.Request, refreshCookieName, a
 func MapRequestToCreateInitalLoginOrVerificationTokenEmailRequest(request *http.Request, validator AccessmanagerValidator) (*CreateInitalLoginOrVerificationTokenEmailRequest, error) {
 
 	var (
-		log *zap.Logger = logger.AcquireFrom(request.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(request.Context(), "external/accessmanager")
 
 		parsedRequest *CreateInitalLoginOrVerificationTokenEmailRequest = &CreateInitalLoginOrVerificationTokenEmailRequest{}
 	)
@@ -468,7 +458,7 @@ func MapRequestToCreateInitalLoginOrVerificationTokenEmailRequest(request *http.
 		return nil, ErrInvalidUserEmail
 	}
 
-	log.Debug("login-request-submitted.", zap.String("email", parsedRequest.Email))
+	logger.Debug("login-request-submitted.", zap.String("email", parsedRequest.Email))
 
 	return parsedRequest, nil
 

--- a/external/accessmanager/fender.go
+++ b/external/accessmanager/fender.go
@@ -152,11 +152,11 @@ func MapRequestToOauthLoginRequest(request *http.Request, validator Accessmanage
 
 		decodedUriValue, err := url.PathUnescape(parsedRequest.RequestUrl)
 		if err != nil {
-			logger.Warn("failed-to-decode-request-url-uri-for-sso-login", zap.String("encoded-request-url", parsedRequest.RequestUrl))
+			logger.Warn("failed-to-decode-request-url-uri-for-sso-login", requestURLLogFields(parsedRequest.RequestUrl)...)
 		}
 
 		if err == nil {
-			logger.Info("request-url-uri-decoded-for-sso-login", zap.String("encoded-request-url", parsedRequest.RequestUrl))
+			logger.Info("request-url-uri-decoded-for-sso-login", requestURLLogFields(parsedRequest.RequestUrl)...)
 			parsedRequest.RequestUrl = decodedUriValue
 		}
 	}
@@ -458,7 +458,7 @@ func MapRequestToCreateInitalLoginOrVerificationTokenEmailRequest(request *http.
 		return nil, ErrInvalidUserEmail
 	}
 
-	logger.Debug("login-request-submitted.", zap.String("email", parsedRequest.Email))
+	logger.Debug("login-request-submitted.", emailLogFields("email", parsedRequest.Email)...)
 
 	return parsedRequest, nil
 

--- a/external/accessmanager/handler.go
+++ b/external/accessmanager/handler.go
@@ -82,9 +82,11 @@ func NewHandler(r *NewHandlerRequest) *Handler {
 // it will remove the user's auth cookies and redirect them to the home page. Otherwise, it will return
 // a blank response with a 200 status code.
 func (h *Handler) UpdateUserEmail(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-update-user-email")
 	request, err := MapRequestToUpdateUserEmailRequest(r, h.CookiePrefixAuthToken, h.CookiePrefixRefreshToken, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -92,6 +94,7 @@ func (h *Handler) UpdateUserEmail(w http.ResponseWriter, r *http.Request) {
 	signOutRequired, err := h.Service.UpdateUserEmail(r.Context(), request)
 	if err != nil && !signOutRequired {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -100,6 +103,7 @@ func (h *Handler) UpdateUserEmail(w http.ResponseWriter, r *http.Request) {
 		h.RemoveCookiesWithName(w, common.AccessTokenAuthInfoCookieName)
 		h.RemoveCookiesWithName(w, common.RefreshTokenAuthInfoCookieName)
 
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -118,10 +122,12 @@ func (h *Handler) UpdateUserEmail(w http.ResponseWriter, r *http.Request) {
 
 // LogoutUserOthers handles logging out all other sessions for a user
 func (h *Handler) LogoutUserOthers(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-logout-user-others")
 
 	request, err := MapRequestToLogoutUserOthersRequest(r, h.Validator, h.CookiePrefixAuthToken, h.CookiePrefixRefreshToken)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -129,6 +135,7 @@ func (h *Handler) LogoutUserOthers(w http.ResponseWriter, r *http.Request) {
 	err = h.Service.LogoutUserOthers(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -140,10 +147,12 @@ func (h *Handler) LogoutUserOthers(w http.ResponseWriter, r *http.Request) {
 // OauthCallback returns a redirect to the respective providers login page
 // TODO: Create tests
 func (h *Handler) OauthLogin(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-oauth-login")
 
 	request, err := MapRequestToOauthLoginRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -151,6 +160,7 @@ func (h *Handler) OauthLogin(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.OauthLogin(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -184,10 +194,12 @@ func (h *Handler) OauthLogin(w http.ResponseWriter, r *http.Request) {
 // request is valid
 // TODO: Create tests
 func (h *Handler) OauthCallback(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-oauth-callback")
 
 	request, err := MapRequestToOauthCallbackRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -200,6 +212,7 @@ func (h *Handler) OauthCallback(w http.ResponseWriter, r *http.Request) {
 		}
 
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -221,10 +234,12 @@ func (h *Handler) OauthCallback(w http.ResponseWriter, r *http.Request) {
 // User requesting must be active & be the same person as target
 // TODO: Create tests
 func (h *Handler) GetUserAPITokenThreshold(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-get-user-api-token-threshold")
 
 	request, err := MapRequestToGetUserAPITokenThresholdRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -232,6 +247,7 @@ func (h *Handler) GetUserAPITokenThreshold(w http.ResponseWriter, r *http.Reques
 	userTokenThreshold, err := h.Service.GetUserAPITokenThreshold(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -244,10 +260,12 @@ func (h *Handler) GetUserAPITokenThreshold(w http.ResponseWriter, r *http.Reques
 // User requesting must be active & be the same person as target
 // TODO: Create tests
 func (h *Handler) GetSpecificUserAPITokens(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-get-specific-user-api-tokens")
 
 	request, err := MapRequestToGetSpecificUserAPITokensRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -255,6 +273,7 @@ func (h *Handler) GetSpecificUserAPITokens(w http.ResponseWriter, r *http.Reques
 	response, err := h.Service.GetSpecificUserAPITokens(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -273,9 +292,11 @@ func (h *Handler) GetSpecificUserAPITokens(w http.ResponseWriter, r *http.Reques
 // User requesting must be active and must be the same person as target.
 // TODO: Create tests
 func (h *Handler) RevokeUserAPIToken(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-revoke-user-api-token")
 	request, err := MapRequestToRevokeUserAPITokenRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -283,6 +304,7 @@ func (h *Handler) RevokeUserAPIToken(w http.ResponseWriter, r *http.Request) {
 	err = h.Service.UpdateUserAPITokenStatus(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -295,10 +317,12 @@ func (h *Handler) RevokeUserAPIToken(w http.ResponseWriter, r *http.Request) {
 // User requesting must be active and must be the same person as target.
 // TODO: Create tests
 func (h *Handler) ActivateUserAPIToken(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-activate-user-api-token")
 
 	request, err := MapRequestToActivateUserAPITokenRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -306,6 +330,7 @@ func (h *Handler) ActivateUserAPIToken(w http.ResponseWriter, r *http.Request) {
 	err = h.Service.UpdateUserAPITokenStatus(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -318,10 +343,12 @@ func (h *Handler) ActivateUserAPIToken(w http.ResponseWriter, r *http.Request) {
 // User requesting must be active and must be the same person as target.
 // TODO: Create tests
 func (h *Handler) DeleteUserAPIToken(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-delete-user-api-token")
 
 	request, err := MapRequestToDeleteUserAPITokenRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -329,6 +356,7 @@ func (h *Handler) DeleteUserAPIToken(w http.ResponseWriter, r *http.Request) {
 	err = h.Service.DeleteUserAPIToken(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -341,10 +369,12 @@ func (h *Handler) DeleteUserAPIToken(w http.ResponseWriter, r *http.Request) {
 // User requesting must be active & be the same person as target
 // TODO: Create tests
 func (h *Handler) CreateUserAPIToken(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-create-user-api-token")
 
 	request, err := MapRequestToCreateUserAPITokenRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -352,6 +382,7 @@ func (h *Handler) CreateUserAPIToken(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.CreateUserAPIToken(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -364,8 +395,7 @@ func (h *Handler) CreateUserAPIToken(w http.ResponseWriter, r *http.Request) {
 // LogoutUser returns reponse from user logout request.
 // TODO: Create tests
 func (h *Handler) LogoutUser(w http.ResponseWriter, r *http.Request) {
-
-	log := logger.AcquireFrom(r.Context())
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-logout-user")
 
 	// Check if there is a refresh token cookie
 	// although it should be there, there is no guarantee that it will be
@@ -373,10 +403,10 @@ func (h *Handler) LogoutUser(w http.ResponseWriter, r *http.Request) {
 	refreshTokenCookie, _ := r.Cookie(h.CookiePrefixRefreshToken)
 	if refreshTokenCookie != nil {
 
-		log.Info("refresh-token-cookie-found-while-logging-out-will-be-removed")
+		logger.Info("refresh-token-cookie-found-while-logging-out-will-be-removed")
 		_, _, err := h.Service.RemoveRefreshTokenWithCookieValue(r.Context(), refreshTokenCookie.Value)
 		if err != nil {
-			log.Warn("failed-to-remove-refresh-token-from-store-during-logout", zap.Error(err))
+			logger.Warn("failed-to-remove-refresh-token-from-store-during-logout", zap.Error(err))
 		}
 	}
 
@@ -390,6 +420,7 @@ func (h *Handler) LogoutUser(w http.ResponseWriter, r *http.Request) {
 		if ok := redirectToHomeIfPlatformHeaderDetected(w, r); ok {
 			return
 		}
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -417,6 +448,7 @@ func (h *Handler) LogoutUser(w http.ResponseWriter, r *http.Request) {
 	err = h.Service.LogoutUser(r.Context(), r)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -431,6 +463,7 @@ func (h *Handler) LogoutUser(w http.ResponseWriter, r *http.Request) {
 // RefreshToken returns reponse from user's request to refresh their token
 // TODO: Create tests
 func (h *Handler) RefreshToken(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-refresh-token")
 
 	request, err := MapRequestToRefreshTokenRequest(r, h.CookiePrefixRefreshToken, h.CookiePrefixAuthToken, h.Validator)
 	if err != nil {
@@ -439,6 +472,7 @@ func (h *Handler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 		h.RemoveCookiesWithName(w, common.RefreshTokenAuthInfoCookieName)
 
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -450,6 +484,7 @@ func (h *Handler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 		h.RemoveCookiesWithName(w, common.RefreshTokenAuthInfoCookieName)
 
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -466,10 +501,12 @@ func (h *Handler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 // access and refresh token
 // TODO: Create tests
 func (h *Handler) LoginUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-login-user")
 
 	request, err := MapRequestToLoginUserRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -477,6 +514,7 @@ func (h *Handler) LoginUser(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.LoginUser(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -502,10 +540,12 @@ func (h *Handler) LoginUser(w http.ResponseWriter, r *http.Request) {
 // Should always return 202 unless mapping request fails. (makes bad actors finding out users on platform harder)
 // TODO: Create tests
 func (h *Handler) CreateInitalLoginOrVerificationTokenEmail(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-create-initial-login-or-verification-token-email")
 
 	request, err := MapRequestToCreateInitalLoginOrVerificationTokenEmailRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -513,6 +553,7 @@ func (h *Handler) CreateInitalLoginOrVerificationTokenEmail(w http.ResponseWrite
 	err = h.Service.CreateInitalLoginOrVerificationTokenEmail(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-accepted-after-error", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPBlankResponse(w, http.StatusAccepted)
 		return
 	}
@@ -524,10 +565,12 @@ func (h *Handler) CreateInitalLoginOrVerificationTokenEmail(w http.ResponseWrite
 // CreateUser returns reponse from user creation
 // TODO: Create tests
 func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-create-user")
 
 	request, err := MapRequestToCreateUserRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -535,6 +578,7 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.CreateUser(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -548,10 +592,12 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 // returned a pair of access and refresh tokens
 // TODO: Create tests
 func (h *Handler) ValidateEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/accessmanager", "handle-validate-email-verification-code")
 
 	request, err := MapRequestToValidateEmailVerificationCodeRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -559,6 +605,7 @@ func (h *Handler) ValidateEmailVerificationCode(w http.ResponseWriter, r *http.R
 	revisions, err := h.Service.ValidateEmailVerificationCode(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/accessmanager/helpers/code.go
+++ b/external/accessmanager/helpers/code.go
@@ -51,14 +51,14 @@ func GenerateUniqueCode(ctx context.Context, store CodeStore, ttl time.Duration)
 
 		exists, err := store.CodeExists(ctx, code)
 		if err != nil {
-			logger.Error("failed-to-check-code-existence", zap.String("code", code), zap.Error(err))
+			logger.Error("failed-to-check-code-existence", zap.Int("attempt", attempt), zap.Bool("code-present", code != ""), zap.Int("code-length", len(code)), zap.Error(err))
 			return "", ErrCodeGenerationFailure
 		}
 
 		if !exists {
 			err = store.StoreCode(ctx, code, ttl)
 			if err != nil {
-				logger.Error("failed-to-store-code", zap.String("code", code), zap.Error(err))
+				logger.Error("failed-to-store-code", zap.Int("attempt", attempt), zap.Bool("code-present", code != ""), zap.Int("code-length", len(code)), zap.Error(err))
 				return "", ErrCodeGenerationFailure
 			}
 

--- a/external/accessmanager/helpers/code.go
+++ b/external/accessmanager/helpers/code.go
@@ -40,37 +40,35 @@ type CodeStore interface {
 // retries with a new code if a collision is detected.
 func GenerateUniqueCode(ctx context.Context, store CodeStore, ttl time.Duration) (string, error) {
 
-	log := logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	logger := logger.AcquirePackageFrom(ctx, "external/accessmanager/helpers")
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		code, err := generateRandomCode()
 		if err != nil {
-			log.Error("amh/failed-to-generate-random-code", zap.Int("attempt", attempt), zap.Error(err))
+			logger.Error("failed-to-generate-random-code", zap.Int("attempt", attempt), zap.Error(err))
 			return "", err
 		}
 
 		exists, err := store.CodeExists(ctx, code)
 		if err != nil {
-			log.Error("amh/failed-to-check-code-existence", zap.String("code", code), zap.Error(err))
+			logger.Error("failed-to-check-code-existence", zap.String("code", code), zap.Error(err))
 			return "", ErrCodeGenerationFailure
 		}
 
 		if !exists {
 			err = store.StoreCode(ctx, code, ttl)
 			if err != nil {
-				log.Error("amh/failed-to-store-code", zap.String("code", code), zap.Error(err))
+				logger.Error("failed-to-store-code", zap.String("code", code), zap.Error(err))
 				return "", ErrCodeGenerationFailure
 			}
 
 			return code, nil
 		}
 
-		log.Warn("amh/code-collision-detected-retrying", zap.Int("attempt", attempt))
+		logger.Warn("code-collision-detected-retrying", zap.Int("attempt", attempt))
 	}
 
-	log.Error("amh/exceeded-max-code-generation-retries", zap.Int("max-retries", maxRetries))
+	logger.Error("exceeded-max-code-generation-retries", zap.Int("max-retries", maxRetries))
 	return "", ErrCodeGenerationFailure
 }
 

--- a/external/accessmanager/logging.go
+++ b/external/accessmanager/logging.go
@@ -1,0 +1,31 @@
+package accessmanager
+
+import (
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
+)
+
+func emailLogFields(prefix, value string) []zap.Field {
+	return []zap.Field{
+		zap.Bool(prefix+"-present", logger.EmailPresentForLog(value)),
+		zap.String(prefix+"-domain", logger.EmailDomainForLog(value)),
+	}
+}
+
+func verificationCodeLogFields(code string) []zap.Field {
+	trimmed := strings.TrimSpace(code)
+	return []zap.Field{
+		zap.Bool("code-present", trimmed != ""),
+		zap.Int("code-length", len(trimmed)),
+	}
+}
+
+func requestURLLogFields(value string) []zap.Field {
+	trimmed := strings.TrimSpace(value)
+	return []zap.Field{
+		zap.Bool("request-url-present", trimmed != ""),
+		zap.Int("request-url-length", len(trimmed)),
+	}
+}

--- a/external/accessmanager/middleware/hardened_rate_limit.go
+++ b/external/accessmanager/middleware/hardened_rate_limit.go
@@ -81,15 +81,13 @@ func (h *HardenedRateLimitProtection) Middleware() mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-			log := logger.AcquireFrom(r.Context()).WithOptions(
-				zap.AddStacktrace(zap.DPanicLevel),
-			)
+			logger := logger.AcquirePackageFrom(r.Context(), "external/accessmanager/middleware")
 
 			clientIP := getValidClientIP(r)
 
 			blocked, err := h.ephemeralStore.IsIPBlocked(r.Context(), clientIP)
 			if err != nil {
-				log.Error("hrl/failed-to-check-ip-block-status",
+				logger.Error("failed-to-check-ip-block-status",
 					zap.String("client-ip", clientIP),
 					zap.Error(err),
 				)
@@ -98,7 +96,7 @@ func (h *HardenedRateLimitProtection) Middleware() mux.MiddlewareFunc {
 			}
 
 			if blocked {
-				log.Warn("hrl/blocked-ip-attempted-verification",
+				logger.Warn("blocked-ip-attempted-verification",
 					zap.String("client-ip", clientIP),
 				)
 
@@ -110,7 +108,7 @@ func (h *HardenedRateLimitProtection) Middleware() mux.MiddlewareFunc {
 
 			err = h.ephemeralStore.TrackHardenedAttempt(r.Context(), clientIP, code, h.maxAttempts, h.windowDuration)
 			if err != nil {
-				log.Warn("hrl/rate-limit-exceeded-blocking-ip",
+				logger.Warn("rate-limit-exceeded-blocking-ip",
 					zap.String("client-ip", clientIP),
 					zap.String("code", code),
 					zap.Int("max-attempts", h.maxAttempts),
@@ -119,7 +117,7 @@ func (h *HardenedRateLimitProtection) Middleware() mux.MiddlewareFunc {
 
 				blockErr := h.ephemeralStore.BlockIP(r.Context(), clientIP, h.blockDuration)
 				if blockErr != nil {
-					log.Error("hrl/failed-to-block-ip-after-rate-limit-exceeded",
+					logger.Error("failed-to-block-ip-after-rate-limit-exceeded",
 						zap.String("client-ip", clientIP),
 						zap.Error(blockErr),
 					)
@@ -129,7 +127,7 @@ func (h *HardenedRateLimitProtection) Middleware() mux.MiddlewareFunc {
 				return
 			}
 
-			log.Info("hrl/verification-attempt",
+			logger.Info("verification-attempt",
 				zap.String("client-ip", clientIP),
 				zap.String("code", code),
 			)

--- a/external/accessmanager/middleware/hardened_rate_limit.go
+++ b/external/accessmanager/middleware/hardened_rate_limit.go
@@ -110,7 +110,8 @@ func (h *HardenedRateLimitProtection) Middleware() mux.MiddlewareFunc {
 			if err != nil {
 				logger.Warn("rate-limit-exceeded-blocking-ip",
 					zap.String("client-ip", clientIP),
-					zap.String("code", code),
+					zap.Bool("code-present", code != ""),
+					zap.Int("code-length", len(code)),
 					zap.Int("max-attempts", h.maxAttempts),
 					zap.Error(err),
 				)
@@ -129,7 +130,8 @@ func (h *HardenedRateLimitProtection) Middleware() mux.MiddlewareFunc {
 
 			logger.Info("verification-attempt",
 				zap.String("client-ip", clientIP),
-				zap.String("code", code),
+				zap.Bool("code-present", code != ""),
+				zap.Int("code-length", len(code)),
 			)
 
 			next.ServeHTTP(w, r)

--- a/external/accessmanager/service.go
+++ b/external/accessmanager/service.go
@@ -221,9 +221,7 @@ func (s *Service) WithGroupService(groupService GroupService) *Service {
 func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest) (bool, error) {
 
 	var (
-		log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 		// whether a change has taken place in this method which means that the user needs to be
 		// signed off of the client they are currently using to make the request
@@ -239,14 +237,14 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 			ID: r.UserId,
 		})
 		if err != nil {
-			log.Error("ams/failed-to-get-requesting-user-by-id", zap.Error(err))
+			logger.Error("failed-to-get-requesting-user-by-id", zap.Error(err))
 			return signUserOutOfPlatform, err
 		}
 
 		requestingUser = userByIdResponse.User
 
 		if !requestingUser.IsAdmin() {
-			log.Warn("ams/non-admin-user-attempted-to-update-another-user-email", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
+			logger.Warn("non-admin-user-attempted-to-update-another-user-email", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
 			return signUserOutOfPlatform, ErrForbiddenUnableToAction
 		}
 	}
@@ -256,7 +254,7 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 		ID: r.TargetUserId,
 	})
 	if err != nil {
-		log.Error("ams/failed-to-get-target-user-by-id", zap.Error(err))
+		logger.Error("failed-to-get-target-user-by-id", zap.Error(err))
 		return signUserOutOfPlatform, err
 	}
 
@@ -267,7 +265,7 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 	standardiseExistingEmail := toolbox.StringStandardisedToLower(targetUser.GetUserEmail())
 	standardiseNewEmail := toolbox.StringStandardisedToLower(r.Email)
 	if standardiseExistingEmail == standardiseNewEmail {
-		log.Warn("ams/user-attempted-to-update-email-to-same-email", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
+		logger.Warn("user-attempted-to-update-email-to-same-email", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
 		return signUserOutOfPlatform, ErrConflictingUserState
 	}
 
@@ -276,11 +274,11 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 		Email: r.Email,
 	})
 	if newEmailInUseErr != nil && !errors.Is(newEmailInUseErr, userv2.ErrUserNotFound) {
-		log.Error("ams/failed-to-verify-whether-new-email-already-in-use", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(err))
+		logger.Error("failed-to-verify-whether-new-email-already-in-use", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(err))
 		return signUserOutOfPlatform, newEmailInUseErr
 	}
 	if newEmailInUseErr == nil {
-		log.Warn("ams/new-email-already-in-use", zap.String("existing-user-id", userByEmailResponse.User.ID), zap.String("target-user-id", r.TargetUserId), zap.String("user-id", r.UserId))
+		logger.Warn("new-email-already-in-use", zap.String("existing-user-id", userByEmailResponse.User.ID), zap.String("target-user-id", r.TargetUserId), zap.String("user-id", r.UserId))
 		return signUserOutOfPlatform, ErrConflictingUserState
 	}
 
@@ -299,7 +297,7 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 		RecipientType: string(audit.User),
 	})
 	if err != nil {
-		log.Error("ams/unable-to-send-change-of-email-request-notification-email-for-to-old-email:", zap.String("user-id", r.TargetUserId))
+		logger.Error("unable-to-send-change-of-email-request-notification-email-for-to-old-email:", zap.String("user-id", r.TargetUserId))
 		return signUserOutOfPlatform, err
 	}
 
@@ -307,7 +305,7 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 	// and unverify the email on the account
 	_, err = targetUser.UpdateStatus(userv2.AccountStatusValidOriginKeyEmailChange)
 	if err != nil {
-		log.Warn("ams/unable-to-update-status-of-user-to-provisioned-after-email-change", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(err))
+		logger.Warn("unable-to-update-status-of-user-to-provisioned-after-email-change", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(err))
 		return signUserOutOfPlatform, ErrConflictingUserState
 	}
 
@@ -320,7 +318,7 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 		User: targetUser,
 	})
 	if err != nil {
-		log.Error("ams/failed-to-update-user-with-new-email", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(err))
+		logger.Error("failed-to-update-user-with-new-email", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(err))
 		return signUserOutOfPlatform, err
 	}
 
@@ -335,29 +333,29 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 		AuthToken:    r.AuthToken,
 	})
 	if wipeOldSessionsErr != nil {
-		log.Error("ams/failed-to-logout-users-other-sessions-for-email-change-request", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(wipeOldSessionsErr))
+		logger.Error("failed-to-logout-users-other-sessions-for-email-change-request", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(wipeOldSessionsErr))
 	}
 	if wipeOldSessionsErr == nil {
-		log.Info("ams/logged-out-users-other-sessions-for-email-change-request", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
+		logger.Info("logged-out-users-other-sessions-for-email-change-request", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
 	}
 
 	// log out of the current session (ignore errors)
 	logOutCurrentSessionErr := s.LogoutUser(ctx, r.Request)
 	if logOutCurrentSessionErr != nil {
-		log.Error("ams/failed-to-logout-user-current-sessions-for-email-change-request", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(logOutCurrentSessionErr))
+		logger.Error("failed-to-logout-user-current-sessions-for-email-change-request", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.Error(logOutCurrentSessionErr))
 	}
 	if logOutCurrentSessionErr == nil {
-		log.Info("ams/logged-out-user-current-sessions-for-email-change-request", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
+		logger.Info("logged-out-user-current-sessions-for-email-change-request", zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId))
 	}
 
 	// send a verification email to the new email address
-	log.Info(fmt.Sprintf("ams/initiate-verification-email-for-user-with-changed-email: %s", targetUser.ID))
+	logger.Info("initiate-verification-email-for-user-with-changed-email", zap.String("user-id", targetUser.ID))
 	_, err = s.CreateEmailVerificationToken(ctx, &CreateEmailVerificationTokenRequest{
 		User:       targetUser,
 		RequestUrl: "",
 	})
 	if err != nil {
-		log.Error(fmt.Sprintf("ams/error-failed-to-initiate-verification-email-for-user-with-changed-emai: %s", targetUser.ID))
+		logger.Error("failed-to-initiate-verification-email-for-user-with-changed-email", zap.String("user-id", targetUser.ID), zap.Error(err))
 		return signUserOutOfPlatform, err
 	}
 
@@ -375,7 +373,7 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 	})
 
 	if auditErr != nil {
-		log.Warn("ams/failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.String("event-type", string(auditEvent)))
+		logger.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", r.UserId), zap.String("target-user-id", r.TargetUserId), zap.String("event-type", string(auditEvent)))
 	}
 
 	return signUserOutOfPlatform, nil
@@ -383,6 +381,8 @@ func (s *Service) UpdateUserEmail(ctx context.Context, r *UpdateUserEmailRequest
 
 // LogoutUserOthers handles logic of managing the user's other log in session
 func (s *Service) LogoutUserOthers(ctx context.Context, r *LogoutUserOthersRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "logout-user-others")
+	logger.Debug("handling-logout-user-others-request")
 
 	var accessTokenId string
 	var refreshTokenId string
@@ -418,19 +418,17 @@ func (s *Service) LogoutUserOthers(ctx context.Context, r *LogoutUserOthersReque
 // OauthCallback handles logic of managing the callback of a provider
 func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*OauthCallbackResponse, error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	if len(s.OauthServices) == 0 {
-		log.Error("no-oauth-provider-passed-to-access-manager-but-oauth-callback-requested", zap.String("requested-provider", r.Provider))
+		logger.Error("no-oauth-provider-passed-to-access-manager-but-oauth-callback-requested", zap.String("requested-provider", r.Provider))
 		return nil, ErrNoOauthProvidersDetected
 	}
 
 	for _, provider := range s.OauthServices {
 
 		if r.Provider != provider.ProviderGetName() {
-			log.Info("skipping-oauth-provider-does-not-match-requested", zap.String("requested-provider", r.Provider), zap.String("sourced-provider", provider.ProviderGetName()))
+			logger.Info("skipping-oauth-provider-does-not-match-requested", zap.String("requested-provider", r.Provider), zap.String("sourced-provider", provider.ProviderGetName()))
 			continue
 		}
 
@@ -469,7 +467,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 
 			decoded64RequestUrl, err := base64.StdEncoding.DecodeString(splitProtectionStateTokenCookieValue[1])
 			if err != nil {
-				log.Warn("failed-to-decode-detected-request-url-uri-for-sso-callback", zap.String("encoded-request-url", splitProtectionStateTokenCookieValue[1]))
+				logger.Warn("failed-to-decode-detected-request-url-uri-for-sso-callback", zap.String("encoded-request-url", splitProtectionStateTokenCookieValue[1]))
 			}
 
 			if err == nil && string(decoded64RequestUrl) != "" {
@@ -512,7 +510,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 			// If user is verified by provider but not our platform, we should trust provider
 			if !persistentUser.Verification.EmailVerified && providerUserInfo.IsUserEmailVerifiedByProvider() {
 
-				log.Info("provider-login-user-email-verified-based-on-provider-records", zap.String("user-id", persistentUser.ID))
+				logger.Info("provider-login-user-email-verified-based-on-provider-records", zap.String("user-id", persistentUser.ID))
 				persistentUser.VerifyEmail()
 			}
 
@@ -520,7 +518,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 				User: persistentUser,
 			})
 			if err != nil {
-				log.Error("provider-login-user-update-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
+				logger.Error("provider-login-user-update-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
 				return &OauthCallbackResponse{
 					ProviderStateCookieKey: providerCookieKey,
 				}, err
@@ -528,7 +526,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 
 			err = s.EphemeralStore.CreateAuth(ctx, UpdateUserResponse.User.ID, tokenDetails)
 			if err != nil {
-				log.Error("provider-login-ephemeral-store-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
+				logger.Error("provider-login-ephemeral-store-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
 				return &OauthCallbackResponse{
 					ProviderStateCookieKey: providerCookieKey,
 				}, err
@@ -548,7 +546,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 			})
 
 			if auditErr != nil {
-				log.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", persistentUser.ID), zap.String("event-type", string(auditEvent)))
+				logger.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", persistentUser.ID), zap.String("event-type", string(auditEvent)))
 			}
 
 			return &OauthCallbackResponse{
@@ -568,7 +566,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 				Email:                    providerUserInfo.GetUserEmail(),
 			})
 			if err != nil {
-				log.Error("provider-signup-user-creation-failed-after-successful-login-initiation", zap.String("user-email:", providerUserInfo.GetUserEmail()))
+				logger.Error("provider-signup-user-creation-failed-after-successful-login-initiation", zap.String("user-email:", providerUserInfo.GetUserEmail()))
 				return &OauthCallbackResponse{
 					ProviderStateCookieKey: providerCookieKey,
 				}, err
@@ -577,7 +575,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 			// If user is verified by provider but not our platform, we should trust provider
 			if !newUserResp.User.Verification.EmailVerified && providerUserInfo.IsUserEmailVerifiedByProvider() {
 
-				log.Info("provider-signup-user-email-verified-based-on-provider-records", zap.String("user-id", newUserResp.User.ID))
+				logger.Info("provider-signup-user-email-verified-based-on-provider-records", zap.String("user-id", newUserResp.User.ID))
 				newUserResp.User.VerifyEmail()
 
 				// Update user with verification information
@@ -585,10 +583,10 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 					User: newUserResp.User,
 				})
 				if err != nil {
-					log.Error(fmt.Sprintf("ams/error-failed-to-save-new-user-verficaiton-by-provider: %s", newUserResp.User.ID))
+					logger.Error("failed-to-save-new-user-verification-by-provider", zap.String("user-id", newUserResp.User.ID), zap.Error(err))
+				} else {
+					logger.Info("successfully-saved-new-user-verification-by-provider", zap.String("user-id", updatedUser.User.ID))
 				}
-
-				log.Info(fmt.Sprintf("ams/successfully-saved-new-user-verficaiton-by-provider: %s", updatedUser.User.ID))
 
 			}
 
@@ -606,10 +604,10 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 			})
 
 			if auditErr != nil {
-				log.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", newUserResp.User.ID), zap.String("event-type", string(auditEvent)))
+				logger.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", newUserResp.User.ID), zap.String("event-type", string(auditEvent)))
 			}
 
-			log.Info(fmt.Sprintf("ams/initiate-new-user-tokens: %s", newUserResp.User.ID))
+			logger.Info("initiate-new-user-tokens", zap.String("user-id", newUserResp.User.ID))
 
 			accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, err := s.UserEmailVerificationRevisions(ctx, &UserEmailVerificationRevisionsRequest{
 				UserID: newUserResp.User.ID})
@@ -631,7 +629,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 			})
 
 			if auditErr != nil {
-				log.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", newUserResp.User.ID), zap.String("event-type", string(auditEvent)))
+				logger.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", newUserResp.User.ID), zap.String("event-type", string(auditEvent)))
 			}
 
 			return &OauthCallbackResponse{
@@ -652,19 +650,17 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 // OauthLogin handles logic of managing the initialisation of provider url
 func (s *Service) OauthLogin(ctx context.Context, r *OauthLoginRequest) (*OauthLoginResponse, error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	if len(s.OauthServices) == 0 {
-		log.Error("no-oauth-provider-passed-to-access-manager-but-oauth-login-requested", zap.String("requested-provider", r.Provider))
+		logger.Error("no-oauth-provider-passed-to-access-manager-but-oauth-login-requested", zap.String("requested-provider", r.Provider))
 		return nil, ErrNoOauthProvidersDetected
 	}
 
 	for _, provider := range s.OauthServices {
 
 		if r.Provider != provider.ProviderGetName() {
-			log.Info("skipping-oauth-provider-does-not-match-requested", zap.String("requested-provider", r.Provider), zap.String("sourced-provider", provider.ProviderGetName()))
+			logger.Info("skipping-oauth-provider-does-not-match-requested", zap.String("requested-provider", r.Provider), zap.String("sourced-provider", provider.ProviderGetName()))
 			continue
 		}
 
@@ -700,6 +696,8 @@ func (s *Service) OauthLogin(ctx context.Context, r *OauthLoginRequest) (*OauthL
 // GetSpecificUserAPITokens retrieves API token for a specific user
 // TODO: Create tests
 func (s *Service) GetSpecificUserAPITokens(ctx context.Context, r *GetSpecificUserAPITokensRequest) (*GetSpecificUserAPITokensResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "get-specific-user-api-tokens")
+	logger.Debug("handling-get-specific-user-api-tokens-request")
 
 	userApiTokenResponse, err := s.ApitokenService.GetAPITokensFor(ctx, &apitoken.GetAPITokensForRequest{
 		ID:            r.UserID,
@@ -727,6 +725,8 @@ func (s *Service) GetSpecificUserAPITokens(ctx context.Context, r *GetSpecificUs
 
 // GetUserAPITokenThreshold retrieves the thresholds applied to the user r. API tokens
 func (s *Service) GetUserAPITokenThreshold(ctx context.Context, r *GetUserAPITokenThresholdRequest) (*GetUserAPITokenThresholdResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "get-user-api-token-threshold")
+	logger.Debug("handling-get-user-api-token-threshold-request")
 
 	// Check if user exist
 	userResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{
@@ -755,6 +755,9 @@ func (s *Service) GetUserAPITokenThreshold(ctx context.Context, r *GetUserAPITok
 // UpdateUserAPITokenStatus updates status on specified API token
 // TODO: Create tests
 func (s *Service) UpdateUserAPITokenStatus(ctx context.Context, r *UserAPITokenStatusRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "update-user-api-token-status")
+	logger.Debug("handling-update-user-api-token-status-request")
+
 	switch r.Status {
 	case apitoken.UserTokenStatusKeyActive:
 		return s.ApitokenService.ActivateAPIToken(ctx, &apitoken.ActivateAPITokenRequest{
@@ -769,6 +772,9 @@ func (s *Service) UpdateUserAPITokenStatus(ctx context.Context, r *UserAPITokenS
 // DeleteUserAPIToken delete specified API token for user
 // TODO: Create tests
 func (s *Service) DeleteUserAPIToken(ctx context.Context, r *DeleteUserAPITokenRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "delete-user-api-token")
+	logger.Debug("handling-delete-user-api-token-request")
+
 	// Check if user exist
 	_, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{
 		ID: r.UserID,
@@ -809,9 +815,7 @@ func (s *Service) DeleteUserAPIToken(ctx context.Context, r *DeleteUserAPITokenR
 // CreateUserAPIToken generates API token for user
 // TODO: Create tests
 func (s *Service) CreateUserAPIToken(ctx context.Context, r *CreateUserAPITokenRequest) (*CreateUserAPITokenResponse, error) {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	// Check if user exist
 	userResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{
@@ -827,7 +831,7 @@ func (s *Service) CreateUserAPIToken(ctx context.Context, r *CreateUserAPITokenR
 	userHighestRankingRole := common.GetUsersHighestRankedRole(persistentUser.Roles)
 	getUserRoleThresholdAllocation := common.UserRolesThresholds.RolesDetails[common.UserRole(userHighestRankingRole)]
 	if !toolbox.StringInSlice(userHighestRankingRole, persistentUser.Roles) {
-		log.Error("highest-role-pulled-is-not-found-in-user-allocated-role", zap.String("user-id", persistentUser.ID), zap.String("role-pulled", userHighestRankingRole), zap.String("user-roles", strings.Join(persistentUser.Roles, ", ")))
+		logger.Error("highest-role-pulled-is-not-found-in-user-allocated-role", zap.String("user-id", persistentUser.ID), zap.String("role-pulled", userHighestRankingRole), zap.String("user-roles", strings.Join(persistentUser.Roles, ", ")))
 	}
 
 	// get user's apitokens count
@@ -871,26 +875,24 @@ func (s *Service) CreateUserAPIToken(ctx context.Context, r *CreateUserAPITokenR
 // allocated thresholds
 func (s *Service) verifyRequestIsWithinUserRoleTokenConstraints(ctx context.Context, userId string, tokenTtl int64, userRoleThresholds *common.UserRoleThresholds) error {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	if tokenTtl == 0 {
 		return nil
 	}
 
 	if tokenTtl < userRoleThresholds.ShortLivedMinimumAllowedTime {
-		log.Error("failed-to-create-user-ephemeral-token", zap.String("failure-reason", "ttl-too-short"), zap.String("user-id", userId), zap.Int64("requested-ttl", tokenTtl), zap.Int64("user-role-rank", userRoleThresholds.Ranking))
+		logger.Error("failed-to-create-user-ephemeral-token", zap.String("failure-reason", "ttl-too-short"), zap.String("user-id", userId), zap.Int64("requested-ttl", tokenTtl), zap.Int64("user-role-rank", userRoleThresholds.Ranking))
 		return ErrCreateUserAPITokenRequestTtlTooShort
 	}
 
 	if tokenTtl > userRoleThresholds.ShortLivedMaximumAllowedTime {
-		log.Error("failed-to-create-user-ephemeral-token", zap.String("failure-reason", "ttl-too-long"), zap.String("user-id", userId), zap.Int64("requested-ttl", tokenTtl), zap.Int64("user-role-rank", userRoleThresholds.Ranking))
+		logger.Error("failed-to-create-user-ephemeral-token", zap.String("failure-reason", "ttl-too-long"), zap.String("user-id", userId), zap.Int64("requested-ttl", tokenTtl), zap.Int64("user-role-rank", userRoleThresholds.Ranking))
 		return ErrCreateUserAPITokenRequestTtlTooLong
 	}
 
 	if tokenTtl%userRoleThresholds.ShortLivedMinimumIncrements != 0 {
-		log.Error("failed-to-create-user-ephemeral-token", zap.String("failure-reason", "ttl-outside-allowed-increment"), zap.String("user-id", userId), zap.Int64("requested-ttl", tokenTtl), zap.Int64("user-role-rank", userRoleThresholds.Ranking))
+		logger.Error("failed-to-create-user-ephemeral-token", zap.String("failure-reason", "ttl-outside-allowed-increment"), zap.String("user-id", userId), zap.Int64("requested-ttl", tokenTtl), zap.Int64("user-role-rank", userRoleThresholds.Ranking))
 		return ErrCreateUserAPITokenRequestTtlOutsideAllowedIncrement
 	}
 
@@ -904,9 +906,7 @@ func (s *Service) getUserApiTokensCountByType(ctx context.Context, userId string
 	var (
 		userPermanentToken int
 		userEphemeralToken int
-		log                *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger             *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 	)
 
 	// get user api tokens
@@ -917,7 +917,7 @@ func (s *Service) getUserApiTokensCountByType(ctx context.Context, userId string
 	})
 
 	if err != nil {
-		log.Error("error-fetching-user-auth-tokens", zap.Error(err))
+		logger.Error("error-fetching-user-auth-tokens", zap.Error(err))
 		return 0, 0, err
 	}
 
@@ -1103,6 +1103,9 @@ func (s *Service) MiddlewareRateLimitOrActiveJWTRequired(r *http.Request) (*Midd
 // checkActivenessOfUser verifies that the user account is currently in an ACTIVE status.
 // Returns the user ID if active, otherwise returns an error.
 func (s *Service) checkActivenessOfUser(ctx context.Context, tokenAuth *auth.TokenAccessDetails) (*MiddlewareAuthedUserResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "check-activeness-of-user")
+	logger.Debug("handling-check-activeness-of-user-request")
+
 	user, isActiveUser := s.isUserLiveStatusActive(ctx, tokenAuth.UserID)
 	if !isActiveUser {
 		return nil, ErrUnauthorizedNonActiveStatus
@@ -1118,9 +1121,7 @@ func (s *Service) checkActivenessOfUser(ctx context.Context, tokenAuth *auth.Tok
 // TODO: Investigate best way to also delete corresponding refresh token
 // TODO: Create tests
 func (s *Service) LogoutUser(ctx context.Context, r *http.Request) error {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	accessTokenDetails, err := s.AuthService.ExtractTokenMetadata(ctx, r)
 	if err != nil {
@@ -1129,12 +1130,12 @@ func (s *Service) LogoutUser(ctx context.Context, r *http.Request) error {
 
 	deleted, err := s.DeleteAuth(ctx, toolbox.CombinedUuidFormat(accessTokenDetails.UserID, accessTokenDetails.AccessUUID))
 	if err != nil {
-		log.Error("ephemeral-delete-failed-after-successful-access-token-retrival", zap.String("user-id:", accessTokenDetails.UserID), zap.Error(err))
+		logger.Error("ephemeral-delete-failed-after-successful-access-token-retrival", zap.String("user-id:", accessTokenDetails.UserID), zap.Error(err))
 		return err
 	}
 
 	if deleted == 0 {
-		log.Error("ephemeral-delete-failed-after-successful-access-token-retrival", zap.String("user-id:", accessTokenDetails.UserID))
+		logger.Error("ephemeral-delete-failed-after-successful-access-token-retrival", zap.String("user-id:", accessTokenDetails.UserID))
 		return ErrUnauthorizedAccessTokenCacheDeletionFailure
 	}
 
@@ -1150,7 +1151,7 @@ func (s *Service) LogoutUser(ctx context.Context, r *http.Request) error {
 	})
 
 	if auditErr != nil {
-		log.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", accessTokenDetails.UserID), zap.String("event-type", string(auditEvent)))
+		logger.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", accessTokenDetails.UserID), zap.String("event-type", string(auditEvent)))
 	}
 
 	return nil
@@ -1160,9 +1161,7 @@ func (s *Service) LogoutUser(ctx context.Context, r *http.Request) error {
 // checks
 // TODO: Create tests
 func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*RefreshTokenResponse, error) {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	tokenUser, refreshTokenDetails, err := s.refreshTokenUserFromCookieValue(ctx, r.RefreshToken)
 	if err != nil {
@@ -1175,13 +1174,13 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 	if response, err := s.refreshTokenRotationResponse(ctx, userID, refreshTokenUuid); err != nil {
 		return nil, err
 	} else if response != nil {
-		log.Info("refresh-token-rotation-replayed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+		logger.Info("refresh-token-rotation-replayed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 		return response, nil
 	}
 
 	lockAcquired, err := s.EphemeralStore.AcquireRefreshTokenRotationLock(ctx, userID, refreshTokenUuid, refreshTokenRotationLockTTL)
 	if err != nil {
-		log.Error("refresh-token-rotation-lock-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
+		logger.Error("refresh-token-rotation-lock-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
 		return nil, err
 	}
 	if !lockAcquired {
@@ -1190,16 +1189,16 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 			return nil, waitErr
 		}
 		if response != nil {
-			log.Info("refresh-token-rotation-replayed-after-wait", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+			logger.Info("refresh-token-rotation-replayed-after-wait", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 			return response, nil
 		}
 
-		log.Error("refresh-token-rotation-lock-timeout-without-result", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+		logger.Error("refresh-token-rotation-lock-timeout-without-result", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 		return nil, ErrUnauthorizedRefreshTokenCacheDeletionFailure
 	}
 	defer func() {
 		if _, releaseErr := s.EphemeralStore.ReleaseRefreshTokenRotationLock(ctx, userID, refreshTokenUuid); releaseErr != nil {
-			log.Warn("refresh-token-rotation-lock-release-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(releaseErr))
+			logger.Warn("refresh-token-rotation-lock-release-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(releaseErr))
 		}
 	}()
 
@@ -1209,26 +1208,26 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 		if response, replayErr := s.refreshTokenRotationResponse(ctx, userID, refreshTokenUuid); replayErr != nil {
 			return nil, replayErr
 		} else if response != nil {
-			log.Info("refresh-token-rotation-replayed-after-delete-miss", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+			logger.Info("refresh-token-rotation-replayed-after-delete-miss", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 			return response, nil
 		}
 
-		log.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id:", userID), zap.Error(err))
+		logger.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id:", userID), zap.Error(err))
 		return nil, ErrUnauthorizedRefreshTokenCacheDeletionFailure
 	}
 
-	log.Info("refresh-token-successfully-removed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+	logger.Info("refresh-token-successfully-removed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 
 	// check if access token is present and clean up along with it
 	if r.AccessToken != "" {
 
-		log.Info("access-token-present-in-refresh-token-request", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+		logger.Info("access-token-present-in-refresh-token-request", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 
 		err := s.RemoveAccessTokenWithCookieValue(ctx, userID, r.AccessToken)
 		if err != nil {
-			log.Warn("access-token-failed-to-delete-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.Error(err))
+			logger.Warn("access-token-failed-to-delete-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.Error(err))
 		} else {
-			log.Info("access-token-deleted-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+			logger.Info("access-token-deleted-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
 		}
 
 	}
@@ -1242,7 +1241,7 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 	// Save the tokens to ephemeralstore
 	err = s.EphemeralStore.CreateAuth(ctx, userID, newTokensDetails)
 	if err != nil {
-		log.Error("ephemeral-store-failed-after-successful-refresh-token-regeneration", zap.String("user-id:", userID), zap.Error(err))
+		logger.Error("ephemeral-store-failed-after-successful-refresh-token-regeneration", zap.String("user-id:", userID), zap.Error(err))
 		return nil, err
 	}
 
@@ -1254,7 +1253,7 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 		RefreshTokenExpiresAt: newTokensDetails.RtExpires,
 	}
 	if err := s.EphemeralStore.StoreRefreshTokenRotationResult(ctx, userID, refreshTokenUuid, rotationResult, refreshTokenRotationReplayTTL); err != nil {
-		log.Warn("refresh-token-rotation-result-store-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
+		logger.Warn("refresh-token-rotation-result-store-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
 	}
 
 	return &RefreshTokenResponse{
@@ -1267,6 +1266,9 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 
 // refreshTokenRotationResponse maps a cached rotation replay payload to the service response.
 func (s *Service) refreshTokenRotationResponse(ctx context.Context, userID, refreshTokenUuid string) (*RefreshTokenResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "refresh-token-rotation-response")
+	logger.Debug("handling-refresh-token-rotation-response-request")
+
 	result, err := s.EphemeralStore.GetRefreshTokenRotationResult(ctx, userID, refreshTokenUuid)
 	if err != nil || result == nil {
 		return nil, err
@@ -1282,9 +1284,7 @@ func (s *Service) refreshTokenRotationResponse(ctx context.Context, userID, refr
 
 // waitForRefreshTokenRotationResponse polls briefly for the winning refresh rotation result.
 func (s *Service) waitForRefreshTokenRotationResponse(ctx context.Context, userID, refreshTokenUuid string) (*RefreshTokenResponse, error) {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	timeout := time.NewTimer(refreshTokenRotationWaitTimeout)
 	defer timeout.Stop()
@@ -1300,7 +1300,7 @@ func (s *Service) waitForRefreshTokenRotationResponse(ctx context.Context, userI
 		}
 		if err != nil {
 			lastErr = err
-			log.Warn("refresh-token-rotation-result-fetch-failed-during-wait", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
+			logger.Warn("refresh-token-rotation-result-fetch-failed-during-wait", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
 		}
 
 		select {
@@ -1315,11 +1315,9 @@ func (s *Service) waitForRefreshTokenRotationResponse(ctx context.Context, userI
 
 // RemoveAccessTokenWithCookieValue removes access token with the given cookie value
 func (s *Service) RemoveAccessTokenWithCookieValue(ctx context.Context, userId, accessTokenCookieValue string) error {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
-	log.Info("processing-access-token-removal-by-cookie-value")
+	logger.Info("processing-access-token-removal-by-cookie-value")
 
 	tempRequest := &http.Request{
 		Header: http.Header{},
@@ -1329,40 +1327,38 @@ func (s *Service) RemoveAccessTokenWithCookieValue(ctx context.Context, userId, 
 
 	accessTokenDetails, err := s.AuthService.ExtractTokenMetadata(ctx, tempRequest)
 	if err != nil {
-		log.Error("failed-to-extract-access-token-details-from-cookie-value", zap.Error(err))
+		logger.Error("failed-to-extract-access-token-details-from-cookie-value", zap.Error(err))
 		return err
 	}
 
 	deleted, err := s.EphemeralStore.DeleteAuth(ctx, toolbox.CombinedUuidFormat(userId, accessTokenDetails.AccessUUID))
 	if err != nil || deleted == 0 {
-		log.Warn("access-token-removal-failed", zap.String("user-id", userId), zap.String("access-token", accessTokenDetails.AccessUUID), zap.Error(err))
+		logger.Warn("access-token-removal-failed", zap.String("user-id", userId), zap.String("access-token", accessTokenDetails.AccessUUID), zap.Error(err))
 		return err
 	}
 
-	log.Info("access-token-successfully-removed", zap.String("user-id", userId), zap.String("refresh-token", accessTokenDetails.AccessUUID))
+	logger.Info("access-token-successfully-removed", zap.String("user-id", userId), zap.String("refresh-token", accessTokenDetails.AccessUUID))
 
 	return nil
 }
 
 // refreshTokenUserFromCookieValue validates a refresh cookie and returns its user and token metadata.
 func (s *Service) refreshTokenUserFromCookieValue(ctx context.Context, refreshTokenCookieValue string) (auth.UserModel, *auth.TokenRefreshDetails, error) {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
-	log.Info("processing-refresh-token-by-cookie-value")
+	logger.Info("processing-refresh-token-by-cookie-value")
 
 	// Check validity
 	refreshToken, err := s.AuthService.CheckRefreshTokenIsValid(ctx, refreshTokenCookieValue)
 	if err != nil {
-		log.Error("failed-to-check-if-refresh-token-is-valid", zap.Error(err))
+		logger.Error("failed-to-check-if-refresh-token-is-valid", zap.Error(err))
 		return nil, nil, err
 	}
 
 	// Get token details
 	refreshTokenDetails, err := s.AuthService.GetRefreshTokenUUID(ctx, refreshToken)
 	if err != nil {
-		log.Error("failed-to-get-refresh-token-by-its-uuid", zap.Error(err))
+		logger.Error("failed-to-get-refresh-token-by-its-uuid", zap.Error(err))
 		return nil, nil, err
 	}
 
@@ -1370,7 +1366,7 @@ func (s *Service) refreshTokenUserFromCookieValue(ctx context.Context, refreshTo
 	persistentUserResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{
 		ID: refreshTokenDetails.UserID})
 	if err != nil {
-		log.Error("unable-to-find-user-for-refresh-token-by-its-provided-user-uuid", zap.Error(err))
+		logger.Error("unable-to-find-user-for-refresh-token-by-its-provided-user-uuid", zap.Error(err))
 		return nil, refreshTokenDetails, err
 	}
 
@@ -1384,12 +1380,10 @@ func (s *Service) RemoveRefreshTokenWithCookieValue(ctx context.Context, refresh
 	var (
 		userId           string
 		refreshTokenUuid string
-		log              *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger           *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 	)
 
-	log.Info("processing-refresh-token-removal-by-cookie-value")
+	logger.Info("processing-refresh-token-removal-by-cookie-value")
 
 	tokenUser, refreshTokenDetails, err := s.refreshTokenUserFromCookieValue(ctx, refreshTokenCookieValue)
 	if err != nil {
@@ -1405,11 +1399,11 @@ func (s *Service) RemoveRefreshTokenWithCookieValue(ctx context.Context, refresh
 	// Delete previous refresh token matching key (<userID>:<tokenUUID>)
 	deleted, err := s.EphemeralStore.DeleteAuth(ctx, toolbox.CombinedUuidFormat(userId, refreshTokenDetails.RefreshUUID))
 	if err != nil || deleted == 0 {
-		log.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id:", userId), zap.Error(err))
+		logger.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id:", userId), zap.Error(err))
 		return nil, refreshTokenUuid, ErrUnauthorizedRefreshTokenCacheDeletionFailure
 	}
 
-	log.Info("refresh-token-successfully-removed", zap.String("user-id", userId), zap.String("refresh-token", refreshTokenDetails.RefreshUUID))
+	logger.Info("refresh-token-successfully-removed", zap.String("user-id", userId), zap.String("refresh-token", refreshTokenDetails.RefreshUUID))
 	return tokenUser, refreshTokenUuid, nil
 }
 
@@ -1418,9 +1412,7 @@ func (s *Service) RemoveRefreshTokenWithCookieValue(ctx context.Context, refresh
 // TODO: Create tests
 func (s *Service) LoginUser(ctx context.Context, r *LoginUserRequest) (*LoginUserResponse, error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	if r.Code != "" {
 		resolvedToken, err := s.resolveTokenFromCode(ctx, r.Code)
@@ -1459,13 +1451,13 @@ func (s *Service) LoginUser(ctx context.Context, r *LoginUserRequest) (*LoginUse
 		User: persistentUser,
 	})
 	if err != nil {
-		log.Error("system-update-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
+		logger.Error("system-update-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
 		return nil, err
 	}
 
 	err = s.EphemeralStore.CreateAuth(ctx, UpdateUserResponse.User.ID, tokenDetails)
 	if err != nil {
-		log.Error("ephemeral-store-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
+		logger.Error("ephemeral-store-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
 		return nil, err
 	}
 
@@ -1482,7 +1474,7 @@ func (s *Service) LoginUser(ctx context.Context, r *LoginUserRequest) (*LoginUse
 	})
 
 	if auditErr != nil {
-		log.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", UpdateUserResponse.User.ID), zap.String("event-type", string(auditEvent)))
+		logger.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", UpdateUserResponse.User.ID), zap.String("event-type", string(auditEvent)))
 	}
 
 	return &LoginUserResponse{
@@ -1496,6 +1488,9 @@ func (s *Service) LoginUser(ctx context.Context, r *LoginUserRequest) (*LoginUse
 // DeleteAuth removes token with matching ID metadata from emphemeral storage
 // TODO: Create tests
 func (s *Service) DeleteAuth(ctx context.Context, tokenID string) (int64, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "delete-auth")
+	logger.Debug("handling-delete-auth-request")
+
 	return s.EphemeralStore.DeleteAuth(ctx, tokenID)
 }
 
@@ -1506,9 +1501,7 @@ func (s *Service) DeleteAuth(ctx context.Context, tokenID string) (int64, error)
 // admin user
 func (s *Service) CreateInitalLoginOrVerificationTokenEmail(ctx context.Context, r *CreateInitalLoginOrVerificationTokenEmailRequest) error {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	persistentUserResponse, err := s.UserService.GetUserByEmail(ctx, &userv2.GetUserByEmailRequest{Email: r.Email})
 	if err != nil {
@@ -1531,7 +1524,7 @@ func (s *Service) CreateInitalLoginOrVerificationTokenEmail(ctx context.Context,
 			return err
 		}
 	default:
-		log.Error("requested-user-in-unexpected-state", zap.String("user-id", persistentUserResponse.User.ID), zap.String("user-status", persistentUserResponse.User.Status))
+		logger.Error("requested-user-in-unexpected-state", zap.String("user-id", persistentUserResponse.User.ID), zap.String("user-status", persistentUserResponse.User.Status))
 		return ErrUserStatusUncaught
 	}
 
@@ -1541,6 +1534,8 @@ func (s *Service) CreateInitalLoginOrVerificationTokenEmail(ctx context.Context,
 // ValidateEmailVerificationCode handles updating the system to illustrate a successful email verification
 // TODO: Create tests
 func (s *Service) ValidateEmailVerificationCode(ctx context.Context, r *ValidateEmailVerificationCodeRequest) (*ValidateEmailVerificationCodeResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "validate-email-verification-code")
+	logger.Debug("handling-validate-email-verification-code-request")
 
 	if r.Code != "" {
 		resolvedToken, err := s.resolveTokenFromCode(ctx, r.Code)
@@ -1578,9 +1573,7 @@ func (s *Service) ValidateEmailVerificationCode(ctx context.Context, r *Validate
 // TODO: Create tests
 func (s *Service) UserEmailVerificationRevisions(ctx context.Context, r *UserEmailVerificationRevisionsRequest) (accessToken string, accessTokenExpiresAt int64, refreshToken string, refreshTokenExpiresAt int64, err error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	persistentUserResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: r.UserID})
 	if err != nil {
@@ -1594,7 +1587,7 @@ func (s *Service) UserEmailVerificationRevisions(ctx context.Context, r *UserEma
 	persistentUser.VerifyEmail()
 	revisionedUser, err := persistentUser.UpdateStatus(userv2.AccountStatusKeyActive)
 	if err != nil {
-		log.Error("user-status-update-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
+		logger.Error("user-status-update-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
 		return "", 0, "", 0, err
 	}
 
@@ -1602,19 +1595,19 @@ func (s *Service) UserEmailVerificationRevisions(ctx context.Context, r *UserEma
 		User: revisionedUser,
 	})
 	if err != nil {
-		log.Error("system-update-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
+		logger.Error("system-update-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
 		return "", 0, "", 0, err
 	}
 
 	newTokenDetails, err := s.AuthService.CreateToken(ctx, UpdateUserResponse.User)
 	if err != nil {
-		log.Error("token-creation-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
+		logger.Error("token-creation-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
 		return "", 0, "", 0, err
 	}
 
 	err = s.EphemeralStore.CreateAuth(ctx, r.UserID, newTokenDetails)
 	if err != nil {
-		log.Error("ephemeral-store-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
+		logger.Error("ephemeral-store-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
 		return "", 0, "", 0, err
 	}
 
@@ -1626,9 +1619,7 @@ func (s *Service) UserEmailVerificationRevisions(ctx context.Context, r *UserEma
 // conventional method (headers)
 // TODO: Create tests
 func (s *Service) TokenAsStringValidator(ctx context.Context, r *TokenAsStringValidatorRequest) (*TokenAsStringValidatorResponse, error) {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	token, err := s.AuthService.ParseAccessTokenFromString(ctx, r.Token)
 	if err != nil {
@@ -1643,7 +1634,7 @@ func (s *Service) TokenAsStringValidator(ctx context.Context, r *TokenAsStringVa
 	// Check to make sure ephemeral token in persistent storage
 	_, err = s.EphemeralStore.FetchAuth(ctx, td)
 	if err != nil {
-		log.Warn("unauthorized-token-not-found", zap.String("user-id", td.UserID))
+		logger.Warn("unauthorized-token-not-found", zap.String("user-id", td.UserID))
 		return nil, ErrUnauthorizedTokenNotFoundInStore
 	}
 
@@ -1659,9 +1650,7 @@ func (s *Service) TokenAsStringValidator(ctx context.Context, r *TokenAsStringVa
 // TODO: Create tests
 func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*CreateUserResponse, error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	response := &CreateUserResponse{}
 
@@ -1688,69 +1677,69 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 		Domain:     "accessmanager",
 	})
 	if auditErr != nil {
-		log.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", response.User.ID), zap.String("event-type", string(auditEvent)))
+		logger.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", response.User.ID), zap.String("event-type", string(auditEvent)))
 	}
 
 	// handle associating pre-registered subscriptions and billing events if any
 	if s.BillingService != nil {
-		log.Info("checking-for-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
+		logger.Info("checking-for-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
 		unassociatedSubResp, err := s.BillingService.GetUnassociatedSubscriptions(ctx, &billing.GetUnassociatedSubscriptionsRequest{
 			Email: newUser.User.Email,
 			Limit: 50,
 		})
 		if err != nil {
-			log.Error("failed-to-check-for-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.Error(err))
+			logger.Error("failed-to-check-for-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.Error(err))
 		} else {
 			if len(unassociatedSubResp.Subscriptions) > 0 {
-				log.Info("found-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.Int("subscription-count", len(unassociatedSubResp.Subscriptions)))
+				logger.Info("found-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.Int("subscription-count", len(unassociatedSubResp.Subscriptions)))
 				_, subscriptionAssociationErr := s.BillingService.AssociateSubscriptionsWithUser(ctx, &billing.AssociateSubscriptionsWithUserRequest{
 					UserID: newUser.User.ID,
 					Email:  newUser.User.Email,
 				})
 				if subscriptionAssociationErr != nil {
-					log.Error("failed-to-associate-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.Error(subscriptionAssociationErr))
+					logger.Error("failed-to-associate-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.Error(subscriptionAssociationErr))
 				} else {
-					log.Info("successfully-associated-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.Int("subscription-count", len(unassociatedSubResp.Subscriptions)))
+					logger.Info("successfully-associated-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.Int("subscription-count", len(unassociatedSubResp.Subscriptions)))
 				}
 			} else {
-				log.Info("no-pre-registered-subscriptions-found", zap.String("user-id", newUser.User.ID))
+				logger.Info("no-pre-registered-subscriptions-found", zap.String("user-id", newUser.User.ID))
 			}
 		}
 
-		log.Info("checking-for-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
+		logger.Info("checking-for-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
 		unassociatedBillingEventsResp, err := s.BillingService.GetUnassociatedBillingEvents(ctx, &billing.GetUnassociatedBillingEventsRequest{
 			Email: newUser.User.Email,
 			Limit: 100,
 		})
 		if err != nil {
-			log.Error("failed-to-check-for-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.Error(err))
+			logger.Error("failed-to-check-for-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.Error(err))
 		} else {
 			if len(unassociatedBillingEventsResp.BillingEvents) > 0 {
-				log.Info("found-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.Int("billing-event-count", len(unassociatedBillingEventsResp.BillingEvents)))
+				logger.Info("found-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.Int("billing-event-count", len(unassociatedBillingEventsResp.BillingEvents)))
 				_, billingEventAssociationErr := s.BillingService.AssociateBillingEventsWithUser(ctx, &billing.AssociateBillingEventsWithUserRequest{
 					UserID: newUser.User.ID,
 					Email:  newUser.User.Email,
 				})
 				if billingEventAssociationErr != nil {
-					log.Error("failed-to-associate-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.Error(billingEventAssociationErr))
+					logger.Error("failed-to-associate-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.Error(billingEventAssociationErr))
 				} else {
-					log.Info("successfully-associated-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.Int("billing-event-count", len(unassociatedBillingEventsResp.BillingEvents)))
+					logger.Info("successfully-associated-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.Int("billing-event-count", len(unassociatedBillingEventsResp.BillingEvents)))
 				}
 			} else {
-				log.Info("no-pre-registered-billing-events-found", zap.String("user-id", newUser.User.ID))
+				logger.Info("no-pre-registered-billing-events-found", zap.String("user-id", newUser.User.ID))
 			}
 		}
 	}
 
 	// handle auto-join/auto-invite group membership if group service is available
 	if s.GroupService != nil {
-		log.Info("checking-for-auto-join-groups", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
+		logger.Info("checking-for-auto-join-groups", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
 		autoJoinGroupsResp, err := s.GroupService.GetParentGroupsWithAutoJoinForEmail(ctx, newUser.User.Email)
 		if err != nil {
-			log.Error("failed-to-check-for-auto-join-groups", zap.String("user-id", newUser.User.ID), zap.Error(err))
+			logger.Error("failed-to-check-for-auto-join-groups", zap.String("user-id", newUser.User.ID), zap.Error(err))
 		} else {
 			if autoJoinGroupsResp != nil && len(autoJoinGroupsResp.Groups) > 0 {
-				log.Info("found-groups-with-auto-join", zap.String("user-id", newUser.User.ID), zap.Int("group-count", len(autoJoinGroupsResp.Groups)))
+				logger.Info("found-groups-with-auto-join", zap.String("user-id", newUser.User.ID), zap.Int("group-count", len(autoJoinGroupsResp.Groups)))
 
 				for _, autoJoinGroup := range autoJoinGroupsResp.Groups {
 					if autoJoinGroup == nil || autoJoinGroup.Settings == nil {
@@ -1772,9 +1761,9 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 							Role:     memberRole,
 						})
 						if memberErr != nil {
-							log.Error("failed-to-auto-join-user-to-group", zap.String("user-id", newUser.User.ID), zap.String("group-id", autoJoinGroup.ID), zap.Error(memberErr))
+							logger.Error("failed-to-auto-join-user-to-group", zap.String("user-id", newUser.User.ID), zap.String("group-id", autoJoinGroup.ID), zap.Error(memberErr))
 						} else {
-							log.Info("successfully-auto-joined-user-to-group", zap.String("user-id", newUser.User.ID), zap.String("group-id", autoJoinGroup.ID))
+							logger.Info("successfully-auto-joined-user-to-group", zap.String("user-id", newUser.User.ID), zap.String("group-id", autoJoinGroup.ID))
 							// Audit log the auto-join
 							s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
 								ActorId:    audit.AuditActorIdSystem,
@@ -1803,9 +1792,9 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 							InvitedByID: audit.AuditActorIdSystem,
 						})
 						if inviteErr != nil {
-							log.Error("failed-to-auto-invite-user-to-group", zap.String("user-id", newUser.User.ID), zap.String("group-id", autoJoinGroup.ID), zap.Error(inviteErr))
+							logger.Error("failed-to-auto-invite-user-to-group", zap.String("user-id", newUser.User.ID), zap.String("group-id", autoJoinGroup.ID), zap.Error(inviteErr))
 						} else {
-							log.Info("successfully-auto-invited-user-to-group", zap.String("user-id", newUser.User.ID), zap.String("group-id", autoJoinGroup.ID))
+							logger.Info("successfully-auto-invited-user-to-group", zap.String("user-id", newUser.User.ID), zap.String("group-id", autoJoinGroup.ID))
 							// Audit log the auto-invite
 							s.AuditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
 								ActorId:    audit.AuditActorIdSystem,
@@ -1823,27 +1812,27 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 					}
 				}
 			} else {
-				log.Info("no-groups-with-auto-join-found", zap.String("user-id", newUser.User.ID))
+				logger.Info("no-groups-with-auto-join-found", zap.String("user-id", newUser.User.ID))
 			}
 		}
 	}
 
 	// handle verification email if not disabled
 	if !r.DisableVerificationEmail {
-		log.Info(fmt.Sprintf("ams/initiate-new-user-verification-email: %s", newUser.User.ID))
+		logger.Info("initiate-new-user-verification-email", zap.String("user-id", newUser.User.ID))
 		_, err = s.CreateEmailVerificationToken(ctx, &CreateEmailVerificationTokenRequest{
 			User:       response.User,
 			RequestUrl: r.RequestUrl,
 		})
 		if err != nil {
-			log.Error(fmt.Sprintf("ams/error-failed-to-initiate-new-user-verification-email: %s", newUser.User.ID))
+			logger.Error("failed-to-initiate-new-user-verification-email", zap.String("user-id", newUser.User.ID), zap.Error(err))
 			return response, err
 		}
 
-		log.Info(fmt.Sprintf("ams/successfully-initiated-new-user-verification-email: %s", newUser.User.ID))
+		logger.Info("successfully-initiated-new-user-verification-email", zap.String("user-id", newUser.User.ID))
 	}
 
-	log.Info(fmt.Sprintf("ams/completed-new-user-creation: %s", newUser.User.ID))
+	logger.Info("completed-new-user-creation", zap.String("user-id", newUser.User.ID))
 
 	return response, nil
 }
@@ -1852,18 +1841,16 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 // TODO: Create tests
 func (s *Service) CreateInitalLoginToken(ctx context.Context, user *userv2.UniversalUser, isDashboardRequest bool, requestUrl string) (string, error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	// cooldownAcquired is false when a recent accepted login email already exists for this user/context.
 	cooldownAcquired, err := s.EphemeralStore.AcquireLoginEmailCooldown(ctx, user.ID, isDashboardRequest, requestUrl, loginEmailCooldownTTL)
 	if err != nil {
-		log.Error("unable-to-acquire-login-email-cooldown:", zap.String("user-id", user.ID), zap.Error(err))
+		logger.Error("unable-to-acquire-login-email-cooldown:", zap.String("user-id", user.ID), zap.Error(err))
 		return "", err
 	}
 	if !cooldownAcquired {
-		log.Info("login-email-cooldown-active", zap.String("user-id", user.ID))
+		logger.Info("login-email-cooldown-active", zap.String("user-id", user.ID))
 		return "", nil
 	}
 
@@ -1875,31 +1862,31 @@ func (s *Service) CreateInitalLoginToken(ctx context.Context, user *userv2.Unive
 		}
 
 		if _, releaseErr := s.EphemeralStore.ReleaseLoginEmailCooldown(ctx, user.ID, isDashboardRequest, requestUrl); releaseErr != nil {
-			log.Warn("login-email-cooldown-release-failed", zap.String("user-id", user.ID), zap.Error(releaseErr))
+			logger.Warn("login-email-cooldown-release-failed", zap.String("user-id", user.ID), zap.Error(releaseErr))
 		}
 	}()
 
 	tokenDetails, err := s.AuthService.CreateInitalToken(ctx, user)
 	if err != nil {
-		log.Error("unable-to-generate-initiate-login-email-token:", zap.String("user-id", user.ID))
+		logger.Error("unable-to-generate-initiate-login-email-token:", zap.String("user-id", user.ID))
 		return "", err
 	}
 
 	err = s.EphemeralStore.StoreToken(ctx, tokenDetails.EphemeralUUID, user.ID, tokenDetails.EtTTL)
 	if err != nil {
-		log.Error("unable-to-store-token-in-ephemeral-store:", zap.String("user-id", user.ID))
+		logger.Error("unable-to-store-token-in-ephemeral-store:", zap.String("user-id", user.ID))
 		return "", err
 	}
 
 	loginCode, err := accessmanagerhelpers.GenerateUniqueCode(ctx, s.EphemeralStore, tokenDetails.EtTTL)
 	if err != nil {
-		log.Error("unable-to-generate-login-code:", zap.String("user-id", user.ID), zap.Error(err))
+		logger.Error("unable-to-generate-login-code:", zap.String("user-id", user.ID), zap.Error(err))
 		return "", err
 	}
 
 	err = s.EphemeralStore.StoreCodeMapping(ctx, loginCode, tokenDetails.EphemeralToken, tokenDetails.EtTTL)
 	if err != nil {
-		log.Error("unable-to-store-login-code-mapping:", zap.String("user-id", user.ID), zap.Error(err))
+		logger.Error("unable-to-store-login-code-mapping:", zap.String("user-id", user.ID), zap.Error(err))
 		return "", err
 	}
 
@@ -1913,7 +1900,7 @@ func (s *Service) CreateInitalLoginToken(ctx context.Context, user *userv2.Unive
 		UserId:             user.ID,
 	})
 	if err != nil {
-		log.Error("unable-to-send-initiate-login-email:", zap.String("user-id", user.ID))
+		logger.Error("unable-to-send-initiate-login-email:", zap.String("user-id", user.ID))
 		return "", err
 	}
 
@@ -1925,32 +1912,30 @@ func (s *Service) CreateInitalLoginToken(ctx context.Context, user *userv2.Unive
 // CreateEmailVerificationToken create token used to validate email associated to user's accounts
 func (s *Service) CreateEmailVerificationToken(ctx context.Context, r *CreateEmailVerificationTokenRequest) (string, error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/accessmanager")
 	user := r.User
 
 	tokenDetails, err := s.AuthService.CreateEmailVerificationToken(ctx, user)
 	if err != nil {
-		log.Error("unable-to-generate-verification-email-token:", zap.String("user-id", user.ID))
+		logger.Error("unable-to-generate-verification-email-token:", zap.String("user-id", user.ID))
 		return "", err
 	}
 
 	err = s.EphemeralStore.StoreToken(ctx, tokenDetails.EmailVerificationUUID, user.ID, tokenDetails.EvTTL)
 	if err != nil {
-		log.Error("unable-to-store-token-in-ephemeral-store:", zap.String("user-id", user.ID))
+		logger.Error("unable-to-store-token-in-ephemeral-store:", zap.String("user-id", user.ID))
 		return "", err
 	}
 
 	verificationCode, err := accessmanagerhelpers.GenerateUniqueCode(ctx, s.EphemeralStore, tokenDetails.EvTTL)
 	if err != nil {
-		log.Error("unable-to-generate-verification-code:", zap.String("user-id", user.ID), zap.Error(err))
+		logger.Error("unable-to-generate-verification-code:", zap.String("user-id", user.ID), zap.Error(err))
 		return "", err
 	}
 
 	err = s.EphemeralStore.StoreCodeMapping(ctx, verificationCode, tokenDetails.EmailVerificationToken, tokenDetails.EvTTL)
 	if err != nil {
-		log.Error("unable-to-store-verification-code-mapping:", zap.String("user-id", user.ID), zap.Error(err))
+		logger.Error("unable-to-store-verification-code-mapping:", zap.String("user-id", user.ID), zap.Error(err))
 		return "", err
 	}
 
@@ -1966,7 +1951,7 @@ func (s *Service) CreateEmailVerificationToken(ctx context.Context, r *CreateEma
 		UserId:             user.ID,
 	})
 	if err != nil {
-		log.Error("unable-to-send-verification-email:", zap.String("user-id", user.ID))
+		logger.Error("unable-to-send-verification-email:", zap.String("user-id", user.ID))
 		return "", err
 	}
 
@@ -1991,6 +1976,9 @@ func getValidRequestorIP(r *http.Request) string {
 // isUserLiveStatusActive checks if the user account with the given ID has an ACTIVE status.
 // Returns the user object and true if active, otherwise nil and false.
 func (s *Service) isUserLiveStatusActive(ctx context.Context, userID string) (*userv2.UniversalUser, bool) {
+	logger := logger.AcquireOperationFrom(ctx, "external/accessmanager", "is-user-live-status-active")
+	logger.Debug("handling-is-user-live-status-active-request")
+
 	persistentUserResponse, err := s.UserService.GetUserByID(ctx,
 		&userv2.GetUserByIDRequest{ID: userID},
 	)
@@ -2009,22 +1997,20 @@ func (s *Service) isUserLiveStatusActive(ctx context.Context, userID string) (*u
 // associated token. It returns an error if the code is not found or has expired.
 func (s *Service) resolveTokenFromCode(ctx context.Context, code string) (string, error) {
 
-	log := logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	logger := logger.AcquirePackageFrom(ctx, "external/accessmanager")
 
 	token, err := s.EphemeralStore.GetCodeMapping(ctx, code)
 	if err != nil {
-		log.Warn("ams/code-to-token-mapping-not-found", zap.String("code", code), zap.Error(err))
+		logger.Warn("code-to-token-mapping-not-found", zap.String("code", code), zap.Error(err))
 		return "", ErrInvalidVerificationCode
 	}
 
 	if token == "" {
-		log.Warn("ams/code-to-token-mapping-returned-empty-token", zap.String("code", code))
+		logger.Warn("code-to-token-mapping-returned-empty-token", zap.String("code", code))
 		return "", ErrInvalidVerificationCode
 	}
 
-	log.Info("ams/successfully-resolved-code-to-token", zap.String("code", code))
+	logger.Info("successfully-resolved-code-to-token", zap.String("code", code))
 
 	return token, nil
 }

--- a/external/accessmanager/service.go
+++ b/external/accessmanager/service.go
@@ -467,7 +467,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 
 			decoded64RequestUrl, err := base64.StdEncoding.DecodeString(splitProtectionStateTokenCookieValue[1])
 			if err != nil {
-				logger.Warn("failed-to-decode-detected-request-url-uri-for-sso-callback", zap.String("encoded-request-url", splitProtectionStateTokenCookieValue[1]))
+				logger.Warn("failed-to-decode-detected-request-url-uri-for-sso-callback", requestURLLogFields(splitProtectionStateTokenCookieValue[1])...)
 			}
 
 			if err == nil && string(decoded64RequestUrl) != "" {
@@ -566,7 +566,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 				Email:                    providerUserInfo.GetUserEmail(),
 			})
 			if err != nil {
-				logger.Error("provider-signup-user-creation-failed-after-successful-login-initiation", zap.String("user-email:", providerUserInfo.GetUserEmail()))
+				logger.Error("provider-signup-user-creation-failed-after-successful-login-initiation", append(emailLogFields("user-email", providerUserInfo.GetUserEmail()), zap.Error(err))...)
 				return &OauthCallbackResponse{
 					ProviderStateCookieKey: providerCookieKey,
 				}, err
@@ -1174,13 +1174,13 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 	if response, err := s.refreshTokenRotationResponse(ctx, userID, refreshTokenUuid); err != nil {
 		return nil, err
 	} else if response != nil {
-		logger.Info("refresh-token-rotation-replayed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+		logger.Info("refresh-token-rotation-replayed", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid))
 		return response, nil
 	}
 
 	lockAcquired, err := s.EphemeralStore.AcquireRefreshTokenRotationLock(ctx, userID, refreshTokenUuid, refreshTokenRotationLockTTL)
 	if err != nil {
-		logger.Error("refresh-token-rotation-lock-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
+		logger.Error("refresh-token-rotation-lock-failed", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid), zap.Error(err))
 		return nil, err
 	}
 	if !lockAcquired {
@@ -1189,16 +1189,16 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 			return nil, waitErr
 		}
 		if response != nil {
-			logger.Info("refresh-token-rotation-replayed-after-wait", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+			logger.Info("refresh-token-rotation-replayed-after-wait", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid))
 			return response, nil
 		}
 
-		logger.Error("refresh-token-rotation-lock-timeout-without-result", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+		logger.Error("refresh-token-rotation-lock-timeout-without-result", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid))
 		return nil, ErrUnauthorizedRefreshTokenCacheDeletionFailure
 	}
 	defer func() {
 		if _, releaseErr := s.EphemeralStore.ReleaseRefreshTokenRotationLock(ctx, userID, refreshTokenUuid); releaseErr != nil {
-			logger.Warn("refresh-token-rotation-lock-release-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(releaseErr))
+			logger.Warn("refresh-token-rotation-lock-release-failed", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid), zap.Error(releaseErr))
 		}
 	}()
 
@@ -1208,7 +1208,7 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 		if response, replayErr := s.refreshTokenRotationResponse(ctx, userID, refreshTokenUuid); replayErr != nil {
 			return nil, replayErr
 		} else if response != nil {
-			logger.Info("refresh-token-rotation-replayed-after-delete-miss", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+			logger.Info("refresh-token-rotation-replayed-after-delete-miss", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid))
 			return response, nil
 		}
 
@@ -1216,18 +1216,18 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 		return nil, ErrUnauthorizedRefreshTokenCacheDeletionFailure
 	}
 
-	logger.Info("refresh-token-successfully-removed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+	logger.Info("refresh-token-successfully-removed", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid))
 
 	// check if access token is present and clean up along with it
 	if r.AccessToken != "" {
 
-		logger.Info("access-token-present-in-refresh-token-request", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+		logger.Info("access-token-present-in-refresh-token-request", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid))
 
 		err := s.RemoveAccessTokenWithCookieValue(ctx, userID, r.AccessToken)
 		if err != nil {
 			logger.Warn("access-token-failed-to-delete-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.Error(err))
 		} else {
-			logger.Info("access-token-deleted-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid))
+			logger.Info("access-token-deleted-after-successful-refresh-token-clean-up", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid))
 		}
 
 	}
@@ -1253,7 +1253,7 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 		RefreshTokenExpiresAt: newTokensDetails.RtExpires,
 	}
 	if err := s.EphemeralStore.StoreRefreshTokenRotationResult(ctx, userID, refreshTokenUuid, rotationResult, refreshTokenRotationReplayTTL); err != nil {
-		logger.Warn("refresh-token-rotation-result-store-failed", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
+		logger.Warn("refresh-token-rotation-result-store-failed", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid), zap.Error(err))
 	}
 
 	return &RefreshTokenResponse{
@@ -1300,7 +1300,7 @@ func (s *Service) waitForRefreshTokenRotationResponse(ctx context.Context, userI
 		}
 		if err != nil {
 			lastErr = err
-			logger.Warn("refresh-token-rotation-result-fetch-failed-during-wait", zap.String("user-id", userID), zap.String("refresh-token", refreshTokenUuid), zap.Error(err))
+			logger.Warn("refresh-token-rotation-result-fetch-failed-during-wait", zap.String("user-id", userID), zap.String("refresh-token-id", refreshTokenUuid), zap.Error(err))
 		}
 
 		select {
@@ -1333,11 +1333,11 @@ func (s *Service) RemoveAccessTokenWithCookieValue(ctx context.Context, userId, 
 
 	deleted, err := s.EphemeralStore.DeleteAuth(ctx, toolbox.CombinedUuidFormat(userId, accessTokenDetails.AccessUUID))
 	if err != nil || deleted == 0 {
-		logger.Warn("access-token-removal-failed", zap.String("user-id", userId), zap.String("access-token", accessTokenDetails.AccessUUID), zap.Error(err))
+		logger.Warn("access-token-removal-failed", zap.String("user-id", userId), zap.String("access-token-id", accessTokenDetails.AccessUUID), zap.Error(err))
 		return err
 	}
 
-	logger.Info("access-token-successfully-removed", zap.String("user-id", userId), zap.String("refresh-token", accessTokenDetails.AccessUUID))
+	logger.Info("access-token-successfully-removed", zap.String("user-id", userId), zap.String("access-token-id", accessTokenDetails.AccessUUID))
 
 	return nil
 }
@@ -1403,7 +1403,7 @@ func (s *Service) RemoveRefreshTokenWithCookieValue(ctx context.Context, refresh
 		return nil, refreshTokenUuid, ErrUnauthorizedRefreshTokenCacheDeletionFailure
 	}
 
-	logger.Info("refresh-token-successfully-removed", zap.String("user-id", userId), zap.String("refresh-token", refreshTokenDetails.RefreshUUID))
+	logger.Info("refresh-token-successfully-removed", zap.String("user-id", userId), zap.String("refresh-token-id", refreshTokenDetails.RefreshUUID))
 	return tokenUser, refreshTokenUuid, nil
 }
 
@@ -1682,7 +1682,7 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 
 	// handle associating pre-registered subscriptions and billing events if any
 	if s.BillingService != nil {
-		logger.Info("checking-for-pre-registered-subscriptions", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
+		logger.Info("checking-for-pre-registered-subscriptions", append([]zap.Field{zap.String("user-id", newUser.User.ID)}, emailLogFields("user-email", newUser.User.Email)...)...)
 		unassociatedSubResp, err := s.BillingService.GetUnassociatedSubscriptions(ctx, &billing.GetUnassociatedSubscriptionsRequest{
 			Email: newUser.User.Email,
 			Limit: 50,
@@ -1706,7 +1706,7 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 			}
 		}
 
-		logger.Info("checking-for-pre-registered-billing-events", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
+		logger.Info("checking-for-pre-registered-billing-events", append([]zap.Field{zap.String("user-id", newUser.User.ID)}, emailLogFields("user-email", newUser.User.Email)...)...)
 		unassociatedBillingEventsResp, err := s.BillingService.GetUnassociatedBillingEvents(ctx, &billing.GetUnassociatedBillingEventsRequest{
 			Email: newUser.User.Email,
 			Limit: 100,
@@ -1733,7 +1733,7 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 
 	// handle auto-join/auto-invite group membership if group service is available
 	if s.GroupService != nil {
-		logger.Info("checking-for-auto-join-groups", zap.String("user-id", newUser.User.ID), zap.String("user-email", newUser.User.Email))
+		logger.Info("checking-for-auto-join-groups", append([]zap.Field{zap.String("user-id", newUser.User.ID)}, emailLogFields("user-email", newUser.User.Email)...)...)
 		autoJoinGroupsResp, err := s.GroupService.GetParentGroupsWithAutoJoinForEmail(ctx, newUser.User.Email)
 		if err != nil {
 			logger.Error("failed-to-check-for-auto-join-groups", zap.String("user-id", newUser.User.ID), zap.Error(err))
@@ -2001,16 +2001,16 @@ func (s *Service) resolveTokenFromCode(ctx context.Context, code string) (string
 
 	token, err := s.EphemeralStore.GetCodeMapping(ctx, code)
 	if err != nil {
-		logger.Warn("code-to-token-mapping-not-found", zap.String("code", code), zap.Error(err))
+		logger.Warn("code-to-token-mapping-not-found", append(verificationCodeLogFields(code), zap.Error(err))...)
 		return "", ErrInvalidVerificationCode
 	}
 
 	if token == "" {
-		logger.Warn("code-to-token-mapping-returned-empty-token", zap.String("code", code))
+		logger.Warn("code-to-token-mapping-returned-empty-token", verificationCodeLogFields(code)...)
 		return "", ErrInvalidVerificationCode
 	}
 
-	logger.Info("successfully-resolved-code-to-token", zap.String("code", code))
+	logger.Info("successfully-resolved-code-to-token", verificationCodeLogFields(code)...)
 
 	return token, nil
 }

--- a/external/accessmanager/service.go
+++ b/external/accessmanager/service.go
@@ -518,7 +518,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 				User: persistentUser,
 			})
 			if err != nil {
-				logger.Error("provider-login-user-update-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
+				logger.Error("provider-login-user-update-failed-after-successful-login-initiation", zap.String("user-id", persistentUser.ID))
 				return &OauthCallbackResponse{
 					ProviderStateCookieKey: providerCookieKey,
 				}, err
@@ -526,7 +526,7 @@ func (s *Service) OauthCallback(ctx context.Context, r *OauthCallbackRequest) (*
 
 			err = s.EphemeralStore.CreateAuth(ctx, UpdateUserResponse.User.ID, tokenDetails)
 			if err != nil {
-				logger.Error("provider-login-ephemeral-store-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
+				logger.Error("provider-login-ephemeral-store-failed-after-successful-login-initiation", zap.String("user-id", persistentUser.ID))
 				return &OauthCallbackResponse{
 					ProviderStateCookieKey: providerCookieKey,
 				}, err
@@ -1130,12 +1130,12 @@ func (s *Service) LogoutUser(ctx context.Context, r *http.Request) error {
 
 	deleted, err := s.DeleteAuth(ctx, toolbox.CombinedUuidFormat(accessTokenDetails.UserID, accessTokenDetails.AccessUUID))
 	if err != nil {
-		logger.Error("ephemeral-delete-failed-after-successful-access-token-retrival", zap.String("user-id:", accessTokenDetails.UserID), zap.Error(err))
+		logger.Error("ephemeral-delete-failed-after-successful-access-token-retrival", zap.String("user-id", accessTokenDetails.UserID), zap.Error(err))
 		return err
 	}
 
 	if deleted == 0 {
-		logger.Error("ephemeral-delete-failed-after-successful-access-token-retrival", zap.String("user-id:", accessTokenDetails.UserID))
+		logger.Error("ephemeral-delete-failed-after-successful-access-token-retrival", zap.String("user-id", accessTokenDetails.UserID))
 		return ErrUnauthorizedAccessTokenCacheDeletionFailure
 	}
 
@@ -1212,7 +1212,7 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 			return response, nil
 		}
 
-		logger.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id:", userID), zap.Error(err))
+		logger.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id", userID), zap.Error(err))
 		return nil, ErrUnauthorizedRefreshTokenCacheDeletionFailure
 	}
 
@@ -1241,7 +1241,7 @@ func (s *Service) RefreshToken(ctx context.Context, r *RefreshTokenRequest) (*Re
 	// Save the tokens to ephemeralstore
 	err = s.EphemeralStore.CreateAuth(ctx, userID, newTokensDetails)
 	if err != nil {
-		logger.Error("ephemeral-store-failed-after-successful-refresh-token-regeneration", zap.String("user-id:", userID), zap.Error(err))
+		logger.Error("ephemeral-store-failed-after-successful-refresh-token-regeneration", zap.String("user-id", userID), zap.Error(err))
 		return nil, err
 	}
 
@@ -1399,7 +1399,7 @@ func (s *Service) RemoveRefreshTokenWithCookieValue(ctx context.Context, refresh
 	// Delete previous refresh token matching key (<userID>:<tokenUUID>)
 	deleted, err := s.EphemeralStore.DeleteAuth(ctx, toolbox.CombinedUuidFormat(userId, refreshTokenDetails.RefreshUUID))
 	if err != nil || deleted == 0 {
-		logger.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id:", userId), zap.Error(err))
+		logger.Error("ephemeral-delete-failed-after-successful-refresh-token-validation", zap.String("user-id", userId), zap.Error(err))
 		return nil, refreshTokenUuid, ErrUnauthorizedRefreshTokenCacheDeletionFailure
 	}
 
@@ -1451,13 +1451,13 @@ func (s *Service) LoginUser(ctx context.Context, r *LoginUserRequest) (*LoginUse
 		User: persistentUser,
 	})
 	if err != nil {
-		logger.Error("system-update-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
+		logger.Error("system-update-failed-after-successful-login-initiation", zap.String("user-id", persistentUser.ID))
 		return nil, err
 	}
 
 	err = s.EphemeralStore.CreateAuth(ctx, UpdateUserResponse.User.ID, tokenDetails)
 	if err != nil {
-		logger.Error("ephemeral-store-failed-after-successful-login-initiation", zap.String("user-id:", persistentUser.ID))
+		logger.Error("ephemeral-store-failed-after-successful-login-initiation", zap.String("user-id", persistentUser.ID))
 		return nil, err
 	}
 
@@ -1587,7 +1587,7 @@ func (s *Service) UserEmailVerificationRevisions(ctx context.Context, r *UserEma
 	persistentUser.VerifyEmail()
 	revisionedUser, err := persistentUser.UpdateStatus(userv2.AccountStatusKeyActive)
 	if err != nil {
-		logger.Error("user-status-update-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
+		logger.Error("user-status-update-failed-after-successful-email-verification", zap.String("user-id", r.UserID))
 		return "", 0, "", 0, err
 	}
 
@@ -1595,19 +1595,19 @@ func (s *Service) UserEmailVerificationRevisions(ctx context.Context, r *UserEma
 		User: revisionedUser,
 	})
 	if err != nil {
-		logger.Error("system-update-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
+		logger.Error("system-update-failed-after-successful-email-verification", zap.String("user-id", r.UserID))
 		return "", 0, "", 0, err
 	}
 
 	newTokenDetails, err := s.AuthService.CreateToken(ctx, UpdateUserResponse.User)
 	if err != nil {
-		logger.Error("token-creation-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
+		logger.Error("token-creation-failed-after-successful-email-verification", zap.String("user-id", r.UserID))
 		return "", 0, "", 0, err
 	}
 
 	err = s.EphemeralStore.CreateAuth(ctx, r.UserID, newTokenDetails)
 	if err != nil {
-		logger.Error("ephemeral-store-failed-after-successful-email-verification", zap.String("user-id:", r.UserID))
+		logger.Error("ephemeral-store-failed-after-successful-email-verification", zap.String("user-id", r.UserID))
 		return "", 0, "", 0, err
 	}
 

--- a/external/apitoken/service.go
+++ b/external/apitoken/service.go
@@ -39,12 +39,16 @@ func NewService(ApitokenRespository ApitokenRespository) *Service {
 
 // GetTotalApiTokens gets the total on api tokens based on passed values
 func (s *Service) GetTotalApiTokens(ctx context.Context, r *GetTotalApiTokensRequest) (int64, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/apitoken", "get-total-api-tokens")
+	logger.Debug("handling-get-total-api-tokens-request")
 
 	return s.ApitokenRespository.GetTotalApiTokens(ctx, r.UserId, "", r.Description, r.Status, r.To, r.From, r.OnlyEphemeral, r.OnlyPermanent)
 }
 
 // DeleteApiTokensByOwnerId deletes the histories that belong to matching user id
 func (s *Service) DeleteApiTokensByOwnerId(ctx context.Context, ownerId string) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/apitoken", "delete-api-tokens-by-owner-id")
+	logger.Debug("handling-delete-api-tokens-by-owner-id-request")
 
 	err := s.ApitokenRespository.DeleteResourcesByOwnerId(ctx, ownerId)
 	if err != nil {
@@ -57,7 +61,7 @@ func (s *Service) DeleteApiTokensByOwnerId(ctx context.Context, ownerId string) 
 // CreateAPIToken creates an API token adding,  any passed additional information
 // TODO: Create tests
 func (s *Service) CreateAPIToken(ctx context.Context, r *CreateAPITokenRequest) (*CreateAPITokenResponse, error) {
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/apitoken")
 
 	if r.UserID == "" {
 		return nil, ErrRequiredUserIDMissing
@@ -86,7 +90,7 @@ func (s *Service) CreateAPIToken(ctx context.Context, r *CreateAPITokenRequest) 
 		// Add duration
 		createdAt, err := time.Parse(common.RFC3339NanoUTC, apiToken.CreatedAt)
 		if err != nil {
-			log.Error("unable-to-set-ttl-for-short-lived-user-api-token", zap.String("token-created-at", apiToken.CreatedAt), zap.String("user-id", r.UserID), zap.Error(err))
+			logger.Error("unable-to-set-ttl-for-short-lived-user-api-token", zap.String("token-created-at", apiToken.CreatedAt), zap.String("user-id", r.UserID), zap.Error(err))
 
 			return nil, ErrErrorCreatingShortLivedAccessToken
 		}
@@ -110,7 +114,7 @@ func (s *Service) CreateAPIToken(ctx context.Context, r *CreateAPITokenRequest) 
 	}
 
 	if r.UserNanoId == "" {
-		log.Warn("api-token-created-with-no-nano-id-ref", zap.String("user-id", r.UserID), zap.String("token-id", persistentApiToken.ID))
+		logger.Warn("api-token-created-with-no-nano-id-ref", zap.String("user-id", r.UserID), zap.String("token-id", persistentApiToken.ID))
 	}
 
 	return &CreateAPITokenResponse{
@@ -121,7 +125,7 @@ func (s *Service) CreateAPIToken(ctx context.Context, r *CreateAPITokenRequest) 
 // ExtractValidateUserAPITokenMetadata retrieves data from passed user api token
 // TODO: Create tests
 func (s *Service) ExtractValidateUserAPITokenMetadata(ctx context.Context, r *http.Request) (*APITokenRequester, error) {
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/apitoken")
 	var requester APITokenRequester
 
 	// secret identifers from headers
@@ -130,7 +134,7 @@ func (s *Service) ExtractValidateUserAPITokenMetadata(ctx context.Context, r *ht
 	splittedToken := strings.Split(userFullToken, ".")
 
 	if len(splittedToken) != 2 {
-		log.Error("user-api-token-passed-does-not-contain-expected-two-segments", zap.Int("number-of-segments", len(splittedToken)))
+		logger.Error("user-api-token-passed-does-not-contain-expected-two-segments", zap.Int("number-of-segments", len(splittedToken)))
 		return nil, ErrInvalidAPIFormatDetected
 	}
 
@@ -145,7 +149,7 @@ func (s *Service) ExtractValidateUserAPITokenMetadata(ctx context.Context, r *ht
 			nonEmptySegment = splittedToken[0]
 		}
 
-		log.Error("user-api-token-passed-does-not-contain-two-non-empty-segments", zap.String("non-empty-segments", nonEmptySegment))
+		logger.Error("user-api-token-passed-does-not-contain-two-non-empty-segments", zap.String("non-empty-segments", nonEmptySegment))
 		return nil, ErrInvalidAPIFormatDetected
 	}
 
@@ -183,6 +187,8 @@ func (s *Service) ExtractValidateUserAPITokenMetadata(ctx context.Context, r *ht
 // UpdateAPITokenLastUsedAt updates the API Token's last used at time to now if the token matches the ID passed
 // TODO: Create tests
 func (s *Service) UpdateAPITokenLastUsedAt(ctx context.Context, r *UpdateAPITokenLastUsedAtRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/apitoken", "update-api-token-last-used-at")
+	logger.Debug("handling-update-api-token-last-used-at-request")
 
 	var targetTokenID string
 
@@ -220,6 +226,8 @@ func (s *Service) UpdateAPITokenLastUsedAt(ctx context.Context, r *UpdateAPIToke
 // ActivateAPIToken updates the API Token's Status to `ACTIVE` if the token matches the ID passed
 // TODO: Create tests
 func (s *Service) ActivateAPIToken(ctx context.Context, r *ActivateAPITokenRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/apitoken", "activate-api-token")
+	logger.Debug("handling-activate-api-token-request")
 
 	_, err := s.updateAPIToken(ctx, &updateAPITokenRequest{
 		APITokenID: r.ID,
@@ -232,6 +240,8 @@ func (s *Service) ActivateAPIToken(ctx context.Context, r *ActivateAPITokenReque
 // RevokeAPIToken updates the API Token's Status to `REVOKE` if the token matches the ID passed
 // TODO: Create tests
 func (s *Service) RevokeAPIToken(ctx context.Context, r *RevokeAPITokenRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/apitoken", "revoke-api-token")
+	logger.Debug("handling-revoke-api-token-request")
 
 	_, err := s.updateAPIToken(ctx, &updateAPITokenRequest{
 		APITokenID: r.ID,
@@ -245,6 +255,8 @@ func (s *Service) RevokeAPIToken(ctx context.Context, r *RevokeAPITokenRequest) 
 // as well as purging corresponding user embedded collection returning an error
 // if any failures occur.
 func (s *Service) DeleteAPIToken(ctx context.Context, r *DeleteAPITokenRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/apitoken", "delete-api-token")
+	logger.Debug("handling-delete-api-token-request")
 
 	return s.ApitokenRespository.DeleteAPITokenFor(ctx, r.UserID, r.APITokenID)
 }
@@ -255,7 +267,7 @@ func (s *Service) GetAPITokensFor(ctx context.Context, r *GetAPITokensForRequest
 
 	var err error
 
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/apitoken")
 
 	// default
 	if r.Order == "" {
@@ -278,7 +290,7 @@ func (s *Service) GetAPITokensFor(ctx context.Context, r *GetAPITokensForRequest
 
 	r.TotalCount = int(totalApiTokens)
 
-	log.Info("total-api-tokens-for-user-found", zap.Int64("total", totalApiTokens))
+	logger.Debug("total-api-tokens-for-user-found", zap.Int64("total", totalApiTokens))
 
 	apitokens, err := s.ApitokenRespository.GetAPITokens(ctx, &GetAPITokensRequest{
 		Order:           r.Order,
@@ -330,6 +342,8 @@ func (s *Service) GetAPITokensFor(ctx context.Context, r *GetAPITokensForRequest
 // GetAPIToken returns the API Token matching the ID stored in repository
 // TODO: Create tests
 func (s *Service) GetAPIToken(ctx context.Context, r *GetAPITokenRequest) (*GetAPITokenResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/apitoken", "get-api-token")
+	logger.Debug("handling-get-api-token-request")
 
 	apitoken, err := s.ApitokenRespository.GetAPITokenByID(ctx, r.ID)
 	if err != nil {
@@ -359,7 +373,7 @@ func (s *Service) GetAPIToken(ctx context.Context, r *GetAPITokenRequest) (*GetA
 // TODO: Create tests
 func (s *Service) GetAPITokens(ctx context.Context, r *GetAPITokensRequest) (*GetAPITokensResponse, error) {
 
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/apitoken")
 
 	// default
 	if r.Order == "" {
@@ -382,7 +396,7 @@ func (s *Service) GetAPITokens(ctx context.Context, r *GetAPITokensRequest) (*Ge
 
 	r.TotalCount = int(totalApiTokens)
 
-	log.Info("total-api-tokens-found", zap.Int64("total", totalApiTokens))
+	logger.Info("total-api-tokens-found", zap.Int64("total", totalApiTokens))
 
 	apitokens, err := s.ApitokenRespository.GetAPITokens(ctx, r)
 	if err != nil {
@@ -428,7 +442,7 @@ func (s *Service) analyseTokenTTLData(ctx context.Context, r *AnalyseTokenTTLDat
 	var userApiTokensToRemove []string
 	var userId string
 	var validUserApiTokens []UserAPIToken
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/apitoken")
 
 	if r == nil {
 		return []UserAPIToken{}
@@ -448,7 +462,7 @@ func (s *Service) analyseTokenTTLData(ctx context.Context, r *AnalyseTokenTTLDat
 
 		expiration, err := time.Parse(common.RFC3339NanoUTC, apiToken.TtlExpiresAt)
 		if err != nil {
-			log.Warn("unable-to-parse-user-api-token-expiry-date", zap.String("token-id", apiToken.ID), zap.String("expiry-date", apiToken.TtlExpiresAt), zap.String("user-id", apiToken.CreatedByID))
+			logger.Warn("unable-to-parse-user-api-token-expiry-date", zap.String("token-id", apiToken.ID), zap.String("expiry-date", apiToken.TtlExpiresAt), zap.String("user-id", apiToken.CreatedByID))
 			continue
 		}
 
@@ -477,7 +491,7 @@ func (s *Service) analyseTokenTTLData(ctx context.Context, r *AnalyseTokenTTLDat
 
 		//  if it fails just log a message and carry on by passing newly structured user object
 		if err != nil {
-			log.Error("failed-to-remove-expired-user-api-token", zap.String("token-id", userTokenId), zap.String("user-id", userId))
+			logger.Error("failed-to-remove-expired-user-api-token", zap.String("token-id", userTokenId), zap.String("user-id", userId))
 		}
 	}
 
@@ -489,6 +503,8 @@ func (s *Service) analyseTokenTTLData(ctx context.Context, r *AnalyseTokenTTLDat
 //
 // TODO: Consider whether user's should be able to update their description
 func (s *Service) updateAPIToken(ctx context.Context, r *updateAPITokenRequest) (*updateAPITokenResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/apitoken", "update-api-token")
+	logger.Debug("handling-update-api-token-request")
 
 	apiToken, err := s.ApitokenRespository.GetAPITokenByID(ctx, r.APITokenID)
 	if err != nil {

--- a/external/audit/service.go
+++ b/external/audit/service.go
@@ -29,7 +29,7 @@ func NewService(AuditRespository AuditRespository) *Service {
 // LogAuditEvent handles creating an log entry event into audit repository
 // TODO: Create tests
 func (s *Service) LogAuditEvent(ctx context.Context, r *LogAuditEventRequest) error {
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/audit")
 
 	entry := AuditLogEntry{
 		ActorId:    r.ActorId,
@@ -40,7 +40,7 @@ func (s *Service) LogAuditEvent(ctx context.Context, r *LogAuditEventRequest) er
 			finalDomainName, err := toolbox.StringConvertToKebabCase(domainName)
 			if err != nil {
 				finalDomainName := toolbox.StringConvertToSnakeCase(toolbox.StringStandardisedToLower(domainName))
-				log.Warn("unable-to-normalise-domain-name-with-tag-rules", zap.String("original-name", domainName), zap.String("final-name", finalDomainName))
+				logger.Warn("unable-to-normalise-domain-name-with-tag-rules", zap.String("original-name", domainName), zap.String("final-name", finalDomainName))
 				return finalDomainName
 			}
 
@@ -59,5 +59,8 @@ func (s *Service) LogAuditEvent(ctx context.Context, r *LogAuditEventRequest) er
 
 // GetTotalAuditLogEvents gets the total on audit-based on passed values
 func (s *Service) GetTotalAuditLogEvents(ctx context.Context, r *GetTotalAuditLogEventsRequest) (int64, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/audit", "get-total-audit-log-events")
+	logger.Debug("handling-get-total-audit-log-events-request")
+
 	return s.AuditRespository.GetTotalAuditLogEvents(ctx, r.UserId, r.To, r.From, r.Domains, r.Actions, r.TargetId, r.TargetTypes)
 }

--- a/external/auth/service.go
+++ b/external/auth/service.go
@@ -58,6 +58,10 @@ func NewService(request *NewServiceRequest) *Service {
 // CreateInitalToken creates a short-lived JWT token for initial user verification.
 // The token is valid for 5 minutes and contains basic user information.
 func (s *Service) CreateInitalToken(ctx context.Context, user UserModel) (*TokenDetails, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "create-initial-token")
+	userID := user.GetUserId()
+	logger.Debug("auth-initial-token-create-started", zap.String("user-id", userID), zap.Bool("admin", user.IsAdmin()))
+
 	td := &TokenDetails{}
 	td.EtExpires = toolbox.GenerateTimeOfExpiryAsSeconds(initialTokenDefaultTTL)
 	td.EtTTL = getTokenTimeToLive(td.EtExpires)
@@ -74,15 +78,21 @@ func (s *Service) CreateInitalToken(ctx context.Context, user UserModel) (*Token
 	var err error
 	td.EphemeralToken, err = et.SignedString([]byte(s.accessTokenSecret))
 	if err != nil {
+		logger.Error("auth-initial-token-signing-failed", zap.String("user-id", userID), zap.Error(err))
 		return nil, fmt.Errorf("signing ephemeral token: %w", err)
 	}
 
+	logger.Debug("auth-initial-token-created", zap.String("user-id", userID), zap.Duration("ttl", td.EtTTL))
 	return td, nil
 }
 
 // CreateEmailVerificationToken creates a short-lived JWT token for email verification.
 // The token is valid for 10 minutes and must be used to verify the user's email address.
 func (s *Service) CreateEmailVerificationToken(ctx context.Context, user UserModel) (*TokenDetails, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "create-email-verification-token")
+	userID := user.GetUserId()
+	logger.Debug("auth-email-verification-token-create-started", zap.String("user-id", userID))
+
 	td := &TokenDetails{}
 	td.EvExpires = toolbox.GenerateTimeOfExpiryAsSeconds(emailVerificationTokenDefaultTTL)
 	td.EvTTL = getTokenTimeToLive(td.EvExpires)
@@ -99,9 +109,11 @@ func (s *Service) CreateEmailVerificationToken(ctx context.Context, user UserMod
 	var err error
 	td.EmailVerificationToken, err = evt.SignedString([]byte(s.accessTokenSecret))
 	if err != nil {
+		logger.Error("auth-email-verification-token-signing-failed", zap.String("user-id", userID), zap.Error(err))
 		return nil, fmt.Errorf("signing email verification token: %w", err)
 	}
 
+	logger.Debug("auth-email-verification-token-created", zap.String("user-id", userID), zap.Duration("ttl", td.EvTTL))
 	return td, nil
 }
 
@@ -110,6 +122,10 @@ func (s *Service) CreateEmailVerificationToken(ctx context.Context, user UserMod
 // Access tokens are valid for 15 minutes and contain user session information.
 // Refresh tokens are valid for 7 days and can be used to obtain new access tokens.
 func (s *Service) CreateToken(ctx context.Context, user UserModel) (*TokenDetails, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "create-token")
+	userID := user.GetUserId()
+	logger.Debug("auth-token-create-started", zap.String("user-id", userID), zap.Bool("admin", user.IsAdmin()), zap.String("user-status", user.GetUserStatus()))
+
 	td := &TokenDetails{}
 	td.AtExpires = toolbox.GenerateTimeOfExpiryAsSeconds(accesstokenDefaultTTL)
 	td.AtTTL = getTokenTimeToLive(td.AtExpires)
@@ -129,6 +145,7 @@ func (s *Service) CreateToken(ctx context.Context, user UserModel) (*TokenDetail
 	var err error
 	td.AccessToken, err = at.SignedString([]byte(s.accessTokenSecret))
 	if err != nil {
+		logger.Error("auth-access-token-signing-failed", zap.String("user-id", userID), zap.Error(err))
 		return nil, fmt.Errorf("signing access token: %w", err)
 	}
 
@@ -141,9 +158,11 @@ func (s *Service) CreateToken(ctx context.Context, user UserModel) (*TokenDetail
 
 	td.RefreshToken, err = rt.SignedString([]byte(s.refreshTokenSecret))
 	if err != nil {
+		logger.Error("auth-refresh-token-signing-failed", zap.String("user-id", userID), zap.Error(err))
 		return nil, fmt.Errorf("signing refresh token: %w", err)
 	}
 
+	logger.Debug("auth-token-created", zap.String("user-id", userID), zap.Duration("access-token-ttl", td.AtTTL), zap.Duration("refresh-token-ttl", td.RtTTL))
 	return td, nil
 }
 
@@ -152,24 +171,37 @@ func (s *Service) CreateToken(ctx context.Context, user UserModel) (*TokenDetail
 // Returns an error if no Authorization header is present or if the header
 // format is invalid.
 func (s *Service) ExtractToken(ctx context.Context, r *http.Request) (string, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "extract-token")
 	authorization := r.Header.Get(httpHeaderKeyAuthorization)
 	if authorization == "" {
+		logger.Warn("auth-bearer-header-missing", zap.String("path", r.URL.Path))
 		return "", ErrNoBearerHeaderFound
 	}
 
-	return getTokenFromHeaderBearerToken(authorization), nil
+	token := getTokenFromHeaderBearerToken(authorization)
+	logger.Debug("auth-bearer-token-extracted", zap.String("path", r.URL.Path), zap.Int("token-length", len(token)))
+	return token, nil
 }
 
 // VerifyToken extracts and verifies the JWT token from the request.
 //
 // It validates the token signature and returns the parsed token if valid.
 func (s *Service) VerifyToken(ctx context.Context, r *http.Request) (*jwt.Token, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "verify-token")
 	tokenString, err := s.ExtractToken(ctx, r)
 	if err != nil {
+		logger.Warn("auth-token-extract-failed", zap.String("path", r.URL.Path), zap.Error(err))
 		return nil, err
 	}
 
-	return s.ParseAccessTokenFromString(ctx, tokenString)
+	token, err := s.ParseAccessTokenFromString(ctx, tokenString)
+	if err != nil {
+		logger.Warn("auth-token-parse-failed", zap.String("path", r.URL.Path), zap.Error(err))
+		return nil, err
+	}
+
+	logger.Debug("auth-token-verified", zap.String("path", r.URL.Path))
+	return token, nil
 }
 
 // ParseAccessTokenFromString parses and validates a JWT token string.
@@ -177,11 +209,11 @@ func (s *Service) VerifyToken(ctx context.Context, r *http.Request) (*jwt.Token,
 // It ensures the token uses HMAC signing and returns detailed errors for
 // expiration, malformed tokens, and other validation failures.
 func (s *Service) ParseAccessTokenFromString(ctx context.Context, tokenAsString string) (*jwt.Token, error) {
-	log := logger.Get(ctx)
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "parse-access-token")
 
 	token, err := jwt.Parse(tokenAsString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			log.Error("unexpected-signing-method", zap.Any("method", token.Header[tokenHeaderKeyAlg]))
+			logger.Error("unexpected-signing-method", zap.Any("method", token.Header[tokenHeaderKeyAlg]))
 			return nil, ErrUnauthorizedTokenUnexpectedSigningMethod
 		}
 		return []byte(s.accessTokenSecret), nil
@@ -190,15 +222,18 @@ func (s *Service) ParseAccessTokenFromString(ctx context.Context, tokenAsString 
 	if err != nil {
 		switch err.Error() {
 		case "Token is expired":
+			logger.Warn("access-token-expired")
 			return nil, ErrUnauthorizedParsedStringTokenExpired
 		case "token contains an invalid number of segments":
+			logger.Warn("access-token-malformatted")
 			return nil, ErrUnauthorizedMalformattedToken
 		default:
-			log.Error("token-parsing-error", zap.Error(err))
+			logger.Error("token-parsing-error", zap.Error(err))
 			return nil, ErrUnauthorizedParsedStringUnknown
 		}
 	}
 
+	logger.Debug("access-token-parsed")
 	return token, nil
 }
 
@@ -206,11 +241,11 @@ func (s *Service) ParseAccessTokenFromString(ctx context.Context, tokenAsString 
 //
 // Similar to ParseAccessTokenFromString but uses the refresh token secret.
 func (s *Service) ParseRefreshTokenFromString(ctx context.Context, tokenAsString string) (*jwt.Token, error) {
-	log := logger.Get(ctx)
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "parse-refresh-token")
 
 	token, err := jwt.Parse(tokenAsString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			log.Error("unexpected-signing-method", zap.Any("method", token.Header[tokenHeaderKeyAlg]))
+			logger.Error("unexpected-signing-method", zap.Any("method", token.Header[tokenHeaderKeyAlg]))
 			return nil, ErrUnauthorizedTokenUnexpectedSigningMethod
 		}
 		return []byte(s.refreshTokenSecret), nil
@@ -219,29 +254,36 @@ func (s *Service) ParseRefreshTokenFromString(ctx context.Context, tokenAsString
 	if err != nil {
 		switch err.Error() {
 		case "Token is expired":
+			logger.Warn("refresh-token-expired")
 			return nil, ErrUnauthorizedParsedStringTokenExpired
 		case "token contains an invalid number of segments":
+			logger.Warn("refresh-token-malformatted")
 			return nil, ErrUnauthorizedMalformattedToken
 		default:
-			log.Error("token-parsing-error", zap.Error(err))
+			logger.Error("token-parsing-error", zap.Error(err))
 			return nil, ErrUnauthorizedParsedStringUnknown
 		}
 	}
 
+	logger.Debug("refresh-token-parsed")
 	return token, nil
 }
 
 // CheckTokenIsValid verifies that the token is valid and has not expired.
 func (s *Service) CheckTokenIsValid(ctx context.Context, r *http.Request) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "check-token-is-valid")
 	token, err := s.VerifyToken(ctx, r)
 	if err != nil {
+		logger.Warn("auth-token-validation-failed", zap.String("path", r.URL.Path), zap.Error(err))
 		return err
 	}
 
 	if _, ok := token.Claims.(jwt.Claims); !ok && !token.Valid {
+		logger.Warn("auth-token-invalid-claims", zap.String("path", r.URL.Path))
 		return ErrUnauthorized
 	}
 
+	logger.Debug("auth-token-valid", zap.String("path", r.URL.Path))
 	return nil
 }
 
@@ -249,61 +291,94 @@ func (s *Service) CheckTokenIsValid(ctx context.Context, r *http.Request) error 
 //
 // Returns TokenAccessDetails containing user ID, access UUID, and authorization status.
 func (s *Service) ExtractTokenMetadata(ctx context.Context, r *http.Request) (*TokenAccessDetails, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "extract-token-metadata")
 	token, err := s.VerifyToken(ctx, r)
 	if err != nil {
+		logger.Warn("auth-token-metadata-verify-failed", zap.String("path", r.URL.Path), zap.Error(err))
 		return nil, err
 	}
 
-	return s.CheckAccessTokenValidityGetDetails(ctx, token)
+	details, err := s.CheckAccessTokenValidityGetDetails(ctx, token)
+	if err != nil {
+		logger.Warn("auth-token-metadata-extract-failed", zap.String("path", r.URL.Path), zap.Error(err))
+		return nil, err
+	}
+
+	logger.Debug("auth-token-metadata-extracted", zap.String("path", r.URL.Path), zap.String("user-id", details.UserID), zap.Bool("admin", details.IsAdmin), zap.Bool("authorized", details.IsAuthorized))
+	return details, nil
 }
 
 // ExtractRefreshTokenMetadataByString retrieves refresh token metadata from a token string.
 func (s *Service) ExtractRefreshTokenMetadataByString(ctx context.Context, tokenAsString string) (*TokenRefreshDetails, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "extract-refresh-token-metadata")
 	token, err := s.ParseRefreshTokenFromString(ctx, tokenAsString)
 	if err != nil {
+		logger.Warn("auth-refresh-token-metadata-parse-failed", zap.Error(err))
 		return nil, err
 	}
 
-	return s.GetRefreshTokenUUID(ctx, token)
+	details, err := s.GetRefreshTokenUUID(ctx, token)
+	if err != nil {
+		logger.Warn("auth-refresh-token-metadata-extract-failed", zap.Error(err))
+		return nil, err
+	}
+
+	logger.Debug("auth-refresh-token-metadata-extracted", zap.String("user-id", details.UserID))
+	return details, nil
 }
 
 // ExtractAccessTokenMetadataByString retrieves access token metadata from a token string.
 func (s *Service) ExtractAccessTokenMetadataByString(ctx context.Context, tokenAsString string) (*TokenAccessDetails, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "extract-access-token-metadata")
 	token, err := s.ParseAccessTokenFromString(ctx, tokenAsString)
 	if err != nil {
+		logger.Warn("auth-access-token-metadata-parse-failed", zap.Error(err))
 		return nil, err
 	}
 
-	return s.CheckAccessTokenValidityGetDetails(ctx, token)
+	details, err := s.CheckAccessTokenValidityGetDetails(ctx, token)
+	if err != nil {
+		logger.Warn("auth-access-token-metadata-extract-failed", zap.Error(err))
+		return nil, err
+	}
+
+	logger.Debug("auth-access-token-metadata-extracted", zap.String("user-id", details.UserID), zap.Bool("admin", details.IsAdmin), zap.Bool("authorized", details.IsAuthorized))
+	return details, nil
 }
 
 // CheckAccessTokenValidityGetDetails return details of a valid acess token
 // TODO: Create tests
 func (s *Service) CheckAccessTokenValidityGetDetails(ctx context.Context, token *jwt.Token) (*TokenAccessDetails, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "check-access-token-validity-get-details")
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if ok && token.Valid {
 		accessUUID, ok := claims[tokenClaimKeyAccessUUID].(string)
 		if !ok {
+			logger.Warn("auth-access-token-missing-access-uuid")
 			return nil, ErrUnauthorizedNoTokenUUID
 		}
 
 		userID, ok := claims[tokenClaimKeySub].(string)
 		if !ok {
+			logger.Warn("auth-access-token-missing-user-id")
 			return nil, ErrUnauthorizedNoUserIDFound
 		}
 
 		isAdmin, ok := claims[tokenClaimKeyAdmin].(bool)
 		if !ok {
+			logger.Warn("auth-access-token-missing-admin-claim", zap.String("user-id", userID))
 			return nil, ErrUnauthorizedNoAdminInfoFound
 		}
 
 		// Check user if active
 		isActive, ok := claims[tokenClaimKeyAuthorized].(bool)
 		if !ok {
+			logger.Warn("auth-access-token-missing-authorized-claim", zap.String("user-id", userID))
 			return nil, ErrUnauthorizedNoAuthorizationInfoFound
 		}
 
+		logger.Debug("auth-access-token-details-valid", zap.String("user-id", userID), zap.Bool("admin", isAdmin), zap.Bool("authorized", isActive))
 		return &TokenAccessDetails{
 			AccessUUID:   accessUUID,
 			UserID:       userID,
@@ -311,6 +386,7 @@ func (s *Service) CheckAccessTokenValidityGetDetails(ctx context.Context, token 
 			IsAuthorized: isActive,
 		}, nil
 	}
+	logger.Warn("auth-access-token-invalid")
 	return nil, ErrUnauthorized
 
 }
@@ -319,16 +395,20 @@ func (s *Service) CheckAccessTokenValidityGetDetails(ctx context.Context, token 
 // the token method conform to "SigningMethodHMAC"
 // TODO: Create tests
 func (s *Service) VerifyRefreshToken(ctx context.Context, t string) (*jwt.Token, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "verify-refresh-token")
 
 	token, err := jwt.Parse(t, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			logger.Error("refresh-token-unexpected-signing-method", zap.Any("method", token.Header[tokenHeaderKeyAlg]))
 			return nil, fmt.Errorf("unexpected-signing-method: %v", token.Header[tokenHeaderKeyAlg])
 		}
 		return []byte(s.refreshTokenSecret), nil
 	})
 	if err != nil {
+		logger.Warn("refresh-token-verification-failed", zap.Error(err))
 		return nil, ErrUnauthorizedRefreshTokenExpired
 	}
+	logger.Debug("refresh-token-verified")
 	return token, nil
 }
 
@@ -336,13 +416,17 @@ func (s *Service) VerifyRefreshToken(ctx context.Context, t string) (*jwt.Token,
 // usable
 // TODO: Create tests
 func (s *Service) CheckRefreshTokenIsValid(ctx context.Context, t string) (*jwt.Token, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "check-refresh-token-is-valid")
 	token, err := s.VerifyRefreshToken(ctx, t)
 	if err != nil {
+		logger.Warn("refresh-token-validation-failed", zap.Error(err))
 		return nil, err
 	}
 	if _, ok := token.Claims.(jwt.Claims); !ok && !token.Valid {
+		logger.Warn("refresh-token-invalid-claims")
 		return nil, err
 	}
+	logger.Debug("refresh-token-valid")
 	return token, nil
 }
 
@@ -350,6 +434,7 @@ func (s *Service) CheckRefreshTokenIsValid(ctx context.Context, t string) (*jwt.
 // Only if the token is valid i.e. the token claims should conform to
 // TODO: Create tests
 func (s *Service) GetRefreshTokenUUID(ctx context.Context, token *jwt.Token) (*TokenRefreshDetails, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/auth", "get-refresh-token-uuid")
 
 	var refreshDetails TokenRefreshDetails
 
@@ -357,12 +442,15 @@ func (s *Service) GetRefreshTokenUUID(ctx context.Context, token *jwt.Token) (*T
 	if ok && token.Valid {
 		refreshDetails.RefreshUUID, ok = claims[tokenClaimKeyRefreshUUID].(string)
 		if !ok {
+			logger.Warn("refresh-token-missing-refresh-uuid")
 			return nil, ErrUnauthorizedNoTokenUUID
 		}
 		refreshDetails.UserID, ok = claims[tokenClaimKeySub].(string)
 		if !ok {
+			logger.Warn("refresh-token-missing-user-id")
 			return nil, ErrUnauthorizedNoUserIDFound
 		}
+		logger.Debug("refresh-token-uuid-extracted", zap.String("user-id", refreshDetails.UserID))
 	}
 
 	return &refreshDetails, nil

--- a/external/billing/logging.go
+++ b/external/billing/logging.go
@@ -1,0 +1,7 @@
+package billing
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/billing/service.go
+++ b/external/billing/service.go
@@ -72,9 +72,7 @@ func (s *Service) WithAuditService(audit AuditService) *Service {
 // CreateSubscription creates a new subscription
 func (s *Service) CreateSubscription(ctx context.Context, req *CreateSubscriptionRequest) (*CreateSubscriptionResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 
 		newSubscription = &Subscription{
 			UserID:                   req.UserID,
@@ -97,18 +95,18 @@ func (s *Service) CreateSubscription(ctx context.Context, req *CreateSubscriptio
 		}
 	)
 
-	log.Debug("initiating-create-subscription-request", zap.Any("request", req))
+	logger.Debug("initiating-create-subscription-request", zap.Any("request", safeLogValue(req)))
 
 	// Generate ID and timestamps
 	newSubscription.GenerateId().SetCreatedAtTimeToNow().SetUpdatedAtTimeToNow()
 
 	createdSubscription, err := s.subscriptionRepository.CreateSubscription(ctx, newSubscription)
 	if err != nil {
-		log.Error("failed-to-create-subscription-error-creating-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-subscription-error-creating-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CreateSubscriptionResponse{}, err
 	}
 
-	log.Debug("create-subscription-request-successful", zap.Any("request", req), zap.Any("created-subscription", createdSubscription))
+	logger.Debug("create-subscription-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("created-subscription", safeLogValue(createdSubscription)))
 
 	return &CreateSubscriptionResponse{
 		Subscription: createdSubscription,
@@ -118,17 +116,15 @@ func (s *Service) CreateSubscription(ctx context.Context, req *CreateSubscriptio
 // UpdateSubscription updates an existing subscription
 func (s *Service) UpdateSubscription(ctx context.Context, req *UpdateSubscriptionRequest) (*UpdateSubscriptionResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-update-subscription-request", zap.Any("request", req))
+	logger.Debug("initiating-update-subscription-request", zap.Any("request", safeLogValue(req)))
 
 	// Get existing subscription
 	subscription, err := s.subscriptionRepository.GetSubscriptionByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-update-subscription-error-getting-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-update-subscription-error-getting-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &UpdateSubscriptionResponse{}, err
 	}
 
@@ -177,11 +173,11 @@ func (s *Service) UpdateSubscription(ctx context.Context, req *UpdateSubscriptio
 
 	updatedSubscription, err := s.subscriptionRepository.UpdateSubscription(ctx, subscription)
 	if err != nil {
-		log.Error("failed-to-update-subscription-error-updating-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-update-subscription-error-updating-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &UpdateSubscriptionResponse{}, err
 	}
 
-	log.Debug("update-subscription-request-successful", zap.Any("request", req), zap.Any("updated-subscription", updatedSubscription))
+	logger.Debug("update-subscription-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("updated-subscription", safeLogValue(updatedSubscription)))
 
 	return &UpdateSubscriptionResponse{
 		Subscription: updatedSubscription,
@@ -191,9 +187,7 @@ func (s *Service) UpdateSubscription(ctx context.Context, req *UpdateSubscriptio
 // GetSubscriptions returns a list of subscriptions
 func (s *Service) GetSubscriptions(ctx context.Context, req *GetSubscriptionsRequest) (*GetSubscriptionsResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
 	// Set defaults
@@ -228,16 +222,16 @@ func (s *Service) GetSubscriptions(ctx context.Context, req *GetSubscriptionsReq
 
 	totalSubscriptions, err := s.subscriptionRepository.GetTotalSubscriptions(ctx, getTotalSubscriptionsRequest)
 	if err != nil {
-		log.Error("failed-to-get-subscriptions-request-error-getting-total-subscriptions", zap.Any("request", req), zap.Any("get-total-subscriptions-request", getTotalSubscriptionsRequest), zap.Error(err))
+		logger.Error("failed-to-get-subscriptions-request-error-getting-total-subscriptions", zap.Any("request", safeLogValue(req)), zap.Any("get-total-subscriptions-request", safeLogValue(getTotalSubscriptionsRequest)), zap.Error(err))
 		return &GetSubscriptionsResponse{}, err
 	}
 
 	req.TotalCount = int(totalSubscriptions)
-	log.Debug("handling-get-subscriptions-request-total-subscriptions-found", zap.Int64("total", totalSubscriptions), zap.Any("request", req))
+	logger.Debug("handling-get-subscriptions-request-total-subscriptions-found", zap.Int64("total", totalSubscriptions), zap.Any("request", safeLogValue(req)))
 
 	subscriptions, err := s.subscriptionRepository.GetSubscriptions(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-subscriptions-request-error-getting-subscriptions", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-subscriptions-request-error-getting-subscriptions", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetSubscriptionsResponse{}, err
 	}
 
@@ -262,20 +256,18 @@ func (s *Service) GetSubscriptions(ctx context.Context, req *GetSubscriptionsReq
 // GetSubscriptionByID retrieves a subscription by its internal ID
 func (s *Service) GetSubscriptionByID(ctx context.Context, req *GetSubscriptionByIDRequest) (*GetSubscriptionByIDResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-get-subscription-by-id-request", zap.Any("request", req))
+	logger.Debug("initiating-get-subscription-by-id-request", zap.Any("request", safeLogValue(req)))
 
 	subscription, err := s.subscriptionRepository.GetSubscriptionByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-subscription-by-id-error-getting-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-subscription-by-id-error-getting-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetSubscriptionByIDResponse{}, err
 	}
 
-	log.Debug("get-subscription-by-id-request-successful", zap.Any("request", req), zap.Any("subscription", subscription))
+	logger.Debug("get-subscription-by-id-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("subscription", safeLogValue(subscription)))
 
 	return &GetSubscriptionByIDResponse{
 		Subscription: subscription,
@@ -285,20 +277,18 @@ func (s *Service) GetSubscriptionByID(ctx context.Context, req *GetSubscriptionB
 // GetSubscriptionByIntegratorID retrieves a subscription by integrator subscription ID
 func (s *Service) GetSubscriptionByIntegratorID(ctx context.Context, req *GetSubscriptionByIntegratorIDRequest) (*GetSubscriptionByIntegratorIDResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-get-subscription-by-integrator-id-request", zap.Any("request", req))
+	logger.Debug("initiating-get-subscription-by-integrator-id-request", zap.Any("request", safeLogValue(req)))
 
 	subscription, err := s.subscriptionRepository.GetSubscriptionByIntegratorID(ctx, req.IntegratorName, req.IntegratorSubscriptionID)
 	if err != nil {
-		log.Error("failed-to-get-subscription-by-integrator-id-error-getting-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-subscription-by-integrator-id-error-getting-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetSubscriptionByIntegratorIDResponse{}, err
 	}
 
-	log.Debug("get-subscription-by-integrator-id-request-successful", zap.Any("request", req), zap.Any("subscription", subscription))
+	logger.Debug("get-subscription-by-integrator-id-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("subscription", safeLogValue(subscription)))
 
 	return &GetSubscriptionByIntegratorIDResponse{
 		Subscription: subscription,
@@ -308,17 +298,15 @@ func (s *Service) GetSubscriptionByIntegratorID(ctx context.Context, req *GetSub
 // CancelSubscription cancels a subscription
 func (s *Service) CancelSubscription(ctx context.Context, req *CancelSubscriptionRequest) (*CancelSubscriptionResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-cancel-subscription-request", zap.Any("request", req))
+	logger.Debug("initiating-cancel-subscription-request", zap.Any("request", safeLogValue(req)))
 
 	// Get existing subscription
 	subscription, err := s.subscriptionRepository.GetSubscriptionByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-cancel-subscription-error-getting-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-cancel-subscription-error-getting-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CancelSubscriptionResponse{}, err
 	}
 
@@ -331,11 +319,11 @@ func (s *Service) CancelSubscription(ctx context.Context, req *CancelSubscriptio
 
 	updatedSubscription, err := s.subscriptionRepository.UpdateSubscription(ctx, subscription)
 	if err != nil {
-		log.Error("failed-to-cancel-subscription-error-updating-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-cancel-subscription-error-updating-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CancelSubscriptionResponse{}, err
 	}
 
-	log.Debug("cancel-subscription-request-successful", zap.Any("request", req), zap.Any("cancelled-subscription", updatedSubscription))
+	logger.Debug("cancel-subscription-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("cancelled-subscription", safeLogValue(updatedSubscription)))
 
 	return &CancelSubscriptionResponse{
 		Subscription: updatedSubscription,
@@ -345,20 +333,18 @@ func (s *Service) CancelSubscription(ctx context.Context, req *CancelSubscriptio
 // DeleteSubscription deletes a subscription
 func (s *Service) DeleteSubscription(ctx context.Context, req *DeleteSubscriptionRequest) (*DeleteSubscriptionResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-delete-subscription-request", zap.Any("request", req))
+	logger.Debug("initiating-delete-subscription-request", zap.Any("request", safeLogValue(req)))
 
 	err := s.subscriptionRepository.DeleteSubscription(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-delete-subscription-error-deleting-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-delete-subscription-error-deleting-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &DeleteSubscriptionResponse{}, err
 	}
 
-	log.Debug("delete-subscription-request-successful", zap.Any("request", req))
+	logger.Debug("delete-subscription-request-successful", zap.Any("request", safeLogValue(req)))
 
 	return &DeleteSubscriptionResponse{
 		Success: true,
@@ -368,9 +354,7 @@ func (s *Service) DeleteSubscription(ctx context.Context, req *DeleteSubscriptio
 // CreateBillingEvent creates a new billing event
 func (s *Service) CreateBillingEvent(ctx context.Context, req *CreateBillingEventRequest) (*CreateBillingEventResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 
 		newEvent = &BillingEvent{
 			SubscriptionID:           req.SubscriptionID,
@@ -390,18 +374,18 @@ func (s *Service) CreateBillingEvent(ctx context.Context, req *CreateBillingEven
 		}
 	)
 
-	log.Debug("initiating-create-billing-event-request", zap.Any("request", req))
+	logger.Debug("initiating-create-billing-event-request", zap.Any("request", safeLogValue(req)))
 
 	// Generate ID and timestamps
 	newEvent.GenerateId().SetCreatedAtTimeToNow().SetUpdatedAtTimeToNow()
 
 	createdEvent, err := s.billingEventsRepository.CreateBillingEvent(ctx, newEvent)
 	if err != nil {
-		log.Error("failed-to-create-billing-event-error-creating-event", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-billing-event-error-creating-event", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CreateBillingEventResponse{}, err
 	}
 
-	log.Debug("create-billing-event-request-successful", zap.Any("request", req), zap.Any("created-event", createdEvent))
+	logger.Debug("create-billing-event-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("created-event", safeLogValue(createdEvent)))
 
 	return &CreateBillingEventResponse{
 		BillingEvent: createdEvent,
@@ -411,9 +395,7 @@ func (s *Service) CreateBillingEvent(ctx context.Context, req *CreateBillingEven
 // GetBillingEvents returns a list of billing events
 func (s *Service) GetBillingEvents(ctx context.Context, req *GetBillingEventsRequest) (*GetBillingEventsResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
 	// Set defaults
@@ -447,16 +429,16 @@ func (s *Service) GetBillingEvents(ctx context.Context, req *GetBillingEventsReq
 
 	totalEvents, err := s.billingEventsRepository.GetTotalBillingEvents(ctx, getTotalBillingEventsRequest)
 	if err != nil {
-		log.Error("failed-to-get-billing-events-request-error-getting-total-events", zap.Any("request", req), zap.Any("get-total-events-request", getTotalBillingEventsRequest), zap.Error(err))
+		logger.Error("failed-to-get-billing-events-request-error-getting-total-events", zap.Any("request", safeLogValue(req)), zap.Any("get-total-events-request", safeLogValue(getTotalBillingEventsRequest)), zap.Error(err))
 		return &GetBillingEventsResponse{}, err
 	}
 
 	req.TotalCount = int(totalEvents)
-	log.Debug("handling-get-billing-events-request-total-events-found", zap.Int64("total", totalEvents), zap.Any("request", req))
+	logger.Debug("handling-get-billing-events-request-total-events-found", zap.Int64("total", totalEvents), zap.Any("request", safeLogValue(req)))
 
 	events, err := s.billingEventsRepository.GetBillingEvents(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-billing-events-request-error-getting-events", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-billing-events-request-error-getting-events", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetBillingEventsResponse{}, err
 	}
 
@@ -481,31 +463,29 @@ func (s *Service) GetBillingEvents(ctx context.Context, req *GetBillingEventsReq
 // GetSubscriptionsByEmail retrieves all subscriptions for a given email address
 func (s *Service) GetSubscriptionsByEmail(ctx context.Context, req *GetSubscriptionsByEmailRequest) (*GetSubscriptionsByEmailResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-get-subscriptions-by-email-request", zap.Any("request", req))
+	logger.Debug("initiating-get-subscriptions-by-email-request", zap.Any("request", safeLogValue(req)))
 
 	// Standardise email to lowercase
 	standardisedEmail := toolbox.StringStandardisedToLower(req.Email)
 
 	subscriptions, err := s.subscriptionRepository.GetSubscriptionsByEmail(ctx, standardisedEmail)
 	if err != nil {
-		log.Error("failed-to-get-subscriptions-by-email-error-getting-subscriptions", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-subscriptions-by-email-error-getting-subscriptions", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetSubscriptionsByEmailResponse{}, err
 	}
 
 	if len(subscriptions) == 0 {
-		log.Debug("get-subscriptions-by-email-no-subscriptions-found", zap.Any("request", req))
+		logger.Debug("get-subscriptions-by-email-no-subscriptions-found", zap.Any("request", safeLogValue(req)))
 		return &GetSubscriptionsByEmailResponse{
 			Subscriptions: []Subscription{},
 			Total:         0,
 		}, nil
 	}
 
-	log.Debug("get-subscriptions-by-email-request-successful", zap.Any("request", req), zap.Int("count", len(subscriptions)))
+	logger.Debug("get-subscriptions-by-email-request-successful", zap.Any("request", safeLogValue(req)), zap.Int("count", len(subscriptions)))
 
 	return &GetSubscriptionsByEmailResponse{
 		Subscriptions: subscriptions,
@@ -516,31 +496,29 @@ func (s *Service) GetSubscriptionsByEmail(ctx context.Context, req *GetSubscript
 // GetBillingEventsByEmail retrieves all billing events for a given email address
 func (s *Service) GetBillingEventsByEmail(ctx context.Context, req *GetBillingEventsByEmailRequest) (*GetBillingEventsByEmailResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-get-billing-events-by-email-request", zap.Any("request", req))
+	logger.Debug("initiating-get-billing-events-by-email-request", zap.Any("request", safeLogValue(req)))
 
 	// Standardise email to lowercase
 	standardisedEmail := toolbox.StringStandardisedToLower(req.Email)
 
 	events, err := s.billingEventsRepository.GetBillingEventsByEmail(ctx, standardisedEmail)
 	if err != nil {
-		log.Error("failed-to-get-billing-events-by-email-error-getting-events", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-billing-events-by-email-error-getting-events", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetBillingEventsByEmailResponse{}, err
 	}
 
 	if len(events) == 0 {
-		log.Debug("get-billing-events-by-email-no-events-found", zap.Any("request", req))
+		logger.Debug("get-billing-events-by-email-no-events-found", zap.Any("request", safeLogValue(req)))
 		return &GetBillingEventsByEmailResponse{
 			BillingEvents: []BillingEvent{},
 			Total:         0,
 		}, nil
 	}
 
-	log.Debug("get-billing-events-by-email-request-successful", zap.Any("request", req), zap.Int("count", len(events)))
+	logger.Debug("get-billing-events-by-email-request-successful", zap.Any("request", safeLogValue(req)), zap.Int("count", len(events)))
 
 	return &GetBillingEventsByEmailResponse{
 		BillingEvents: events,
@@ -551,23 +529,21 @@ func (s *Service) GetBillingEventsByEmail(ctx context.Context, req *GetBillingEv
 // AssociateSubscriptionsWithUser associates all subscriptions with a given email to a user ID
 func (s *Service) AssociateSubscriptionsWithUser(ctx context.Context, req *AssociateSubscriptionsWithUserRequest) (*AssociateSubscriptionsWithUserResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-associate-subscriptions-with-user-request", zap.Any("request", req))
+	logger.Debug("initiating-associate-subscriptions-with-user-request", zap.Any("request", safeLogValue(req)))
 
 	// Standardise email to lowercase
 	standardisedEmail := toolbox.StringStandardisedToLower(req.Email)
 
 	count, err := s.subscriptionRepository.AssociateSubscriptionsWithUser(ctx, req.UserID, standardisedEmail)
 	if err != nil {
-		log.Error("failed-to-associate-subscriptions-with-user-error-associating-subscriptions", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-associate-subscriptions-with-user-error-associating-subscriptions", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &AssociateSubscriptionsWithUserResponse{}, err
 	}
 
-	log.Info("associate-subscriptions-with-user-request-successful",
+	logger.Info("associate-subscriptions-with-user-request-successful",
 		zap.String("user-id", req.UserID),
 		zap.String("email", req.Email),
 		zap.Int("associated-count", count))
@@ -581,23 +557,21 @@ func (s *Service) AssociateSubscriptionsWithUser(ctx context.Context, req *Assoc
 // AssociateBillingEventsWithUser associates all billing events with a given email to a user ID
 func (s *Service) AssociateBillingEventsWithUser(ctx context.Context, req *AssociateBillingEventsWithUserRequest) (*AssociateBillingEventsWithUserResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-associate-billing-events-with-user-request", zap.Any("request", req))
+	logger.Debug("initiating-associate-billing-events-with-user-request", zap.Any("request", safeLogValue(req)))
 
 	// Standardise email to lowercase
 	standardisedEmail := toolbox.StringStandardisedToLower(req.Email)
 
 	count, err := s.billingEventsRepository.AssociateBillingEventsWithUser(ctx, req.UserID, standardisedEmail)
 	if err != nil {
-		log.Error("failed-to-associate-billing-events-with-user-error-associating-events", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-associate-billing-events-with-user-error-associating-events", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &AssociateBillingEventsWithUserResponse{}, err
 	}
 
-	log.Info("associate-billing-events-with-user-request-successful",
+	logger.Info("associate-billing-events-with-user-request-successful",
 		zap.String("user-id", req.UserID),
 		zap.String("email", req.Email),
 		zap.Int("associated-count", count))
@@ -612,12 +586,10 @@ func (s *Service) AssociateBillingEventsWithUser(ctx context.Context, req *Assoc
 // Useful for monitoring and reporting orphaned subscriptions
 func (s *Service) GetUnassociatedSubscriptions(ctx context.Context, req *GetUnassociatedSubscriptionsRequest) (*GetUnassociatedSubscriptionsResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-get-unassociated-subscriptions-request", zap.Any("request", req))
+	logger.Debug("initiating-get-unassociated-subscriptions-request", zap.Any("request", safeLogValue(req)))
 
 	// Set default limit if not provided
 	if req.Limit == 0 {
@@ -626,20 +598,20 @@ func (s *Service) GetUnassociatedSubscriptions(ctx context.Context, req *GetUnas
 
 	subscriptions, err := s.subscriptionRepository.GetUnassociatedSubscriptions(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-unassociated-subscriptions-error-getting-subscriptions", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-unassociated-subscriptions-error-getting-subscriptions", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetUnassociatedSubscriptionsResponse{}, err
 	}
 
 	if len(subscriptions) == 0 {
-		log.Debug("get-unassociated-subscriptions-no-subscriptions-found", zap.Any("request", req))
+		logger.Debug("get-unassociated-subscriptions-no-subscriptions-found", zap.Any("request", safeLogValue(req)))
 		return &GetUnassociatedSubscriptionsResponse{
 			Subscriptions: []Subscription{},
 			Total:         0,
 		}, nil
 	}
 
-	log.Info("get-unassociated-subscriptions-request-successful",
-		zap.Any("request", req),
+	logger.Info("get-unassociated-subscriptions-request-successful",
+		zap.Any("request", safeLogValue(req)),
 		zap.Int("count", len(subscriptions)))
 
 	return &GetUnassociatedSubscriptionsResponse{
@@ -652,12 +624,10 @@ func (s *Service) GetUnassociatedSubscriptions(ctx context.Context, req *GetUnas
 // Useful for monitoring and reporting orphaned billing events
 func (s *Service) GetUnassociatedBillingEvents(ctx context.Context, req *GetUnassociatedBillingEventsRequest) (*GetUnassociatedBillingEventsResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-get-unassociated-billing-events-request", zap.Any("request", req))
+	logger.Debug("initiating-get-unassociated-billing-events-request", zap.Any("request", safeLogValue(req)))
 
 	// Set default limit if not provided
 	if req.Limit == 0 {
@@ -666,20 +636,20 @@ func (s *Service) GetUnassociatedBillingEvents(ctx context.Context, req *GetUnas
 
 	events, err := s.billingEventsRepository.GetUnassociatedBillingEvents(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-unassociated-billing-events-error-getting-events", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-unassociated-billing-events-error-getting-events", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetUnassociatedBillingEventsResponse{}, err
 	}
 
 	if len(events) == 0 {
-		log.Debug("get-unassociated-billing-events-no-events-found", zap.Any("request", req))
+		logger.Debug("get-unassociated-billing-events-no-events-found", zap.Any("request", safeLogValue(req)))
 		return &GetUnassociatedBillingEventsResponse{
 			BillingEvents: []BillingEvent{},
 			Total:         0,
 		}, nil
 	}
 
-	log.Info("get-unassociated-billing-events-request-successful",
-		zap.Any("request", req),
+	logger.Info("get-unassociated-billing-events-request-successful",
+		zap.Any("request", safeLogValue(req)),
 		zap.Int("count", len(events)))
 
 	return &GetUnassociatedBillingEventsResponse{
@@ -692,16 +662,14 @@ func (s *Service) GetUnassociatedBillingEvents(ctx context.Context, req *GetUnas
 // Used for manual association by admins
 func (s *Service) UpdateSubscriptionUserID(ctx context.Context, req *UpdateSubscriptionUserIDRequest) (*UpdateSubscriptionUserIDResponse, error) {
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger = logger.AcquirePackageFrom(ctx, "external/billing")
 	)
 
-	log.Debug("initiating-update-subscription-user-id-request", zap.Any("request", req))
+	logger.Debug("initiating-update-subscription-user-id-request", zap.Any("request", safeLogValue(req)))
 
 	updatedSubscription, oldSubscription, err := s.subscriptionRepository.UpdateSubscriptionUserID(ctx, req.SubscriptionID, req.UserID)
 	if err != nil {
-		log.Error("failed-to-update-subscription-user-id-error-updating-subscription", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-update-subscription-user-id-error-updating-subscription", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &UpdateSubscriptionUserIDResponse{}, err
 	}
 
@@ -722,11 +690,11 @@ func (s *Service) UpdateSubscriptionUserID(ctx context.Context, req *UpdateSubsc
 			},
 		})
 		if err != nil {
-			log.Error("failed-to-log-audit-event-after-updating-subscription-user-id", zap.Any("request", req), zap.Error(err))
+			logger.Error("failed-to-log-audit-event-after-updating-subscription-user-id", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		}
 	}
 
-	log.Info("update-subscription-user-id-request-successful",
+	logger.Info("update-subscription-user-id-request-successful",
 		zap.String("subscription-id", req.SubscriptionID),
 		zap.String("user-id", req.UserID))
 

--- a/external/billing/service.go
+++ b/external/billing/service.go
@@ -545,7 +545,8 @@ func (s *Service) AssociateSubscriptionsWithUser(ctx context.Context, req *Assoc
 
 	logger.Info("associate-subscriptions-with-user-request-successful",
 		zap.String("user-id", req.UserID),
-		zap.String("email", req.Email),
+		zap.Bool("email-present", emailPresentForLog(req.Email)),
+		zap.String("email-domain", emailDomainForLog(req.Email)),
 		zap.Int("associated-count", count))
 
 	return &AssociateSubscriptionsWithUserResponse{
@@ -573,7 +574,8 @@ func (s *Service) AssociateBillingEventsWithUser(ctx context.Context, req *Assoc
 
 	logger.Info("associate-billing-events-with-user-request-successful",
 		zap.String("user-id", req.UserID),
-		zap.String("email", req.Email),
+		zap.Bool("email-present", emailPresentForLog(req.Email)),
+		zap.String("email-domain", emailDomainForLog(req.Email)),
 		zap.Int("associated-count", count))
 
 	return &AssociateBillingEventsWithUserResponse{

--- a/external/billingmanager/fender.go
+++ b/external/billingmanager/fender.go
@@ -15,11 +15,11 @@ import (
 func mapRequestToProcessBillingProviderWebhooksRequest(request *http.Request, validator BillingManagerValidator) (*ProcessBillingProviderWebhooksRequest, error) {
 
 	var parsedRequest ProcessBillingProviderWebhooksRequest
-	log := logger.AcquireFrom(request.Context())
+	logger := logger.AcquirePackageFrom(request.Context(), "external/billingmanager")
 
 	providerName, err := toolbox.GetVariableValueFromUri(request, "providerName")
 	if err != nil {
-		log.Error("unable-get-provider-name-from-uri", zap.Any("request", request), zap.Error(err))
+		logger.Error("unable-get-provider-name-from-uri", zap.String("method", request.Method), zap.String("path", request.URL.Path), zap.Error(err))
 		return nil, ErrBillingManagerUnableToGetProviderNameFromURI
 	}
 
@@ -33,24 +33,24 @@ func mapRequestToProcessBillingProviderWebhooksRequest(request *http.Request, va
 // struct.
 func mapRequestToGetUserBillingEventsRequest(request *http.Request, validator BillingManagerValidator) (*GetUserBillingEventsRequest, error) {
 	var parsedRequest GetUserBillingEventsRequest
-	log := logger.AcquireFrom(request.Context())
+	logger := logger.AcquirePackageFrom(request.Context(), "external/billingmanager")
 	requestingUserId := accessmanagerhelpers.AcquireFrom(request.Context())
 
 	if requestingUserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrBillingManagerUnableToIdentifyUser
 	}
 
 	userId, err := toolbox.GetVariableValueFromUri(request, "userId")
 	if err != nil {
-		log.Error("unable-get-user-id-from-uri", zap.Any("request", request), zap.Error(err))
+		logger.Error("unable-get-user-id-from-uri", zap.String("method", request.Method), zap.String("path", request.URL.Path), zap.Error(err))
 		return nil, ErrBillingManagerUnableToGetUserIdFromURI
 	}
 
 	query := request.URL.Query()
 	err = querydecoder.New(query).Decode(&parsedRequest)
 	if err != nil {
-		log.Error("unable-to-decode-query-to-billing-events-request", zap.Any("request", request), zap.Error(err))
+		logger.Error("unable-to-decode-query-to-billing-events-request", zap.String("method", request.Method), zap.String("path", request.URL.Path), zap.Error(err))
 		return nil, ErrInvalidBillingManagerRequestPayload
 	}
 
@@ -64,17 +64,17 @@ func mapRequestToGetUserBillingEventsRequest(request *http.Request, validator Bi
 // struct.
 func mapRequestToGetUserSubscriptionStatusRequest(request *http.Request, validator BillingManagerValidator) (*GetUserSubscriptionStatusRequest, error) {
 	var parsedRequest GetUserSubscriptionStatusRequest
-	log := logger.AcquireFrom(request.Context())
+	logger := logger.AcquirePackageFrom(request.Context(), "external/billingmanager")
 	requestingUserId := accessmanagerhelpers.AcquireFrom(request.Context())
 
 	if requestingUserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrBillingManagerUnableToIdentifyUser
 	}
 
 	userId, err := toolbox.GetVariableValueFromUri(request, "userId")
 	if err != nil {
-		log.Error("unable-get-user-id-from-uri", zap.Any("request", request), zap.Error(err))
+		logger.Error("unable-get-user-id-from-uri", zap.String("method", request.Method), zap.String("path", request.URL.Path), zap.Error(err))
 		return nil, ErrBillingManagerUnableToGetUserIdFromURI
 	}
 
@@ -88,17 +88,17 @@ func mapRequestToGetUserSubscriptionStatusRequest(request *http.Request, validat
 // struct.
 func mapRequestToGetUserBillingDetailRequest(request *http.Request, validator BillingManagerValidator) (*GetUserBillingDetailRequest, error) {
 	var parsedRequest GetUserBillingDetailRequest
-	log := logger.AcquireFrom(request.Context())
+	logger := logger.AcquirePackageFrom(request.Context(), "external/billingmanager")
 	requestingUserId := accessmanagerhelpers.AcquireFrom(request.Context())
 
 	if requestingUserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrBillingManagerUnableToIdentifyUser
 	}
 
 	userId, err := toolbox.GetVariableValueFromUri(request, "userId")
 	if err != nil {
-		log.Error("unable-get-user-id-from-uri", zap.Any("request", request), zap.Error(err))
+		logger.Error("unable-get-user-id-from-uri", zap.String("method", request.Method), zap.String("path", request.URL.Path), zap.Error(err))
 		return nil, ErrBillingManagerUnableToGetUserIdFromURI
 	}
 

--- a/external/billingmanager/handler.go
+++ b/external/billingmanager/handler.go
@@ -2,10 +2,12 @@ package billingmanager
 
 import (
 	"context"
+	"github.com/ooaklee/ghatd/external/logger"
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/errormanifest"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // BillingManagerService manages business logic around billingmanager request
@@ -44,9 +46,11 @@ func NewHandler(service BillingManagerService, validator BillingManagerValidator
 // ProcessBillingProviderWebhooks handles request to process
 // billing provider webhooks
 func (h *Handler) ProcessBillingProviderWebhooks(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/billingmanager", "handle-process-billing-provider-webhooks")
 	request, err := mapRequestToProcessBillingProviderWebhooksRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -54,6 +58,7 @@ func (h *Handler) ProcessBillingProviderWebhooks(w http.ResponseWriter, r *http.
 	err = h.Service.ProcessBillingProviderWebhooks(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -64,9 +69,11 @@ func (h *Handler) ProcessBillingProviderWebhooks(w http.ResponseWriter, r *http.
 
 // GetUserBillingEvents handles request to get user billing events
 func (h *Handler) GetUserBillingEvents(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/billingmanager", "handle-get-user-billing-events")
 	request, err := mapRequestToGetUserBillingEventsRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -74,6 +81,7 @@ func (h *Handler) GetUserBillingEvents(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetUserBillingEvents(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -90,9 +98,11 @@ func (h *Handler) GetUserBillingEvents(w http.ResponseWriter, r *http.Request) {
 
 // GetUserSubscriptionStatus handles request to get user subscription status
 func (h *Handler) GetUserSubscriptionStatus(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/billingmanager", "handle-get-user-subscription-status")
 	request, err := mapRequestToGetUserSubscriptionStatusRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -100,6 +110,7 @@ func (h *Handler) GetUserSubscriptionStatus(w http.ResponseWriter, r *http.Reque
 	response, err := h.Service.GetUserSubscriptionStatus(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -110,9 +121,11 @@ func (h *Handler) GetUserSubscriptionStatus(w http.ResponseWriter, r *http.Reque
 
 // GetUserBillingDetail handles request to get user billing detail
 func (h *Handler) GetUserBillingDetail(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/billingmanager", "handle-get-user-billing-detail")
 	request, err := mapRequestToGetUserBillingDetailRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -120,6 +133,7 @@ func (h *Handler) GetUserBillingDetail(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetUserBillingDetail(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -130,14 +144,17 @@ func (h *Handler) GetUserBillingDetail(w http.ResponseWriter, r *http.Request) {
 
 // GetPricingPlans handles request to get pricing plans.
 func (h *Handler) GetPricingPlans(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/billingmanager", "handle-get-pricing-plans")
 	request, err := MapRequestToGetPricingPlansRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetPricingPlans(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -152,14 +169,17 @@ func (h *Handler) GetPricingPlans(w http.ResponseWriter, r *http.Request) {
 
 // GetPricePlanBySlug handles request to get a pricing plan by slug.
 func (h *Handler) GetPricePlanBySlug(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/billingmanager", "handle-get-price-plan-by-slug")
 	request, err := MapRequestToGetPricePlanBySlugRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetPricePlanBySlug(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -169,14 +189,17 @@ func (h *Handler) GetPricePlanBySlug(w http.ResponseWriter, r *http.Request) {
 
 // GetPricingFeatures handles request to get pricing feature catalog items.
 func (h *Handler) GetPricingFeatures(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/billingmanager", "handle-get-pricing-features")
 	request, err := MapRequestToGetPriceFeaturesRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetPricingFeatures(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/billingmanager/logging.go
+++ b/external/billingmanager/logging.go
@@ -1,10 +1,6 @@
-package billing
+package billingmanager
 
 import "github.com/ooaklee/ghatd/external/logger"
-
-func safeLogValue(value any) any {
-	return logger.SafeValue(value)
-}
 
 func emailPresentForLog(value string) bool {
 	return logger.EmailPresentForLog(value)

--- a/external/billingmanager/service.go
+++ b/external/billingmanager/service.go
@@ -91,20 +91,20 @@ func (s *Service) WithPricerService(pricerSvc PricerService) *Service {
 // This is the main entry point for webhook processing
 func (s *Service) ProcessBillingProviderWebhooks(ctx context.Context, req *ProcessBillingProviderWebhooksRequest) error {
 
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/billingmanager")
 	var (
 		subscriptionId string
 	)
 
 	payload, err := s.ProviderRegistry.VerifyAndParseWebhookPayload(ctx, req.ProviderName, req.Request)
 	if err != nil {
-		log.Error("failed-to-verify-and-parse-webhook-payload", zap.String("provider", req.ProviderName), zap.Error(err))
+		logger.Error("failed-to-verify-and-parse-webhook-payload", zap.String("provider", req.ProviderName), zap.Error(err))
 		return err
 	}
 
 	userID, err := s.resolveUserID(ctx, payload)
 	if err != nil {
-		log.Error("failed-to-resolve-user-id", zap.String("provider", req.ProviderName), zap.Error(err))
+		logger.Error("failed-to-resolve-user-id", zap.String("provider", req.ProviderName), zap.Error(err))
 		return err
 	}
 
@@ -112,12 +112,12 @@ func (s *Service) ProcessBillingProviderWebhooks(ctx context.Context, req *Proce
 
 		subscription, err := s.findOrCreateSubscription(ctx, req.ProviderName, payload, userID)
 		if err != nil {
-			log.Error("failed-to-find-or-create-subscription", zap.String("provider", req.ProviderName), zap.String("user-id", userID), zap.Any("payload", payload), zap.Error(err))
+			logger.Error("failed-to-find-or-create-subscription", append(webhookPayloadFieldsForLog(req.ProviderName, userID, payload), zap.Error(err))...)
 			return err
 		}
 
 		if err := s.updateSubscriptionFromPayload(ctx, subscription, payload); err != nil {
-			log.Error("failed-to-update-subscription-from-payload", zap.String("provider", req.ProviderName), zap.String("user-id", userID), zap.String("subscription-id", subscription.ID), zap.Any("payload", payload), zap.Error(err))
+			logger.Error("failed-to-update-subscription-from-payload", append(webhookPayloadFieldsForLog(req.ProviderName, userID, payload), zap.String("subscription-id", subscription.ID), zap.Error(err))...)
 			return err
 		}
 
@@ -127,7 +127,7 @@ func (s *Service) ProcessBillingProviderWebhooks(ctx context.Context, req *Proce
 	billingEventSuccessfullyCreated := true
 	if err := s.createBillingEvent(ctx, subscriptionId, userID, req.ProviderName, payload); err != nil {
 		billingEventSuccessfullyCreated = false
-		log.Warn("failed-to-create-billing-event", zap.String("provider", req.ProviderName), zap.String("user-id", userID), zap.String("subscription-id", subscriptionId), zap.Any("payload", payload), zap.Error(err))
+		logger.Warn("failed-to-create-billing-event", append(webhookPayloadFieldsForLog(req.ProviderName, userID, payload), zap.String("subscription-id", subscriptionId), zap.Error(err))...)
 	}
 
 	// Optional audit logging
@@ -172,14 +172,14 @@ func (s *Service) ProcessBillingProviderWebhooks(ctx context.Context, req *Proce
 // GetPricingPlans retrieves pricing plans for external BMS clients.
 func (s *Service) GetPricingPlans(ctx context.Context, req *GetPricingPlansRequest) (*GetPricingPlansResponse, error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/billingmanager")
 
 	if s.PricerService == nil {
-		log.Error("pricer-service-not-enabled", zap.String("user-id", req.UserID))
+		logger.Error("pricer-service-not-enabled", zap.String("user-id", req.UserID))
 		return nil, ErrBillingManagerPricerServiceNotSet
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, req.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, req.UserID, logger)
 	if !isAdmin {
 		// Non-admin users are not allowed to access pricing in certain states, i.e draft, archieved, etc
 		// we should override any queries to ensure they can only see active pricing plans
@@ -188,12 +188,12 @@ func (s *Service) GetPricingPlans(ctx context.Context, req *GetPricingPlansReque
 		}
 		req.GetPricePlansRequest.IsNotDeleted = true
 		req.GetPricePlansRequest.IsPublished = true
-		log.Debug("non-admin-user-requesting-pricing-plans-only-returning-plans-in-valid-state", zap.String("user-id", req.UserID))
+		logger.Debug("non-admin-user-requesting-pricing-plans-only-returning-plans-in-valid-state", zap.String("user-id", req.UserID))
 	}
 
 	response, err := s.PricerService.GetPricePlans(ctx, req.GetPricePlansRequest)
 	if err != nil {
-		log.Error("failed-to-get-pricing-plans", zap.String("user-id", req.UserID), zap.Error(err))
+		logger.Error("failed-to-get-pricing-plans", zap.String("user-id", req.UserID), zap.Error(err))
 		return nil, err
 	}
 
@@ -202,10 +202,10 @@ func (s *Service) GetPricingPlans(ctx context.Context, req *GetPricingPlansReque
 
 // GetPricePlanBySlug retrieves a pricing plan by slug for external BMS clients.
 func (s *Service) GetPricePlanBySlug(ctx context.Context, req *GetPricePlanBySlugRequest) (*GetPricePlanBySlugResponse, error) {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/billingmanager")
 
 	if s.PricerService == nil {
-		log.Error("pricer-service-not-enabled", zap.String("user-id", req.UserID))
+		logger.Error("pricer-service-not-enabled", zap.String("user-id", req.UserID))
 		return nil, ErrBillingManagerPricerServiceNotSet
 	}
 
@@ -214,12 +214,12 @@ func (s *Service) GetPricePlanBySlug(ctx context.Context, req *GetPricePlanBySlu
 		return nil, err
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, req.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, req.UserID, logger)
 	if !isAdmin {
 		// Non-admin users are not allowed to access pricing in certain states, i.e draft, archieved, etc
 		// we should override any queries to ensure they can only see active pricing plans
 		if response.PricePlan.DeletedAt != "" || !isPricePlanPubliclyVisible(response.PricePlan.PublishedAt) {
-			log.Debug("non-admin-user-requesting-pricing-plans-only-returning-plans-in-valid-state", zap.String("user-id", req.UserID))
+			logger.Debug("non-admin-user-requesting-pricing-plans-only-returning-plans-in-valid-state", zap.String("user-id", req.UserID))
 			return nil, pricer.ErrPricePlanNotFound
 		}
 	}
@@ -229,14 +229,14 @@ func (s *Service) GetPricePlanBySlug(ctx context.Context, req *GetPricePlanBySlu
 
 // GetPricingFeatures retrieves pricing feature catalog items for external BMS clients.
 func (s *Service) GetPricingFeatures(ctx context.Context, req *GetPriceFeaturesRequest) (*GetPriceFeaturesResponse, error) {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/billingmanager")
 
 	if s.PricerService == nil {
-		log.Error("pricer-service-not-enabled", zap.String("user-id", req.UserID))
+		logger.Error("pricer-service-not-enabled", zap.String("user-id", req.UserID))
 		return nil, ErrBillingManagerPricerServiceNotSet
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, req.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, req.UserID, logger)
 	if !isAdmin {
 		// Non-admin users are not allowed to access price features in certain states, i.e draft, archieved, etc
 		// we should override any queries to ensure they can only see active features
@@ -246,7 +246,7 @@ func (s *Service) GetPricingFeatures(ctx context.Context, req *GetPriceFeaturesR
 
 		req.GetFeaturesRequest.IsNotDeleted = true
 		req.GetFeaturesRequest.IsPublished = true
-		log.Debug("non-admin-user-requesting-pricing-features-only-returning-features-in-valid-state", zap.String("user-id", req.UserID))
+		logger.Debug("non-admin-user-requesting-pricing-features-only-returning-features-in-valid-state", zap.String("user-id", req.UserID))
 	}
 
 	response, err := s.PricerService.GetFeatures(ctx, req.GetFeaturesRequest)
@@ -277,15 +277,15 @@ func isPricePlanPubliclyVisible(publishedAt string) bool {
 func (s *Service) GetUserSubscriptionStatus(ctx context.Context, req *GetUserSubscriptionStatusRequest) (*GetUserSubscriptionStatusResponse, error) {
 
 	var (
-		log                   = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                = logger.AcquirePackageFrom(ctx, "external/billingmanager")
 		logFields []zap.Field = initLogFieldsWithUserIdAndRequestingUserId(req.UserID, req.RequestingUserID)
 	)
 
-	log.Info("getting-subscription-status-for-user")
+	logger.Info("getting-subscription-status-for-user")
 
 	err := s.isUserAuthorisedToProceedWithUserOperation(ctx, req.UserID, req.RequestingUserID)
 	if err != nil {
-		log.Error("failed-to-access-subscription-status-for-user", append(logFields, zap.Error(err))...)
+		logger.Error("failed-to-access-subscription-status-for-user", append(logFields, zap.Error(err))...)
 		return nil, err
 	}
 
@@ -297,18 +297,18 @@ func (s *Service) GetUserSubscriptionStatus(ctx context.Context, req *GetUserSub
 		Order:      "created_at_desc",
 	})
 	if err != nil {
-		log.Error("unexpected-error-while-attempting-to-get-user-subscription-status", append(logFields, zap.Error(err))...)
+		logger.Error("unexpected-error-while-attempting-to-get-user-subscription-status", append(logFields, zap.Error(err))...)
 		return nil, err
 	}
 
 	// Check if user has any subscriptions
 	if subscriptionsResp.Total == 0 || len(subscriptionsResp.Subscriptions) == 0 {
-		log.Info("no-active-subscription-with-user-id-falling-back-to-user-email", logFields...)
+		logger.Info("no-active-subscription-with-user-id-falling-back-to-user-email", logFields...)
 		userResp, err := s.UserService.GetUserByID(ctx, &user.GetUserByIDRequest{ID: req.UserID})
 		if err == nil {
 			emailSubsResp, _ := s.BillingService.GetSubscriptionsByEmail(ctx, &billing.GetSubscriptionsByEmailRequest{Email: userResp.User.Email})
 			if len(emailSubsResp.Subscriptions) > 0 {
-				log.Info("found-email-based-subscription-associating-with-user", append(logFields, zap.String("email", userResp.User.Email), zap.Int("found-subscriptions", len(emailSubsResp.Subscriptions)))...)
+				logger.Info("found-email-based-subscription-associating-with-user", append(logFields, zap.String("email", userResp.User.Email), zap.Int("found-subscriptions", len(emailSubsResp.Subscriptions)))...)
 				// Associate found subscriptions with user
 				_, _ = s.BillingService.AssociateSubscriptionsWithUser(ctx, &billing.AssociateSubscriptionsWithUserRequest{
 					UserID: req.UserID,
@@ -327,7 +327,7 @@ func (s *Service) GetUserSubscriptionStatus(ctx context.Context, req *GetUserSub
 	}
 
 	if subscriptionsResp.Total == 0 || len(subscriptionsResp.Subscriptions) == 0 {
-		log.Info("no-active-subscription-found", logFields...)
+		logger.Info("no-active-subscription-found", logFields...)
 		return &GetUserSubscriptionStatusResponse{
 			SubscriptionStatus: &SubscriptionStatus{
 				HasSubscription: false,
@@ -337,7 +337,7 @@ func (s *Service) GetUserSubscriptionStatus(ctx context.Context, req *GetUserSub
 	}
 
 	subscription := subscriptionsResp.Subscriptions[0]
-	log.Info("subscription-status-retrieved", append(logFields, zap.String("subscription-id", subscription.ID))...)
+	logger.Info("subscription-status-retrieved", append(logFields, zap.String("subscription-id", subscription.ID))...)
 
 	return &GetUserSubscriptionStatusResponse{
 		SubscriptionStatus: &SubscriptionStatus{
@@ -361,15 +361,15 @@ func (s *Service) GetUserSubscriptionStatus(ctx context.Context, req *GetUserSub
 func (s *Service) GetUserBillingEvents(ctx context.Context, req *GetUserBillingEventsRequest) (*GetUserBillingEventsResponse, error) {
 
 	var (
-		log                   = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                = logger.AcquirePackageFrom(ctx, "external/billingmanager")
 		logFields []zap.Field = initLogFieldsWithUserIdAndRequestingUserId(req.UserID, req.RequestingUserID)
 	)
 
-	log.Info("getting-billing-events-for-user")
+	logger.Info("getting-billing-events-for-user")
 
 	err := s.isUserAuthorisedToProceedWithUserOperation(ctx, req.UserID, req.RequestingUserID)
 	if err != nil {
-		log.Error("failed-to-access-billing-events-for-user", append(logFields, zap.Error(err))...)
+		logger.Error("failed-to-access-billing-events-for-user", append(logFields, zap.Error(err))...)
 		return nil, err
 	}
 
@@ -381,7 +381,7 @@ func (s *Service) GetUserBillingEvents(ctx context.Context, req *GetUserBillingE
 		Order:      req.Order,
 	})
 	if err != nil {
-		log.Error("failed-to-retrieve-billing-events-for-user", append(logFields, zap.Error(err))...)
+		logger.Error("failed-to-retrieve-billing-events-for-user", append(logFields, zap.Error(err))...)
 		return nil, err
 	}
 
@@ -401,7 +401,7 @@ func (s *Service) GetUserBillingEvents(ctx context.Context, req *GetUserBillingE
 		}
 	}
 
-	log.Info("billing-events-retrieved-for-user", append(logFields, zap.Int("total-events", eventsResp.Total), zap.Int("returned-events", len(events)))...)
+	logger.Info("billing-events-retrieved-for-user", append(logFields, zap.Int("total-events", eventsResp.Total), zap.Int("returned-events", len(events)))...)
 
 	return &GetUserBillingEventsResponse{
 		Events: events,
@@ -413,15 +413,15 @@ func (s *Service) GetUserBillingEvents(ctx context.Context, req *GetUserBillingE
 func (s *Service) GetUserBillingDetail(ctx context.Context, req *GetUserBillingDetailRequest) (*GetUserBillingDetailResponse, error) {
 
 	var (
-		log                   = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                = logger.AcquirePackageFrom(ctx, "external/billingmanager")
 		logFields []zap.Field = initLogFieldsWithUserIdAndRequestingUserId(req.UserID, req.RequestingUserID)
 	)
 
-	log.Info("getting-billing-detail-for-user")
+	logger.Info("getting-billing-detail-for-user")
 
 	err := s.isUserAuthorisedToProceedWithUserOperation(ctx, req.UserID, req.RequestingUserID)
 	if err != nil {
-		log.Error("failed-to-access-billing-detail-for-user", append(logFields, zap.Error(err))...)
+		logger.Error("failed-to-access-billing-detail-for-user", append(logFields, zap.Error(err))...)
 		return nil, err
 	}
 
@@ -433,13 +433,13 @@ func (s *Service) GetUserBillingDetail(ctx context.Context, req *GetUserBillingD
 		Order:      "created_at_desc",
 	})
 	if err != nil {
-		log.Error("unexpected-error-while-attempting-to-get-user-billing-detail", append(logFields, zap.Error(err))...)
+		logger.Error("unexpected-error-while-attempting-to-get-user-billing-detail", append(logFields, zap.Error(err))...)
 		return nil, err
 	}
 
 	// Check if user has any subscriptions
 	if subscriptionsResp.Total == 0 || len(subscriptionsResp.Subscriptions) == 0 {
-		log.Info("no-active-subscription-found", logFields...)
+		logger.Info("no-active-subscription-found", logFields...)
 		return &GetUserBillingDetailResponse{
 			BillingDetail: &BillingDetail{
 				HasSubscription: false,
@@ -462,21 +462,21 @@ func (s *Service) GetUserBillingDetail(ctx context.Context, req *GetUserBillingD
 	// Generate human-readable summary
 	detail.Summary = s.generateSubscriptionSummary(&subscription)
 
-	log.Info("billing-detail-retrieved", logFields...)
+	logger.Info("billing-detail-retrieved", logFields...)
 	return &GetUserBillingDetailResponse{
 		BillingDetail: detail,
 	}, nil
 }
 
 // isRequesterAdmin safely checks if the requester has admin privileges
-func (s *Service) isRequesterAdmin(ctx context.Context, userID string, log *zap.Logger) bool {
+func (s *Service) isRequesterAdmin(ctx context.Context, userID string, logger *zap.Logger) bool {
 	if s.UserService == nil {
 		return false
 	}
 
 	userResp, err := s.UserService.GetUserByID(ctx, &user.GetUserByIDRequest{ID: userID})
 	if err != nil || userResp == nil || userResp.User == nil {
-		log.Warn("unable-to-resolve-requester-for-admin-check", zap.String("user-id", userID), zap.Error(err))
+		logger.Warn("unable-to-resolve-requester-for-admin-check", zap.String("user-id", userID), zap.Error(err))
 		return false
 	}
 
@@ -487,12 +487,12 @@ func (s *Service) isRequesterAdmin(ctx context.Context, userID string, log *zap.
 // Returns an error if not authorised or prerequisites are not met.
 func (s *Service) isUserAuthorisedToProceedWithUserOperation(ctx context.Context, targetUserId, requestingUserId string) error {
 	var (
-		log                   = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                = logger.AcquirePackageFrom(ctx, "external/billingmanager")
 		logFields []zap.Field = initLogFieldsWithUserIdAndRequestingUserId(targetUserId, requestingUserId)
 	)
 
 	if targetUserId == "" {
-		log.Warn("failed-to-get-billing-detail-user-id-is-missing", logFields...)
+		logger.Warn("failed-to-get-billing-detail-user-id-is-missing", logFields...)
 		return ErrBillingManagerRequiresUserIdIsMissing
 	}
 
@@ -500,15 +500,15 @@ func (s *Service) isUserAuthorisedToProceedWithUserOperation(ctx context.Context
 
 		userResp, err := s.UserService.GetUserByID(ctx, &user.GetUserByIDRequest{ID: requestingUserId})
 		if err != nil {
-			log.Warn("failed-to-get-billing-detail-requesting-user-not-found", append(logFields, zap.Error(err))...)
+			logger.Warn("failed-to-get-billing-detail-requesting-user-not-found", append(logFields, zap.Error(err))...)
 			return ErrBillingManagerRequiresUserIdIsMissing
 		}
 		if !userResp.User.IsAdmin() {
-			log.Warn("failed-to-get-billing-detail-requesting-user-not-admin", logFields...)
+			logger.Warn("failed-to-get-billing-detail-requesting-user-not-admin", logFields...)
 			return ErrBillingManagerUserUnauthorisedToCarryOutOperation
 		}
 
-		log.Info("admin-user-requesting-billing-detail-for-another-user", logFields...)
+		logger.Info("admin-user-requesting-billing-detail-for-another-user", logFields...)
 	}
 	return nil
 }
@@ -519,8 +519,8 @@ func (s *Service) isUserAuthorisedToProceedWithUserOperation(ctx context.Context
 func (s *Service) resolveUserID(ctx context.Context, payload *paymentprovider.WebhookPayload) (string, error) {
 
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-		err error
+		logger = logger.AcquirePackageFrom(ctx, "external/billingmanager")
+		err    error
 	)
 
 	subResp, err := s.BillingService.GetSubscriptionByIntegratorID(ctx, &billing.GetSubscriptionByIntegratorIDRequest{
@@ -528,27 +528,27 @@ func (s *Service) resolveUserID(ctx context.Context, payload *paymentprovider.We
 		IntegratorSubscriptionID: payload.SubscriptionID,
 	})
 	if err == nil {
-		log.Info("found-existing-subscription-using-event-type-and-subscription-id", zap.String("user-id", subResp.Subscription.UserID), zap.String("subscription-id", subResp.Subscription.ID), zap.String("event-type", payload.EventType))
+		logger.Info("found-existing-subscription-using-event-type-and-subscription-id", zap.String("user-id", subResp.Subscription.UserID), zap.String("subscription-id", subResp.Subscription.ID), zap.String("event-type", payload.EventType))
 		return subResp.Subscription.UserID, nil
 	}
 
-	log.Info("unable-to-find-existing-subscription-using-event-type-and-subscription-id", zap.String("event-type", payload.EventType))
+	logger.Info("unable-to-find-existing-subscription-using-event-type-and-subscription-id", zap.String("event-type", payload.EventType))
 
 	if s.UserService != nil && payload.CustomerEmail != "" {
 		userResp, err := s.UserService.GetUserByEmail(ctx, &user.GetUserByEmailRequest{Email: payload.CustomerEmail})
 		if err == nil {
-			log.Info("found-user-id-falling-back-to-payload-email", zap.String("user-id", userResp.User.GetUserId()), zap.String("payload-email", payload.CustomerEmail))
+			logger.Info("found-user-id-falling-back-to-payload-email", zap.String("user-id", userResp.User.GetUserId()), zap.String("payload-email", payload.CustomerEmail))
 			return userResp.User.GetUserId(), nil
 		}
 	}
 
 	// if email is missing we need to error out as we have no way to identify the user
 	if payload.CustomerEmail == "" {
-		log.Warn("unable-to-identify-user-no-email-in-payload", zap.String("subscription-id", payload.SubscriptionID), zap.String("customer-id", payload.CustomerID))
+		logger.Warn("unable-to-identify-user-no-email-in-payload", zap.String("subscription-id", payload.SubscriptionID), zap.String("customer-id", payload.CustomerID))
 		return "", ErrBillingManagerNoUserIdentifyingInformationInPayload
 	}
 
-	log.Info("no-user-found-will-store-subscription-with-email-only", zap.String("email", payload.CustomerEmail))
+	logger.Info("no-user-found-will-store-subscription-with-email-only", zap.String("email", payload.CustomerEmail))
 
 	return "", nil
 }
@@ -557,8 +557,8 @@ func (s *Service) resolveUserID(ctx context.Context, payload *paymentprovider.We
 func (s *Service) findOrCreateSubscription(ctx context.Context, providerName string, payload *paymentprovider.WebhookPayload, userID string) (*billing.Subscription, error) {
 
 	var (
-		log = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-		err error
+		logger = logger.AcquirePackageFrom(ctx, "external/billingmanager")
+		err    error
 	)
 
 	// Try to find existing subscription by integrator ID
@@ -567,7 +567,7 @@ func (s *Service) findOrCreateSubscription(ctx context.Context, providerName str
 		IntegratorSubscriptionID: payload.SubscriptionID,
 	})
 	if err == nil {
-		log.Info("found-existing-subscription-using-integrator-and-subscription-id", zap.String("user-id", subResp.Subscription.UserID), zap.String("subscription-id", subResp.Subscription.ID), zap.String("provider", providerName))
+		logger.Info("found-existing-subscription-using-integrator-and-subscription-id", zap.String("user-id", subResp.Subscription.UserID), zap.String("subscription-id", subResp.Subscription.ID), zap.String("provider", providerName))
 		return subResp.Subscription, nil
 	}
 
@@ -615,7 +615,7 @@ func (s *Service) findOrCreateSubscription(ctx context.Context, providerName str
 		logFields = append(logFields, zap.String("available-until-date", "not-set"))
 	}
 
-	log.Info("attempting-to-create-new-subscription", logFields...)
+	logger.Info("attempting-to-create-new-subscription", logFields...)
 
 	createResp, err := s.BillingService.CreateSubscription(ctx, createReq)
 	if err != nil {
@@ -628,7 +628,7 @@ func (s *Service) findOrCreateSubscription(ctx context.Context, providerName str
 func (s *Service) updateSubscriptionFromPayload(ctx context.Context, subscription *billing.Subscription, payload *paymentprovider.WebhookPayload) error {
 
 	var (
-		log       = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger    = logger.AcquirePackageFrom(ctx, "external/billingmanager")
 		logFields = []zap.Field{
 			zap.String("subscription-id", subscription.ID),
 		}
@@ -641,36 +641,36 @@ func (s *Service) updateSubscriptionFromPayload(ctx context.Context, subscriptio
 
 	// Update dates if present
 	if payload.NextBillingDate != "" {
-		log.Debug("updating-next-billing-date", append(logFields, zap.String("next-billing-date", payload.NextBillingDate))...)
+		logger.Debug("updating-next-billing-date", append(logFields, zap.String("next-billing-date", payload.NextBillingDate))...)
 		nextBillingDate := parseTimeOrNil(payload.NextBillingDate)
 		updateReq.NextBillingDate = nextBillingDate
 	}
 
 	if payload.AvailableUntilDate != "" {
-		log.Debug("updating-available-until-date", append(logFields, zap.String("available-until-date", payload.AvailableUntilDate))...)
+		logger.Debug("updating-available-until-date", append(logFields, zap.String("available-until-date", payload.AvailableUntilDate))...)
 		availableUntilDate := parseTimeOrNil(payload.AvailableUntilDate)
 		updateReq.AvailableUntilDate = availableUntilDate
 	}
 
 	// Update plan name if present
 	if payload.PlanName != "" {
-		log.Debug("updating-plan-name", append(logFields, zap.String("plan-name", payload.PlanName))...)
+		logger.Debug("updating-plan-name", append(logFields, zap.String("plan-name", payload.PlanName))...)
 		updateReq.PlanName = &payload.PlanName
 	}
 
 	// Update URLs if present
 	if payload.CancelURL != "" {
-		log.Debug("updating-cancel-url", append(logFields, zap.String("cancel-url", payload.CancelURL))...)
+		logger.Debug("updating-cancel-url", append(logFields, zap.String("cancel-url", payload.CancelURL))...)
 		updateReq.CancelURL = &payload.CancelURL
 	}
 	if payload.UpdateURL != "" {
-		log.Debug("updating-update-url", append(logFields, zap.String("update-url", payload.UpdateURL))...)
+		logger.Debug("updating-update-url", append(logFields, zap.String("update-url", payload.UpdateURL))...)
 		updateReq.UpdateURL = &payload.UpdateURL
 	}
 
 	// Handle cancellation
 	if payload.EventType == paymentprovider.EventTypeSubscriptionCancelled {
-		log.Info("marking-subscription-as-cancelled", append(logFields, zap.String("user-id", payload.CustomerID))...)
+		logger.Info("marking-subscription-as-cancelled", append(logFields, zap.String("user-id", payload.CustomerID))...)
 		now := time.Now()
 		updateReq.CancelledAt = &now
 	}
@@ -682,12 +682,12 @@ func (s *Service) updateSubscriptionFromPayload(ctx context.Context, subscriptio
 // createBillingEvent creates an audit trail event
 func (s *Service) createBillingEvent(ctx context.Context, subscriptionID, userID, providerName string, payload *paymentprovider.WebhookPayload) error {
 
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/billingmanager")
 	logFields := []zap.Field{
 		zap.String("subscription-id", subscriptionID), zap.String("user-id", userID), zap.String("provider", providerName), zap.String("event-type", payload.EventType), zap.String("event-id", payload.EventID),
 	}
 
-	log.Info("creating-billing-event", logFields...)
+	logger.Info("creating-billing-event", logFields...)
 	eventTime := parseTimeOrNil(payload.EventTime)
 	if eventTime == nil {
 		now := time.Now()
@@ -714,11 +714,11 @@ func (s *Service) createBillingEvent(ctx context.Context, subscriptionID, userID
 	_, err := s.BillingService.CreateBillingEvent(ctx, createReq)
 
 	if err != nil {
-		log.Error("failed-to-create-billing-event", append(logFields, zap.Error(err))...)
+		logger.Error("failed-to-create-billing-event", append(logFields, zap.Error(err))...)
 		return err
 	}
 
-	log.Info("billing-event-created", logFields...)
+	logger.Info("billing-event-created", logFields...)
 	return nil
 }
 
@@ -766,4 +766,22 @@ func initLogFieldsWithUserIdAndRequestingUserId(userId, requestingUserId string)
 		logFields = append(logFields, zap.String("requesting-user-id", requestingUserId))
 	}
 	return logFields
+}
+
+func webhookPayloadFieldsForLog(providerName string, userID string, payload *paymentprovider.WebhookPayload) []zap.Field {
+	fields := []zap.Field{
+		zap.String("provider", providerName),
+		zap.String("user-id", userID),
+	}
+	if payload == nil {
+		return fields
+	}
+
+	return append(fields,
+		zap.String("event-type", payload.EventType),
+		zap.String("event-id", payload.EventID),
+		zap.String("subscription-id", payload.SubscriptionID),
+		zap.String("customer-id", payload.CustomerID),
+		zap.Bool("is-subscription", payload.IsSubscription()),
+	)
 }

--- a/external/billingmanager/service.go
+++ b/external/billingmanager/service.go
@@ -308,7 +308,11 @@ func (s *Service) GetUserSubscriptionStatus(ctx context.Context, req *GetUserSub
 		if err == nil {
 			emailSubsResp, _ := s.BillingService.GetSubscriptionsByEmail(ctx, &billing.GetSubscriptionsByEmailRequest{Email: userResp.User.Email})
 			if len(emailSubsResp.Subscriptions) > 0 {
-				logger.Info("found-email-based-subscription-associating-with-user", append(logFields, zap.String("email", userResp.User.Email), zap.Int("found-subscriptions", len(emailSubsResp.Subscriptions)))...)
+				logger.Info("found-email-based-subscription-associating-with-user", append(logFields,
+					zap.Bool("email-present", emailPresentForLog(userResp.User.Email)),
+					zap.String("email-domain", emailDomainForLog(userResp.User.Email)),
+					zap.Int("found-subscriptions", len(emailSubsResp.Subscriptions)),
+				)...)
 				// Associate found subscriptions with user
 				_, _ = s.BillingService.AssociateSubscriptionsWithUser(ctx, &billing.AssociateSubscriptionsWithUserRequest{
 					UserID: req.UserID,
@@ -537,7 +541,11 @@ func (s *Service) resolveUserID(ctx context.Context, payload *paymentprovider.We
 	if s.UserService != nil && payload.CustomerEmail != "" {
 		userResp, err := s.UserService.GetUserByEmail(ctx, &user.GetUserByEmailRequest{Email: payload.CustomerEmail})
 		if err == nil {
-			logger.Info("found-user-id-falling-back-to-payload-email", zap.String("user-id", userResp.User.GetUserId()), zap.String("payload-email", payload.CustomerEmail))
+			logger.Info("found-user-id-falling-back-to-payload-email",
+				zap.String("user-id", userResp.User.GetUserId()),
+				zap.Bool("payload-email-present", emailPresentForLog(payload.CustomerEmail)),
+				zap.String("payload-email-domain", emailDomainForLog(payload.CustomerEmail)),
+			)
 			return userResp.User.GetUserId(), nil
 		}
 	}
@@ -548,7 +556,10 @@ func (s *Service) resolveUserID(ctx context.Context, payload *paymentprovider.We
 		return "", ErrBillingManagerNoUserIdentifyingInformationInPayload
 	}
 
-	logger.Info("no-user-found-will-store-subscription-with-email-only", zap.String("email", payload.CustomerEmail))
+	logger.Info("no-user-found-will-store-subscription-with-email-only",
+		zap.Bool("email-present", emailPresentForLog(payload.CustomerEmail)),
+		zap.String("email-domain", emailDomainForLog(payload.CustomerEmail)),
+	)
 
 	return "", nil
 }
@@ -594,7 +605,8 @@ func (s *Service) findOrCreateSubscription(ctx context.Context, providerName str
 	logFields := []zap.Field{
 		zap.String("provider", providerName),
 		zap.String("subscription-id", payload.SubscriptionID),
-		zap.String("email", payload.CustomerEmail),
+		zap.Bool("email-present", emailPresentForLog(payload.CustomerEmail)),
+		zap.String("email-domain", emailDomainForLog(payload.CustomerEmail)),
 	}
 
 	// Add user-id to logs if present, otherwise note it's email-only

--- a/external/contacter/handler.go
+++ b/external/contacter/handler.go
@@ -2,9 +2,11 @@ package contacter
 
 import (
 	"context"
+	"github.com/ooaklee/ghatd/external/logger"
 	"net/http"
 
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // ContacterService interface defines expected methods of a valid contacter service
@@ -38,17 +40,20 @@ func NewHandler(service ContacterService, validator ContacterValidator, errorMap
 
 // GetCommsStats handles retrieving aggregated stats about platform comms
 func (h *Handler) GetCommsStats(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contacter", "handle-get-comms-stats")
 	request := &GetCommsStatsRequest{
 		WithEmailRegex: r.URL.Query().Get("with_email_regex"),
 	}
 
 	if err := h.Validator.Validate(request); err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetCommsStats(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/contacter/logging.go
+++ b/external/contacter/logging.go
@@ -1,0 +1,7 @@
+package contacter
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/contacter/service.go
+++ b/external/contacter/service.go
@@ -173,7 +173,7 @@ func (s *Service) UpdateComms(ctx context.Context, req *UpdateCommsRequest) (*Up
 	// Fetch existing comms to preserve existing data
 	existingCommsSlice, err := s.contacterRepository.GetCommsByIds(ctx, []string{req.CommsId})
 	if err != nil {
-		logger.Error("failed-to-update-comms-error-fetching-existing-comms", zap.String("comms_id", req.CommsId), zap.Error(err))
+		logger.Error("failed-to-update-comms-error-fetching-existing-comms", zap.String("comms-id", req.CommsId), zap.Error(err))
 		return &UpdateCommsResponse{}, err
 	}
 

--- a/external/contacter/service.go
+++ b/external/contacter/service.go
@@ -38,9 +38,7 @@ func NewService(contacterRepository contacterRepository) *Service {
 func (s *Service) CreateComms(ctx context.Context, req *CreateCommsRequest) (*CreateCommsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/contacter")
 
 		newComms *Comms = &Comms{
 			Message: req.Message,
@@ -49,7 +47,7 @@ func (s *Service) CreateComms(ctx context.Context, req *CreateCommsRequest) (*Cr
 		}
 	)
 
-	logger.Debug("initiating-create-comms-request", zap.Any("request", req))
+	logger.Debug("initiating-create-comms-request", zap.Any("request", safeLogValue(req)))
 
 	newComms = newComms.SetCommsType(string(req.Type)).SetStandardisedEmail(req.Email).SetStandardisedFullName(req.FullName)
 
@@ -73,11 +71,11 @@ func (s *Service) CreateComms(ctx context.Context, req *CreateCommsRequest) (*Cr
 
 	createdComms, err := s.contacterRepository.CreateComms(ctx, newComms)
 	if err != nil {
-		logger.Error("failed-to-create-comms-error-creating-comms", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-comms-error-creating-comms", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CreateCommsResponse{}, err
 	}
 
-	logger.Debug("create-comms-request-successful", zap.Any("request", req), zap.Any("created-comms", createdComms))
+	logger.Debug("create-comms-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("created-comms", safeLogValue(createdComms)))
 
 	return &CreateCommsResponse{
 		Comms: createdComms,
@@ -88,9 +86,7 @@ func (s *Service) CreateComms(ctx context.Context, req *CreateCommsRequest) (*Cr
 func (s *Service) GetComms(ctx context.Context, req *GetCommsRequest) (*GetCommsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/contacter")
 	)
 
 	// default
@@ -129,16 +125,16 @@ func (s *Service) GetComms(ctx context.Context, req *GetCommsRequest) (*GetComms
 	}
 	totalComms, err := s.contacterRepository.GetTotalComms(ctx, getTotalCommsRequest)
 	if err != nil {
-		logger.Error("failed-to-get-comms-request-error-getting-total-comms", zap.Any("request", req), zap.Any("get-total-comms-request", getTotalCommsRequest), zap.Error(err))
+		logger.Error("failed-to-get-comms-request-error-getting-total-comms", zap.Any("request", safeLogValue(req)), zap.Any("get-total-comms-request", safeLogValue(getTotalCommsRequest)), zap.Error(err))
 		return &GetCommsResponse{}, err
 	}
 
 	req.TotalCount = int(totalComms)
-	logger.Debug("handling-get-comms-request-total-comms-found", zap.Int64("total", totalComms), zap.Any("request", req))
+	logger.Debug("handling-get-comms-request-total-comms-found", zap.Int64("total", totalComms), zap.Any("request", safeLogValue(req)))
 
 	comms, err := s.contacterRepository.GetComms(ctx, req)
 	if err != nil {
-		logger.Error("failed-to-get-comms-request-error-getting-comms", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-comms-request-error-getting-comms", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetCommsResponse{}, err
 	}
 
@@ -165,12 +161,10 @@ func (s *Service) GetComms(ctx context.Context, req *GetCommsRequest) (*GetComms
 func (s *Service) UpdateComms(ctx context.Context, req *UpdateCommsRequest) (*UpdateCommsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/contacter")
 	)
 
-	logger.Debug("initiating-update-comms-request", zap.Any("request", req))
+	logger.Debug("initiating-update-comms-request", zap.Any("request", safeLogValue(req)))
 
 	if req.CommsId == "" {
 		return nil, ErrCommsIdRequired
@@ -209,11 +203,11 @@ func (s *Service) UpdateComms(ctx context.Context, req *UpdateCommsRequest) (*Up
 
 	updatedComms, err := s.contacterRepository.UpdateComms(ctx, &comms)
 	if err != nil {
-		logger.Error("failed-to-update-comms-error-updating-comms", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-update-comms-error-updating-comms", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &UpdateCommsResponse{}, err
 	}
 
-	logger.Debug("update-comms-request-successful", zap.Any("request", req), zap.Any("updated-comms", updatedComms))
+	logger.Debug("update-comms-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("updated-comms", safeLogValue(updatedComms)))
 
 	return &UpdateCommsResponse{
 		Comms: updatedComms,
@@ -223,11 +217,9 @@ func (s *Service) UpdateComms(ctx context.Context, req *UpdateCommsRequest) (*Up
 // GetCommsStats retrieves aggregated stats about platform comms
 func (s *Service) GetCommsStats(ctx context.Context, req *GetCommsStatsRequest) (*GetCommsStatsResponse, error) {
 
-	var logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/contacter")
 
-	logger.Debug("initiating-get-comms-stats-request", zap.Any("request", req))
+	logger.Debug("initiating-get-comms-stats-request", zap.Any("request", safeLogValue(req)))
 
 	stats, err := s.contacterRepository.GetCommsStatsCounts(ctx, req)
 	if err != nil {

--- a/external/contentmanager/fender.go
+++ b/external/contentmanager/fender.go
@@ -17,10 +17,8 @@ import (
 func mapRequestToCreatePostRequest(r *http.Request, validator contentManagerValidator) (*CreatePostRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = &CreatePostRequest{
 			CreatePostRequest: &post.CreatePostRequest{},
@@ -39,7 +37,7 @@ func mapRequestToCreatePostRequest(r *http.Request, validator contentManagerVali
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-create-post-request", zap.Error(err))
+		logger.Warn("validation-failed-for-create-post-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -50,10 +48,8 @@ func mapRequestToCreatePostRequest(r *http.Request, validator contentManagerVali
 func mapRequestToUpdatePostByIdRequest(r *http.Request, validator contentManagerValidator) (*UpdatePostByIdRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = &UpdatePostByIdRequest{
 			UpdatePostRequest: &post.UpdatePostRequest{},
@@ -71,7 +67,7 @@ func mapRequestToUpdatePostByIdRequest(r *http.Request, validator contentManager
 	// Extract postId from URI
 	baseRequest.PostId, err = tctcToolbox.GetVariableValueFromUri(r, "postId")
 	if err != nil {
-		log.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
+		logger.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
 		return nil, post.ErrIdIsRequired
 	}
 
@@ -79,7 +75,7 @@ func mapRequestToUpdatePostByIdRequest(r *http.Request, validator contentManager
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-update-post-by-id-request", zap.Error(err))
+		logger.Warn("validation-failed-for-update-post-by-id-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -90,10 +86,8 @@ func mapRequestToUpdatePostByIdRequest(r *http.Request, validator contentManager
 func mapRequestToRestorePostByIdRequest(r *http.Request, validator contentManagerValidator) (*RestorePostByIdRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = &RestorePostByIdRequest{
 			RestorePostByIdRequest: &post.RestorePostByIdRequest{},
@@ -106,7 +100,7 @@ func mapRequestToRestorePostByIdRequest(r *http.Request, validator contentManage
 	// Extract postId from URI
 	baseRequest.Id, err = tctcToolbox.GetVariableValueFromUri(r, "postId")
 	if err != nil {
-		log.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
+		logger.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
 		return nil, post.ErrIdIsRequired
 	}
 
@@ -114,7 +108,7 @@ func mapRequestToRestorePostByIdRequest(r *http.Request, validator contentManage
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-restore-post-by-id-request", zap.Error(err))
+		logger.Warn("validation-failed-for-restore-post-by-id-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -125,10 +119,8 @@ func mapRequestToRestorePostByIdRequest(r *http.Request, validator contentManage
 func mapRequestToDeletePostByIdRequest(r *http.Request, validator contentManagerValidator) (*DeletePostByIdRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = &DeletePostByIdRequest{
 			DeletePostByIdRequest: &post.DeletePostByIdRequest{},
@@ -142,14 +134,14 @@ func mapRequestToDeletePostByIdRequest(r *http.Request, validator contentManager
 	query := r.URL.Query()
 	err = querydecoder.New(query).Decode(&baseRequest)
 	if err != nil {
-		log.Warn("failed-to-decode-query-for-get-glossary-items-request", zap.Error(err))
+		logger.Warn("failed-to-decode-query-for-get-glossary-items-request", zap.Error(err))
 		return nil, post.ErrInvalidPostQueryParam
 	}
 
 	// Extract postId from URI
 	baseRequest.Id, err = tctcToolbox.GetVariableValueFromUri(r, "postId")
 	if err != nil {
-		log.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
+		logger.Warn("failed-to-extract-post-id-from-uri", zap.Error(err))
 		return nil, post.ErrIdIsRequired
 	}
 
@@ -157,7 +149,7 @@ func mapRequestToDeletePostByIdRequest(r *http.Request, validator contentManager
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-delete-post-by-id-request", zap.Error(err))
+		logger.Warn("validation-failed-for-delete-post-by-id-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -168,10 +160,8 @@ func mapRequestToDeletePostByIdRequest(r *http.Request, validator contentManager
 func mapRequestToGetGlossaryItemsRequest(r *http.Request, validator contentManagerValidator) (*GetGlossaryItemsRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = GetGlossaryItemsRequest{
 			GetGlossaryItemsRequest: &post.GetGlossaryItemsRequest{
@@ -187,7 +177,7 @@ func mapRequestToGetGlossaryItemsRequest(r *http.Request, validator contentManag
 	query := r.URL.Query()
 	err = querydecoder.New(query).Decode(&baseRequest)
 	if err != nil {
-		log.Warn("failed-to-decode-query-for-get-glossary-items-request", zap.Error(err))
+		logger.Warn("failed-to-decode-query-for-get-glossary-items-request", zap.Error(err))
 		return nil, post.ErrInvalidPostQueryParam
 	}
 
@@ -195,7 +185,7 @@ func mapRequestToGetGlossaryItemsRequest(r *http.Request, validator contentManag
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-get-glossary-items-request", zap.Error(err))
+		logger.Warn("validation-failed-for-get-glossary-items-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -206,10 +196,8 @@ func mapRequestToGetGlossaryItemsRequest(r *http.Request, validator contentManag
 func mapRequestToGetFaqItemsRequest(r *http.Request, validator contentManagerValidator) (*GetFaqItemsRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = GetFaqItemsRequest{
 			GetFaqItemsRequest: &post.GetFaqItemsRequest{
@@ -225,7 +213,7 @@ func mapRequestToGetFaqItemsRequest(r *http.Request, validator contentManagerVal
 	query := r.URL.Query()
 	err = querydecoder.New(query).Decode(&baseRequest)
 	if err != nil {
-		log.Warn("failed-to-decode-query-for-get-faq-items-request", zap.Error(err))
+		logger.Warn("failed-to-decode-query-for-get-faq-items-request", zap.Error(err))
 		return nil, post.ErrInvalidPostQueryParam
 	}
 
@@ -233,7 +221,7 @@ func mapRequestToGetFaqItemsRequest(r *http.Request, validator contentManagerVal
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-get-faq-items-request", zap.Error(err))
+		logger.Warn("validation-failed-for-get-faq-items-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -244,10 +232,8 @@ func mapRequestToGetFaqItemsRequest(r *http.Request, validator contentManagerVal
 func mapRequestToGetArticlesRequest(r *http.Request, validator contentManagerValidator) (*GetArticlesRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = GetArticlesRequest{
 			GetArticlesRequest: &post.GetArticlesRequest{
@@ -263,7 +249,7 @@ func mapRequestToGetArticlesRequest(r *http.Request, validator contentManagerVal
 	query := r.URL.Query()
 	err = querydecoder.New(query).Decode(&baseRequest)
 	if err != nil {
-		log.Warn("failed-to-decode-query-for-get-articles-request", zap.Error(err))
+		logger.Warn("failed-to-decode-query-for-get-articles-request", zap.Error(err))
 		return nil, post.ErrInvalidPostQueryParam
 	}
 
@@ -271,7 +257,7 @@ func mapRequestToGetArticlesRequest(r *http.Request, validator contentManagerVal
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-get-articles-request", zap.Error(err))
+		logger.Warn("validation-failed-for-get-articles-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -282,10 +268,8 @@ func mapRequestToGetArticlesRequest(r *http.Request, validator contentManagerVal
 func mapRequestToGetChangelogItemsRequest(r *http.Request, validator contentManagerValidator) (*GetChangelogItemsRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = GetChangelogItemsRequest{
 			GetChangelogItemsRequest: &post.GetChangelogItemsRequest{
@@ -301,7 +285,7 @@ func mapRequestToGetChangelogItemsRequest(r *http.Request, validator contentMana
 	query := r.URL.Query()
 	err = querydecoder.New(query).Decode(&baseRequest)
 	if err != nil {
-		log.Warn("failed-to-decode-query-for-get-changelog-items-request", zap.Error(err))
+		logger.Warn("failed-to-decode-query-for-get-changelog-items-request", zap.Error(err))
 		return nil, post.ErrInvalidPostQueryParam
 	}
 
@@ -309,7 +293,7 @@ func mapRequestToGetChangelogItemsRequest(r *http.Request, validator contentMana
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-get-changelog-items-request", zap.Error(err))
+		logger.Warn("validation-failed-for-get-changelog-items-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -320,10 +304,8 @@ func mapRequestToGetChangelogItemsRequest(r *http.Request, validator contentMana
 func mapRequestToGetChangelogItemByUrlFriendlyIdRequest(r *http.Request, validator contentManagerValidator) (*GetChangelogItemByUrlFriendlyIdRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = GetChangelogItemByUrlFriendlyIdRequest{}
 	)
@@ -338,7 +320,7 @@ func mapRequestToGetChangelogItemByUrlFriendlyIdRequest(r *http.Request, validat
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-get-changelog-item-by-url-friendly-id-request", zap.Error(err))
+		logger.Warn("validation-failed-for-get-changelog-item-by-url-friendly-id-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -350,10 +332,8 @@ func mapRequestToGetChangelogItemByUrlFriendlyIdRequest(r *http.Request, validat
 func mapRequestToGetArticleItemByUrlFriendlyIdRequest(r *http.Request, validator contentManagerValidator) (*GetArticleItemByUrlFriendlyIdRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = GetArticleItemByUrlFriendlyIdRequest{}
 	)
@@ -368,7 +348,7 @@ func mapRequestToGetArticleItemByUrlFriendlyIdRequest(r *http.Request, validator
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-get-article-item-by-url-friendly-id-request", zap.Error(err))
+		logger.Warn("validation-failed-for-get-article-item-by-url-friendly-id-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -380,10 +360,8 @@ func mapRequestToGetArticleItemByUrlFriendlyIdRequest(r *http.Request, validator
 func mapRequestToGetLatestPostsByTypeRequest(r *http.Request, validator contentManagerValidator) (*GetLatestPostsByTypeRequest, error) {
 
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = GetLatestPostsByTypeRequest{
 			GetLatestPostsByTypeRequest: &post.GetLatestPostsByTypeRequest{},
@@ -397,7 +375,7 @@ func mapRequestToGetLatestPostsByTypeRequest(r *http.Request, validator contentM
 	query := r.URL.Query()
 	err = querydecoder.New(query).Decode(&baseRequest)
 	if err != nil {
-		log.Warn("failed-to-decode-query-for-get-latest-posts-by-type-request", zap.Error(err))
+		logger.Warn("failed-to-decode-query-for-get-latest-posts-by-type-request", zap.Error(err))
 		return nil, post.ErrInvalidPostQueryParam
 	}
 
@@ -405,7 +383,7 @@ func mapRequestToGetLatestPostsByTypeRequest(r *http.Request, validator contentM
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-get-latest-posts-by-type-request", zap.Error(err))
+		logger.Warn("validation-failed-for-get-latest-posts-by-type-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 
@@ -415,10 +393,8 @@ func mapRequestToGetLatestPostsByTypeRequest(r *http.Request, validator contentM
 // mapRequestToGetLatestNotificationOverviewsRequest maps the http request to the get latest notification overviews request
 func mapRequestToGetLatestNotificationOverviewsRequest(r *http.Request, validator contentManagerValidator) (*GetLatestNotificationOverviewsRequest, error) {
 	var (
-		err error
-		log *zap.Logger = logger.AcquireFrom(r.Context()).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		err    error
+		logger *zap.Logger = logger.AcquirePackageFrom(r.Context(), "external/contentmanager")
 
 		parsedRequest = GetLatestNotificationOverviewsRequest{
 			GetLatestNotificationOverviewsRequest: &common.GetLatestNotificationOverviewsRequest{},
@@ -429,7 +405,7 @@ func mapRequestToGetLatestNotificationOverviewsRequest(r *http.Request, validato
 	query := r.URL.Query()
 	err = querydecoder.New(query).Decode(&baseRequest)
 	if err != nil {
-		log.Warn("failed-to-decode-query-for-get-latest-notification-overviews-request", zap.Error(err))
+		logger.Warn("failed-to-decode-query-for-get-latest-notification-overviews-request", zap.Error(err))
 		return nil, post.ErrInvalidPostQueryParam
 	}
 
@@ -438,7 +414,7 @@ func mapRequestToGetLatestNotificationOverviewsRequest(r *http.Request, validato
 
 	err = validateParsedRequest(parsedRequest, validator)
 	if err != nil {
-		log.Warn("validation-failed-for-get-latest-notification-overviews-request", zap.Error(err))
+		logger.Warn("validation-failed-for-get-latest-notification-overviews-request", zap.Error(err))
 		return nil, post.ErrPostBadRequest
 	}
 

--- a/external/contentmanager/handler.go
+++ b/external/contentmanager/handler.go
@@ -2,12 +2,14 @@ package contentmanager
 
 import (
 	"context"
+	"github.com/ooaklee/ghatd/external/logger"
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/common"
 	"github.com/ooaklee/ghatd/external/errormanifest"
 	"github.com/ooaklee/ghatd/external/post"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // contentManagerService manages business logic for
@@ -59,9 +61,11 @@ func NewHandler(service contentManagerService, validator contentManagerValidator
 
 // CreatePost handles the request for creating a post
 func (h *Handler) CreatePost(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-create-post")
 	request, err := mapRequestToCreatePostRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -69,6 +73,7 @@ func (h *Handler) CreatePost(w http.ResponseWriter, r *http.Request) {
 	newlyCreated, err := h.service.CreatePost(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -79,9 +84,11 @@ func (h *Handler) CreatePost(w http.ResponseWriter, r *http.Request) {
 
 // UpdatePostById handles the request for updating a post by its ID
 func (h *Handler) UpdatePostById(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-update-post-by-id")
 	request, err := mapRequestToUpdatePostByIdRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -89,6 +96,7 @@ func (h *Handler) UpdatePostById(w http.ResponseWriter, r *http.Request) {
 	updatedPost, err := h.service.UpdatePostById(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -99,9 +107,11 @@ func (h *Handler) UpdatePostById(w http.ResponseWriter, r *http.Request) {
 
 // DeletePostById handles the request for deleting a post by its ID
 func (h *Handler) DeletePostById(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-delete-post-by-id")
 	request, err := mapRequestToDeletePostByIdRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -109,6 +119,7 @@ func (h *Handler) DeletePostById(w http.ResponseWriter, r *http.Request) {
 	_, err = h.service.DeletePostById(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -119,9 +130,11 @@ func (h *Handler) DeletePostById(w http.ResponseWriter, r *http.Request) {
 
 // RestorePostById handles the request for restoring a post by its ID
 func (h *Handler) RestorePostById(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-restore-post-by-id")
 	request, err := mapRequestToRestorePostByIdRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -129,6 +142,7 @@ func (h *Handler) RestorePostById(w http.ResponseWriter, r *http.Request) {
 	restoredPost, err := h.service.RestorePostById(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -139,9 +153,11 @@ func (h *Handler) RestorePostById(w http.ResponseWriter, r *http.Request) {
 
 // GetChangelogItems handles the request for getting changelog posts
 func (h *Handler) GetChangelogItems(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-get-changelog-items")
 	request, err := mapRequestToGetChangelogItemsRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -149,6 +165,7 @@ func (h *Handler) GetChangelogItems(w http.ResponseWriter, r *http.Request) {
 	posts, err := h.service.GetChangelogItems(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -166,9 +183,11 @@ func (h *Handler) GetChangelogItems(w http.ResponseWriter, r *http.Request) {
 // GetChangelogItemByUrlFriendlyId handles the request for getting changelog item by its
 // url friendly id
 func (h *Handler) GetChangelogItemByUrlFriendlyId(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-get-changelog-item-by-url-friendly-id")
 	request, err := mapRequestToGetChangelogItemByUrlFriendlyIdRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -176,6 +195,7 @@ func (h *Handler) GetChangelogItemByUrlFriendlyId(w http.ResponseWriter, r *http
 	post, err := h.service.GetChangelogItemByUrlFriendlyId(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -186,9 +206,11 @@ func (h *Handler) GetChangelogItemByUrlFriendlyId(w http.ResponseWriter, r *http
 
 // GetGlossaryItems handles the request for getting glossary posts
 func (h *Handler) GetGlossaryItems(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-get-glossary-items")
 	request, err := mapRequestToGetGlossaryItemsRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -196,6 +218,7 @@ func (h *Handler) GetGlossaryItems(w http.ResponseWriter, r *http.Request) {
 	posts, err := h.service.GetGlossaryItems(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -212,9 +235,11 @@ func (h *Handler) GetGlossaryItems(w http.ResponseWriter, r *http.Request) {
 
 // GetFaqItems handles the request for getting faq posts
 func (h *Handler) GetFaqItems(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-get-faq-items")
 	request, err := mapRequestToGetFaqItemsRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -222,6 +247,7 @@ func (h *Handler) GetFaqItems(w http.ResponseWriter, r *http.Request) {
 	posts, err := h.service.GetFaqItems(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -238,9 +264,11 @@ func (h *Handler) GetFaqItems(w http.ResponseWriter, r *http.Request) {
 
 // GetArticles handles the request for getting articles posts
 func (h *Handler) GetArticles(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-get-articles")
 	request, err := mapRequestToGetArticlesRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -248,6 +276,7 @@ func (h *Handler) GetArticles(w http.ResponseWriter, r *http.Request) {
 	posts, err := h.service.GetArticles(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -265,9 +294,11 @@ func (h *Handler) GetArticles(w http.ResponseWriter, r *http.Request) {
 // GetArticleItemByUrlFriendlyId handles the request for getting article item by its
 // url friendly id
 func (h *Handler) GetArticleItemByUrlFriendlyId(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-get-article-item-by-url-friendly-id")
 	request, err := mapRequestToGetArticleItemByUrlFriendlyIdRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -275,6 +306,7 @@ func (h *Handler) GetArticleItemByUrlFriendlyId(w http.ResponseWriter, r *http.R
 	post, err := h.service.GetArticleItemByUrlFriendlyId(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -285,9 +317,11 @@ func (h *Handler) GetArticleItemByUrlFriendlyId(w http.ResponseWriter, r *http.R
 
 // GetLatestPostsByType handles the request for getting the latest posts by type
 func (h *Handler) GetLatestPostsByType(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-get-latest-posts-by-type")
 	request, err := mapRequestToGetLatestPostsByTypeRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -295,6 +329,7 @@ func (h *Handler) GetLatestPostsByType(w http.ResponseWriter, r *http.Request) {
 	posts, err := h.service.GetLatestPostsByType(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -305,14 +340,17 @@ func (h *Handler) GetLatestPostsByType(w http.ResponseWriter, r *http.Request) {
 
 // GetLatestNotificationOverviews handles the request for getting the latest notification overviews for the user
 func (h *Handler) GetLatestNotificationOverviews(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/contentmanager", "handle-get-latest-notification-overviews")
 	request, err := mapRequestToGetLatestNotificationOverviewsRequest(r, h.validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	overviews, err := h.service.GetLatestNotificationOverviews(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/contentmanager/logging.go
+++ b/external/contentmanager/logging.go
@@ -1,0 +1,7 @@
+package contentmanager
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/contentmanager/service.go
+++ b/external/contentmanager/service.go
@@ -67,25 +67,25 @@ func NewService(postService postService, userService userService) *Service {
 // CreatePost handles logic associate with creating a new post
 func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*CreatePostResponse, error) {
 
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Info("handling-create-post-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/contentmanager")
+	logger.Info("handling-create-post-request", zap.Any("request", safeLogValue(req)))
 
 	requestingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 		ID: req.UserId,
 	})
 	if err != nil {
-		log.Error("failed-to-get-user-associated-with-post-creation-request", zap.String("user-id", req.UserId), zap.Error(err))
+		logger.Error("failed-to-get-user-associated-with-post-creation-request", zap.String("user-id", req.UserId), zap.Error(err))
 		return nil, err
 	}
 
 	if !requestingUser.User.IsAdmin() {
-		log.Warn("non-admin-user-attempting-to-create-post", zap.String("user-id", req.UserId), zap.Any("request", req))
+		logger.Warn("non-admin-user-attempting-to-create-post", zap.String("user-id", req.UserId), zap.Any("request", safeLogValue(req)))
 		return nil, ErrUnauthorisedCMUser
 	}
 
 	newPost, err := s.postService.CreatePost(ctx, req.CreatePostRequest)
 	if err != nil {
-		log.Error("failed-to-create-post", zap.Error(err))
+		logger.Error("failed-to-create-post", zap.Error(err))
 		return nil, err
 	}
 
@@ -97,25 +97,25 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 // UpdatePostById handles logic associated with updating an existing post by its ID
 func (s *Service) UpdatePostById(ctx context.Context, req *UpdatePostByIdRequest) (*UpdatePostByIdResponse, error) {
 
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Info("handling-update-post-by-id-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/contentmanager")
+	logger.Info("handling-update-post-by-id-request", zap.Any("request", safeLogValue(req)))
 
 	requestingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 		ID: req.UserId,
 	})
 	if err != nil {
-		log.Error("failed-to-get-user-associated-with-post-update-request", zap.String("user-id", req.UserId), zap.Error(err))
+		logger.Error("failed-to-get-user-associated-with-post-update-request", zap.String("user-id", req.UserId), zap.Error(err))
 		return nil, err
 	}
 
 	if !requestingUser.User.IsAdmin() {
-		log.Warn("non-admin-user-attempting-to-update-post", zap.String("user-id", req.UserId), zap.Any("request", req))
+		logger.Warn("non-admin-user-attempting-to-update-post", zap.String("user-id", req.UserId), zap.Any("request", safeLogValue(req)))
 		return nil, ErrUnauthorisedCMUser
 	}
 
 	updatedPost, err := s.postService.UpdatePost(ctx, req.UpdatePostRequest)
 	if err != nil {
-		log.Error("failed-to-update-post", zap.Error(err))
+		logger.Error("failed-to-update-post", zap.Error(err))
 		return nil, err
 	}
 
@@ -127,25 +127,25 @@ func (s *Service) UpdatePostById(ctx context.Context, req *UpdatePostByIdRequest
 // DeletePostById handles logic associated with deleting an existing post by its ID
 func (s *Service) DeletePostById(ctx context.Context, req *DeletePostByIdRequest) (*DeletePostByIdResponse, error) {
 
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Info("handling-delete-post-by-id-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/contentmanager")
+	logger.Info("handling-delete-post-by-id-request", zap.Any("request", safeLogValue(req)))
 
 	requestingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 		ID: req.UserId,
 	})
 	if err != nil {
-		log.Error("failed-to-get-user-associated-with-post-delete-request", zap.String("user-id", req.UserId), zap.Error(err))
+		logger.Error("failed-to-get-user-associated-with-post-delete-request", zap.String("user-id", req.UserId), zap.Error(err))
 		return nil, err
 	}
 
 	if !requestingUser.User.IsAdmin() {
-		log.Warn("non-admin-user-attempting-to-delete-post", zap.String("user-id", req.UserId), zap.Any("request", req))
+		logger.Warn("non-admin-user-attempting-to-delete-post", zap.String("user-id", req.UserId), zap.Any("request", safeLogValue(req)))
 		return nil, ErrUnauthorisedCMUser
 	}
 
 	deletedPostResponse, err := s.postService.DeletePostById(ctx, req.DeletePostByIdRequest)
 	if err != nil {
-		log.Error("failed-to-delete-post", zap.Error(err))
+		logger.Error("failed-to-delete-post", zap.Error(err))
 		return nil, err
 	}
 
@@ -157,25 +157,25 @@ func (s *Service) DeletePostById(ctx context.Context, req *DeletePostByIdRequest
 // RestorePostById handles logic associated with restoring a soft-deleted post by ID
 func (s *Service) RestorePostById(ctx context.Context, req *RestorePostByIdRequest) (*RestorePostByIdResponse, error) {
 
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Info("handling-restore-post-by-id-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/contentmanager")
+	logger.Info("handling-restore-post-by-id-request", zap.Any("request", safeLogValue(req)))
 
 	requestingUser, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 		ID: req.UserId,
 	})
 	if err != nil {
-		log.Error("failed-to-get-user-associated-with-post-restore-request", zap.String("user-id", req.UserId), zap.Error(err))
+		logger.Error("failed-to-get-user-associated-with-post-restore-request", zap.String("user-id", req.UserId), zap.Error(err))
 		return nil, err
 	}
 
 	if !requestingUser.User.IsAdmin() {
-		log.Warn("non-admin-user-attempting-to-restore-post", zap.String("user-id", req.UserId), zap.Any("request", req))
+		logger.Warn("non-admin-user-attempting-to-restore-post", zap.String("user-id", req.UserId), zap.Any("request", safeLogValue(req)))
 		return nil, ErrUnauthorisedCMUser
 	}
 
 	restoredPostResponse, err := s.postService.RestorePostById(ctx, req.RestorePostByIdRequest)
 	if err != nil {
-		log.Error("failed-to-restore-post", zap.Error(err))
+		logger.Error("failed-to-restore-post", zap.Error(err))
 		return nil, err
 	}
 
@@ -188,18 +188,18 @@ func (s *Service) RestorePostById(ctx context.Context, req *RestorePostByIdReque
 func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsByTypeRequest) (*GetLatestPostsByTypeResponse, error) {
 
 	var (
-		log            = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger         = logger.AcquirePackageFrom(ctx, "external/contentmanager")
 		requestingUser *userV2.UniversalUser
 	)
 
-	log.Info("handling-get-latest-posts-by-type-request")
+	logger.Info("handling-get-latest-posts-by-type-request")
 
 	if req.UserId != "" {
 		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 			ID: req.UserId,
 		})
 		if err != nil {
-			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			logger.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
 			return nil, err
 		}
 
@@ -208,7 +208,7 @@ func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsB
 
 	matchingPostOverviewsResp, err := s.postService.GetLatestPostsByType(ctx, req.GetLatestPostsByTypeRequest)
 	if err != nil {
-		log.Error("failed-to-get-latest-posts-by-type", zap.Error(err))
+		logger.Error("failed-to-get-latest-posts-by-type", zap.Error(err))
 		return nil, err
 	}
 
@@ -227,6 +227,9 @@ func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsB
 
 // GetLatestNotificationOverviews handles logic associated with getting the latest notification overviews for the user
 func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *GetLatestNotificationOverviewsRequest) (*GetLatestNotificationOverviewsResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/contentmanager", "get-latest-notification-overviews")
+	logger.Debug("handling-get-latest-notification-overviews-request")
+
 	overviews, err := s.postService.GetLatestNotificationOverviews(ctx, req.GetLatestNotificationOverviewsRequest)
 	if err != nil {
 		return nil, err
@@ -242,12 +245,12 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *GetLa
 func (s *Service) GetChangelogItemByUrlFriendlyId(ctx context.Context, req *GetChangelogItemByUrlFriendlyIdRequest) (*post.Post, error) {
 
 	var (
-		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                           = logger.AcquirePackageFrom(ctx, "external/contentmanager")
 		requestingUser                   *userV2.UniversalUser
 		userIdToUserFirstNameLastInitial = make(map[string]string)
 	)
 
-	log.Info("handling-get-changelog-item-request")
+	logger.Info("handling-get-changelog-item-request")
 
 	if !strings.HasPrefix(req.UrlFriendlyId, "changelog-") {
 		// make sure only changelogs are returned
@@ -259,7 +262,7 @@ func (s *Service) GetChangelogItemByUrlFriendlyId(ctx context.Context, req *GetC
 			ID: req.UserId,
 		})
 		if err != nil {
-			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			logger.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
 			return nil, err
 		}
 
@@ -271,7 +274,7 @@ func (s *Service) GetChangelogItemByUrlFriendlyId(ctx context.Context, req *GetC
 
 	matchingPost, err := s.postService.GetPostByUrlFriendlyId(ctx, req.UrlFriendlyId)
 	if err != nil {
-		log.Error("failed-to-get-changelog-item", zap.Error(err))
+		logger.Error("failed-to-get-changelog-item", zap.Error(err))
 		return nil, err
 	}
 
@@ -288,7 +291,7 @@ func (s *Service) GetChangelogItemByUrlFriendlyId(ctx context.Context, req *GetC
 		},
 	}
 
-	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, postsResponse, userIdToUserFirstNameLastInitial, log)
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, postsResponse, userIdToUserFirstNameLastInitial, logger)
 
 	return &postsResponse.Posts[0], nil
 }
@@ -298,12 +301,12 @@ func (s *Service) GetChangelogItemByUrlFriendlyId(ctx context.Context, req *GetC
 func (s *Service) GetArticleItemByUrlFriendlyId(ctx context.Context, req *GetArticleItemByUrlFriendlyIdRequest) (*post.Post, error) {
 
 	var (
-		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                           = logger.AcquirePackageFrom(ctx, "external/contentmanager")
 		requestingUser                   *userV2.UniversalUser
 		userIdToUserFirstNameLastInitial = make(map[string]string)
 	)
 
-	log.Info("handling-get-article-item-request")
+	logger.Info("handling-get-article-item-request")
 
 	if !strings.HasPrefix(req.UrlFriendlyId, "article-") {
 		// make sure only articles are returned
@@ -315,7 +318,7 @@ func (s *Service) GetArticleItemByUrlFriendlyId(ctx context.Context, req *GetArt
 			ID: req.UserId,
 		})
 		if err != nil {
-			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			logger.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
 			return nil, err
 		}
 
@@ -327,7 +330,7 @@ func (s *Service) GetArticleItemByUrlFriendlyId(ctx context.Context, req *GetArt
 
 	matchingPost, err := s.postService.GetPostByUrlFriendlyId(ctx, req.UrlFriendlyId)
 	if err != nil {
-		log.Error("failed-to-get-article-item", zap.Error(err))
+		logger.Error("failed-to-get-article-item", zap.Error(err))
 		return nil, err
 	}
 
@@ -344,7 +347,7 @@ func (s *Service) GetArticleItemByUrlFriendlyId(ctx context.Context, req *GetArt
 		},
 	}
 
-	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, postsResponse, userIdToUserFirstNameLastInitial, log)
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, postsResponse, userIdToUserFirstNameLastInitial, logger)
 
 	return &postsResponse.Posts[0], nil
 }
@@ -353,19 +356,19 @@ func (s *Service) GetArticleItemByUrlFriendlyId(ctx context.Context, req *GetArt
 func (s *Service) GetChangelogItems(ctx context.Context, req *GetChangelogItemsRequest) (*GetChangelogItemsResponse, error) {
 
 	var (
-		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                           = logger.AcquirePackageFrom(ctx, "external/contentmanager")
 		requestingUser                   *userV2.UniversalUser
 		userIdToUserFirstNameLastInitial = make(map[string]string)
 	)
 
-	log.Info("handling-get-changelog-items-request")
+	logger.Info("handling-get-changelog-items-request")
 
 	if req.UserId != "" {
 		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 			ID: req.UserId,
 		})
 		if err != nil {
-			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			logger.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
 			return nil, err
 		}
 
@@ -383,11 +386,11 @@ func (s *Service) GetChangelogItems(ctx context.Context, req *GetChangelogItemsR
 
 	matchingPosts, err := s.postService.GetChangelogItems(ctx, req.GetChangelogItemsRequest)
 	if err != nil {
-		log.Error("failed-to-get-changelog-items", zap.Error(err))
+		logger.Error("failed-to-get-changelog-items", zap.Error(err))
 		return nil, err
 	}
 
-	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, log)
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, logger)
 
 	return &GetChangelogItemsResponse{
 		GetChangelogItemsResponse: matchingPosts,
@@ -398,19 +401,19 @@ func (s *Service) GetChangelogItems(ctx context.Context, req *GetChangelogItemsR
 func (s *Service) GetGlossaryItems(ctx context.Context, req *GetGlossaryItemsRequest) (*GetGlossaryItemsResponse, error) {
 
 	var (
-		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                           = logger.AcquirePackageFrom(ctx, "external/contentmanager")
 		requestingUser                   *userV2.UniversalUser
 		userIdToUserFirstNameLastInitial = make(map[string]string)
 	)
 
-	log.Info("handling-get-glossary-items-request")
+	logger.Info("handling-get-glossary-items-request")
 
 	if req.UserId != "" {
 		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 			ID: req.UserId,
 		})
 		if err != nil {
-			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			logger.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
 			return nil, err
 		}
 
@@ -428,11 +431,11 @@ func (s *Service) GetGlossaryItems(ctx context.Context, req *GetGlossaryItemsReq
 
 	matchingPosts, err := s.postService.GetGlossaryItems(ctx, req.GetGlossaryItemsRequest)
 	if err != nil {
-		log.Error("failed-to-get-glossary-items", zap.Error(err))
+		logger.Error("failed-to-get-glossary-items", zap.Error(err))
 		return nil, err
 	}
 
-	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, log)
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, logger)
 
 	return &GetGlossaryItemsResponse{
 		GetGlossaryItemsResponse: matchingPosts,
@@ -443,19 +446,19 @@ func (s *Service) GetGlossaryItems(ctx context.Context, req *GetGlossaryItemsReq
 func (s *Service) GetFaqItems(ctx context.Context, req *GetFaqItemsRequest) (*GetFaqItemsResponse, error) {
 
 	var (
-		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                           = logger.AcquirePackageFrom(ctx, "external/contentmanager")
 		requestingUser                   *userV2.UniversalUser
 		userIdToUserFirstNameLastInitial = make(map[string]string)
 	)
 
-	log.Info("handling-get-faq-items-request")
+	logger.Info("handling-get-faq-items-request")
 
 	if req.UserId != "" {
 		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 			ID: req.UserId,
 		})
 		if err != nil {
-			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			logger.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
 			return nil, err
 		}
 
@@ -473,11 +476,11 @@ func (s *Service) GetFaqItems(ctx context.Context, req *GetFaqItemsRequest) (*Ge
 
 	matchingPosts, err := s.postService.GetFaqItems(ctx, req.GetFaqItemsRequest)
 	if err != nil {
-		log.Error("failed-to-get-faq-items", zap.Error(err))
+		logger.Error("failed-to-get-faq-items", zap.Error(err))
 		return nil, err
 	}
 
-	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, log)
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, logger)
 
 	return &GetFaqItemsResponse{
 		GetFaqItemsResponse: matchingPosts,
@@ -488,19 +491,19 @@ func (s *Service) GetFaqItems(ctx context.Context, req *GetFaqItemsRequest) (*Ge
 func (s *Service) GetArticles(ctx context.Context, req *GetArticlesRequest) (*GetArticlesResponse, error) {
 
 	var (
-		log                              = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+		logger                           = logger.AcquirePackageFrom(ctx, "external/contentmanager")
 		requestingUser                   *userV2.UniversalUser
 		userIdToUserFirstNameLastInitial = make(map[string]string)
 	)
 
-	log.Info("handling-get-articles-request")
+	logger.Info("handling-get-articles-request")
 
 	if req.UserId != "" {
 		getRequestingUserResp, err := s.userService.GetUserByID(ctx, &userV2.GetUserByIDRequest{
 			ID: req.UserId,
 		})
 		if err != nil {
-			log.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
+			logger.Error("failed-to-get-user-associated-with-provided-user-id", zap.String("user-id", req.UserId), zap.Error(err))
 			return nil, err
 		}
 
@@ -518,11 +521,11 @@ func (s *Service) GetArticles(ctx context.Context, req *GetArticlesRequest) (*Ge
 
 	matchingPosts, err := s.postService.GetArticles(ctx, req.GetArticlesRequest)
 	if err != nil {
-		log.Error("failed-to-get-articles", zap.Error(err))
+		logger.Error("failed-to-get-articles", zap.Error(err))
 		return nil, err
 	}
 
-	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, log)
+	s.handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx, matchingPosts, userIdToUserFirstNameLastInitial, logger)
 
 	return &GetArticlesResponse{
 		GetArticlesResponse: matchingPosts,
@@ -531,7 +534,7 @@ func (s *Service) GetArticles(ctx context.Context, req *GetArticlesRequest) (*Ge
 
 // handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet handles instances publish_as is not set but a publish_at is given,
 // we must try to set and default to user's first name and last name initial
-func (s *Service) handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx context.Context, matchingPostsHolder ResponseHolder, userIdToUserFirstNameLastInitial map[string]string, log *zap.Logger) {
+func (s *Service) handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(ctx context.Context, matchingPostsHolder ResponseHolder, userIdToUserFirstNameLastInitial map[string]string, logger *zap.Logger) {
 	matchingPosts := matchingPostsHolder.GetEmbeddedPostsResponse()
 	for i, post := range matchingPosts.Posts {
 		if post.PublishedAs == "" && post.PublishedAt != "" {
@@ -542,7 +545,7 @@ func (s *Service) handleDynamicUpdatingOfPostsWithPublishDateAndNoPublishAsSet(c
 					ID: post.PublishedByUserId,
 				})
 				if err != nil {
-					log.Error("failed-to-get-user-associated-with-post-publication", zap.String("user-id", post.PublishedByUserId), zap.Error(err))
+					logger.Error("failed-to-get-user-associated-with-post-publication", zap.String("user-id", post.PublishedByUserId), zap.Error(err))
 
 					userIdToUserFirstNameLastInitial[post.PublishedByUserId] = DefaultPostAuthor
 					continue

--- a/external/emailmanager/emailmanager.go
+++ b/external/emailmanager/emailmanager.go
@@ -40,12 +40,21 @@ type Config struct {
 	EnableAuditLogging bool
 }
 
+type localOutputProvider interface {
+	IsLocalOutputProvider() bool
+}
+
 // DefaultConfig returns a config with sensible defaults
 func DefaultConfig() *Config {
 	return &Config{
 		ShouldSendEmail:    true,
 		EnableAuditLogging: true,
 	}
+}
+
+func isLocalOutputProvider(provider emailprovider.EmailProvider) bool {
+	localProvider, ok := provider.(localOutputProvider)
+	return ok && localProvider.IsLocalOutputProvider()
 }
 
 // NewEmailManager creates a new email manager
@@ -175,23 +184,58 @@ func (m *EmailManager) SendEmail(ctx context.Context, req *SendEmailRequest) err
 		Subject:  req.Subject,
 		HTMLBody: req.HTMLBody,
 	}
+	emailInfo := &EmailInfo{
+		To:            req.To,
+		From:          req.From,
+		Subject:       req.Subject,
+		EmailProvider: m.provider.Name(),
+		UserId:        req.UserId,
+		RecipientType: req.RecipientType,
+	}
+
+	if !m.config.ShouldSendEmail {
+		messageID := ""
+		if isLocalOutputProvider(m.provider) {
+			result, err := m.provider.Send(ctx, email)
+			if err != nil {
+				logger.Error("failed-to-output-local-email", append(outboundEmailLogFields(m.provider.Name(), "", req.To, req.From, req.Subject), zap.Error(err))...)
+				return ErrEmailMailerSendFailed
+			}
+			messageID = result.MessageID
+			emailInfo.EmailProvider = result.Provider
+		}
+
+		logger.Info("email-outputted-locally-not-sent-disabled-by-config",
+			outboundEmailLogFields(emailInfo.EmailProvider, messageID, req.To, req.From, req.Subject)...,
+		)
+
+		if m.config.EnableAuditLogging && m.auditService != nil {
+			m.logAuditEvent(ctx, emailInfo)
+		}
+
+		return nil
+	}
+
+	if !m.provider.IsHealthy(ctx) {
+		logger.Error("email-provider-is-not-healthy",
+			zap.String("provider", m.provider.Name()),
+		)
+		return ErrEmailMailerProviderUnavailable
+	}
 
 	// Send via provider
 	result, err := m.provider.Send(ctx, email)
 	if err != nil {
+		logger.Error("failed-to-send-email", append(outboundEmailLogFields(m.provider.Name(), "", req.To, req.From, req.Subject), zap.Error(err))...)
 		return ErrEmailMailerSendFailed
 	}
+	emailInfo.EmailProvider = result.Provider
 
-	// Log audit event if enabled
+	logger.Info("email-sent-successfully",
+		outboundEmailLogFields(result.Provider, result.MessageID, req.To, req.From, req.Subject)...,
+	)
+
 	if m.config.EnableAuditLogging && m.auditService != nil {
-		emailInfo := &EmailInfo{
-			To:            req.To,
-			From:          req.From,
-			Subject:       req.Subject,
-			EmailProvider: result.Provider,
-			UserId:        req.UserId,
-			RecipientType: req.RecipientType,
-		}
 		m.logAuditEvent(ctx, emailInfo)
 	}
 
@@ -202,10 +246,30 @@ func (m *EmailManager) SendEmail(ctx context.Context, req *SendEmailRequest) err
 func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.RenderedEmail, emailInfo *EmailInfo) error {
 	logger := logger.AcquirePackageFrom(ctx, "external/emailmanager")
 
+	email := &emailprovider.Email{
+		To:       rendered.To,
+		From:     rendered.From,
+		ReplyTo:  rendered.ReplyTo,
+		Subject:  rendered.Subject,
+		HTMLBody: rendered.HTMLBody,
+	}
+
 	// Check if we should actually send or just log
 	if !m.config.ShouldSendEmail {
+		messageID := ""
+		providerName := emailInfo.EmailProvider
+		if isLocalOutputProvider(m.provider) {
+			result, err := m.provider.Send(ctx, email)
+			if err != nil {
+				logger.Error("failed-to-output-local-email", append(outboundEmailLogFields(providerName, "", rendered.To, rendered.From, rendered.Subject), zap.Error(err))...)
+				return ErrEmailMailerSendFailed
+			}
+			messageID = result.MessageID
+			providerName = result.Provider
+		}
+
 		logger.Info("email-outputted-locally-not-sent-disabled-by-config",
-			outboundEmailLogFields(emailInfo.EmailProvider, "", rendered.To, rendered.From, rendered.Subject)...,
+			outboundEmailLogFields(providerName, messageID, rendered.To, rendered.From, rendered.Subject)...,
 		)
 
 		// Still log audit event even if not sending
@@ -222,15 +286,6 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 			zap.String("provider", m.provider.Name()),
 		)
 		return ErrEmailMailerProviderUnavailable
-	}
-
-	// Create email object
-	email := &emailprovider.Email{
-		To:       rendered.To,
-		From:     rendered.From,
-		ReplyTo:  rendered.ReplyTo,
-		Subject:  rendered.Subject,
-		HTMLBody: rendered.HTMLBody,
 	}
 
 	// Send via provider

--- a/external/emailmanager/emailmanager.go
+++ b/external/emailmanager/emailmanager.go
@@ -205,10 +205,7 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 	// Check if we should actually send or just log
 	if !m.config.ShouldSendEmail {
 		logger.Info("email-outputted-locally-not-sent-disabled-by-config",
-			zap.String("to", rendered.To),
-			zap.String("from", rendered.From),
-			zap.String("subject", rendered.Subject),
-			zap.String("provider", emailInfo.EmailProvider),
+			outboundEmailLogFields(emailInfo.EmailProvider, "", rendered.To, rendered.From, rendered.Subject)...,
 		)
 
 		// Still log audit event even if not sending
@@ -239,19 +236,12 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 	// Send via provider
 	result, err := m.provider.Send(ctx, email)
 	if err != nil {
-		logger.Error("failed-to-send-email",
-			zap.String("provider", m.provider.Name()),
-			zap.String("to", rendered.To),
-			zap.Error(err),
-		)
+		logger.Error("failed-to-send-email", append(outboundEmailLogFields(m.provider.Name(), "", rendered.To, rendered.From, rendered.Subject), zap.Error(err))...)
 		return ErrEmailMailerSendFailed
 	}
 
 	logger.Info("email-sent-successfully",
-		zap.String("provider", result.Provider),
-		zap.String("message_id", result.MessageID),
-		zap.String("to", rendered.To),
-		zap.String("subject", rendered.Subject),
+		outboundEmailLogFields(result.Provider, result.MessageID, rendered.To, rendered.From, rendered.Subject)...,
 	)
 
 	// Log audit event if enabled
@@ -283,12 +273,12 @@ func (m *EmailManager) logAuditEvent(ctx context.Context, emailInfo *EmailInfo) 
 	})
 
 	if err != nil {
-		logger.Warn("failed-to-log-audit-event",
+		logger.Warn("failed-to-log-audit-event", append(
+			subjectLogFields(emailInfo.Subject),
 			zap.String("actor-id", audit.AuditActorIdSystem),
 			zap.String("user-id", emailInfo.UserId),
 			zap.String("event-type", string(audit.UserEmailOutbound)),
-			zap.String("subject", emailInfo.Subject),
 			zap.Error(err),
-		)
+		)...)
 	}
 }

--- a/external/emailmanager/emailmanager.go
+++ b/external/emailmanager/emailmanager.go
@@ -64,6 +64,9 @@ func NewEmailManager(templater emailTemplater, provider emailprovider.EmailProvi
 
 // SendVerificationEmail sends a verification email
 func (m *EmailManager) SendVerificationEmail(ctx context.Context, req *SendVerificationEmailRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/emailmanager", "send-verification-email")
+	logger.Debug("handling-send-verification-email-request")
+
 	// Generate template
 	templateReq := &emailtemplater.GenerateVerificationEmailRequest{
 		FirstName:          req.FirstName,
@@ -95,6 +98,9 @@ func (m *EmailManager) SendVerificationEmail(ctx context.Context, req *SendVerif
 
 // SendLoginEmail sends a login email
 func (m *EmailManager) SendLoginEmail(ctx context.Context, req *SendLoginEmailRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/emailmanager", "send-login-email")
+	logger.Debug("handling-send-login-email-request")
+
 	// Generate template
 	templateReq := &emailtemplater.GenerateLoginEmailRequest{
 		Email:              req.Email,
@@ -124,6 +130,9 @@ func (m *EmailManager) SendLoginEmail(ctx context.Context, req *SendLoginEmailRe
 
 // SendCustomEmail sends a custom email from the base template
 func (m *EmailManager) SendCustomEmail(ctx context.Context, req *SendCustomEmailRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/emailmanager", "send-custom-email")
+	logger.Debug("handling-send-custom-email-request")
+
 	// Generate template
 	templateReq := &emailtemplater.GenerateFromBaseTemplateRequest{
 		EmailSubject:         req.EmailSubject,
@@ -155,6 +164,9 @@ func (m *EmailManager) SendCustomEmail(ctx context.Context, req *SendCustomEmail
 
 // SendEmail sends a pre-rendered email
 func (m *EmailManager) SendEmail(ctx context.Context, req *SendEmailRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/emailmanager", "send-email")
+	logger.Debug("handling-send-email-request")
+
 	// Create email from request
 	email := &emailprovider.Email{
 		To:       req.To,
@@ -188,11 +200,11 @@ func (m *EmailManager) SendEmail(ctx context.Context, req *SendEmailRequest) err
 
 // sendEmail is the internal method that handles sending and audit logging
 func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.RenderedEmail, emailInfo *EmailInfo) error {
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/emailmanager")
 
 	// Check if we should actually send or just log
 	if !m.config.ShouldSendEmail {
-		log.Info("email-outputted-locally-not-sent-disabled-by-config",
+		logger.Info("email-outputted-locally-not-sent-disabled-by-config",
 			zap.String("to", rendered.To),
 			zap.String("from", rendered.From),
 			zap.String("subject", rendered.Subject),
@@ -209,7 +221,7 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 
 	// Check if provider is healthy
 	if !m.provider.IsHealthy(ctx) {
-		log.Error("email-provider-is-not-healthy",
+		logger.Error("email-provider-is-not-healthy",
 			zap.String("provider", m.provider.Name()),
 		)
 		return ErrEmailMailerProviderUnavailable
@@ -227,7 +239,7 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 	// Send via provider
 	result, err := m.provider.Send(ctx, email)
 	if err != nil {
-		log.Error("failed-to-send-email",
+		logger.Error("failed-to-send-email",
 			zap.String("provider", m.provider.Name()),
 			zap.String("to", rendered.To),
 			zap.Error(err),
@@ -235,7 +247,7 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 		return ErrEmailMailerSendFailed
 	}
 
-	log.Info("email-sent-successfully",
+	logger.Info("email-sent-successfully",
 		zap.String("provider", result.Provider),
 		zap.String("message_id", result.MessageID),
 		zap.String("to", rendered.To),
@@ -252,7 +264,7 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 
 // logAuditEvent logs an audit event for the sent email
 func (m *EmailManager) logAuditEvent(ctx context.Context, emailInfo *EmailInfo) {
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/emailmanager")
 
 	err := m.auditService.LogAuditEvent(ctx, &audit.LogAuditEventRequest{
 		ActorId:    audit.AuditActorIdSystem,
@@ -271,7 +283,7 @@ func (m *EmailManager) logAuditEvent(ctx context.Context, emailInfo *EmailInfo) 
 	})
 
 	if err != nil {
-		log.Warn("failed-to-log-audit-event",
+		logger.Warn("failed-to-log-audit-event",
 			zap.String("actor-id", audit.AuditActorIdSystem),
 			zap.String("user-id", emailInfo.UserId),
 			zap.String("event-type", string(audit.UserEmailOutbound)),

--- a/external/emailmanager/emailmanager.go
+++ b/external/emailmanager/emailmanager.go
@@ -195,6 +195,7 @@ func (m *EmailManager) SendEmail(ctx context.Context, req *SendEmailRequest) err
 
 	if !m.config.ShouldSendEmail {
 		messageID := ""
+		outputtedLocally := false
 		if isLocalOutputProvider(m.provider) {
 			result, err := m.provider.Send(ctx, email)
 			if err != nil {
@@ -203,11 +204,10 @@ func (m *EmailManager) SendEmail(ctx context.Context, req *SendEmailRequest) err
 			}
 			messageID = result.MessageID
 			emailInfo.EmailProvider = result.Provider
+			outputtedLocally = true
 		}
 
-		logger.Info("email-outputted-locally-not-sent-disabled-by-config",
-			outboundEmailLogFields(emailInfo.EmailProvider, messageID, req.To, req.From, req.Subject)...,
-		)
+		logDisabledEmail(logger, emailInfo.EmailProvider, messageID, req.To, req.From, req.Subject, outputtedLocally)
 
 		if m.config.EnableAuditLogging && m.auditService != nil {
 			m.logAuditEvent(ctx, emailInfo)
@@ -258,6 +258,7 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 	if !m.config.ShouldSendEmail {
 		messageID := ""
 		providerName := emailInfo.EmailProvider
+		outputtedLocally := false
 		if isLocalOutputProvider(m.provider) {
 			result, err := m.provider.Send(ctx, email)
 			if err != nil {
@@ -266,11 +267,10 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 			}
 			messageID = result.MessageID
 			providerName = result.Provider
+			outputtedLocally = true
 		}
 
-		logger.Info("email-outputted-locally-not-sent-disabled-by-config",
-			outboundEmailLogFields(providerName, messageID, rendered.To, rendered.From, rendered.Subject)...,
-		)
+		logDisabledEmail(logger, providerName, messageID, rendered.To, rendered.From, rendered.Subject, outputtedLocally)
 
 		// Still log audit event even if not sending
 		if m.config.EnableAuditLogging && m.auditService != nil {
@@ -305,6 +305,17 @@ func (m *EmailManager) sendEmail(ctx context.Context, rendered *emailtemplater.R
 	}
 
 	return nil
+}
+
+func logDisabledEmail(logger *zap.Logger, providerName, messageID, to, from, subject string, outputtedLocally bool) {
+	eventName := "email-not-sent-disabled-by-config"
+	if outputtedLocally {
+		eventName = "email-outputted-locally-not-sent-disabled-by-config"
+	}
+
+	logger.Info(eventName,
+		outboundEmailLogFields(providerName, messageID, to, from, subject)...,
+	)
 }
 
 // logAuditEvent logs an audit event for the sent email

--- a/external/emailmanager/examples/examples.go
+++ b/external/emailmanager/examples/examples.go
@@ -374,7 +374,7 @@ func createExampleManager() *emailmanager.EmailManager {
 	tmplr, _ := emailtemplater.NewEmailTemplater(templaterConfig)
 
 	provider := emailprovider.NewLoggingEmailProvider(&emailprovider.LoggingEmailProviderConfig{
-		DisableFullHtmlBodyPreview: true,
+		MaxStoredEmails: 50,
 	})
 
 	auditService := &MockAuditService{}

--- a/external/emailmanager/logging.go
+++ b/external/emailmanager/logging.go
@@ -32,7 +32,7 @@ func outboundEmailLogFields(provider, messageID, to, from, subject string) []zap
 		zap.String("provider", provider),
 	}
 	if messageID != "" {
-		fields = append(fields, zap.String("message_id", messageID))
+		fields = append(fields, zap.String("message-id", messageID))
 	}
 	fields = append(fields, emailLogFields("recipient", to)...)
 	fields = append(fields, emailLogFields("sender", from)...)

--- a/external/emailmanager/logging.go
+++ b/external/emailmanager/logging.go
@@ -7,6 +7,8 @@ import (
 	"go.uber.org/zap"
 )
 
+// emailLogFields returns safe email metadata fields using the supplied prefix.
+// It records address presence and domain without logging the full address.
 func emailLogFields(prefix, value string) []zap.Field {
 	return []zap.Field{
 		zap.Bool(prefix+"-present", logger.EmailPresentForLog(value)),
@@ -14,6 +16,7 @@ func emailLogFields(prefix, value string) []zap.Field {
 	}
 }
 
+// subjectLogFields returns safe subject metadata without logging subject text.
 func subjectLogFields(value string) []zap.Field {
 	trimmed := strings.TrimSpace(value)
 	return []zap.Field{
@@ -22,6 +25,8 @@ func subjectLogFields(value string) []zap.Field {
 	}
 }
 
+// outboundEmailLogFields returns the standard safe field set for outbound email logs.
+// It includes provider, optional message ID, recipient/sender domains, and subject metadata.
 func outboundEmailLogFields(provider, messageID, to, from, subject string) []zap.Field {
 	fields := []zap.Field{
 		zap.String("provider", provider),

--- a/external/emailmanager/logging.go
+++ b/external/emailmanager/logging.go
@@ -1,0 +1,36 @@
+package emailmanager
+
+import (
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
+)
+
+func emailLogFields(prefix, value string) []zap.Field {
+	return []zap.Field{
+		zap.Bool(prefix+"-present", logger.EmailPresentForLog(value)),
+		zap.String(prefix+"-domain", logger.EmailDomainForLog(value)),
+	}
+}
+
+func subjectLogFields(value string) []zap.Field {
+	trimmed := strings.TrimSpace(value)
+	return []zap.Field{
+		zap.Bool("subject-present", trimmed != ""),
+		zap.Int("subject-length", len(trimmed)),
+	}
+}
+
+func outboundEmailLogFields(provider, messageID, to, from, subject string) []zap.Field {
+	fields := []zap.Field{
+		zap.String("provider", provider),
+	}
+	if messageID != "" {
+		fields = append(fields, zap.String("message_id", messageID))
+	}
+	fields = append(fields, emailLogFields("recipient", to)...)
+	fields = append(fields, emailLogFields("sender", from)...)
+	fields = append(fields, subjectLogFields(subject)...)
+	return fields
+}

--- a/external/emailmanager/standard_test.go
+++ b/external/emailmanager/standard_test.go
@@ -72,3 +72,82 @@ func TestNewStandardEmailManager(t *testing.T) {
 		})
 	}
 }
+
+func TestEmailManagerOutputsToLocalProviderWhenSendingDisabled(t *testing.T) {
+	provider := emailprovider.NewLoggingEmailProvider(&emailprovider.LoggingEmailProviderConfig{
+		TimeProvider: func() time.Time {
+			return time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	manager, err := NewStandardEmailManager(&NewStandardEmailManagerRequest{
+		Provider:                      provider,
+		FrontendBaseURL:               "https://app.example.com",
+		EmailVerificationFullEndpoint: "https://api.example.com/v0/auth/verify",
+		DashboardVerificationURIPath:  "https://api.example.com/v0/auth/verify",
+		Environment:                   "local",
+		BusinessEntityName:            "Example",
+		BusinessEntityWebsite:         "https://example.com",
+		WelcomeEmailSubject:           "Welcome",
+		LoginEmailSubject:             "Login",
+		FromEmailAddress:              "hello@example.com",
+		NoReplyEmailAddress:           "noreply@example.com",
+		TimeProvider: func() time.Time {
+			return time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+		},
+		Config: &Config{
+			ShouldSendEmail:    false,
+			EnableAuditLogging: false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewStandardEmailManager() error = %v", err)
+	}
+
+	err = manager.SendLoginEmail(context.Background(), &SendLoginEmailRequest{
+		Email: "user@example.com",
+		Token: "login-token",
+		Code:  "ABC12345",
+	})
+	if err != nil {
+		t.Fatalf("SendLoginEmail() error = %v", err)
+	}
+
+	emails := provider.Inbox().List()
+	if len(emails) != 1 {
+		t.Fatalf("captured emails = %d, want 1", len(emails))
+	}
+	if !strings.Contains(emails[0].HTMLBody, "login-token") || !strings.Contains(emails[0].HTMLBody, "ABC12345") {
+		t.Fatalf("captured email body does not include login token and code")
+	}
+}
+
+func TestEmailManagerSendEmailOutputsToLocalProviderWhenSendingDisabled(t *testing.T) {
+	provider := emailprovider.NewLoggingEmailProvider(&emailprovider.LoggingEmailProviderConfig{
+		TimeProvider: func() time.Time {
+			return time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+		},
+	})
+	manager := NewEmailManager(nil, provider, nil, &Config{
+		ShouldSendEmail:    false,
+		EnableAuditLogging: false,
+	})
+
+	err := manager.SendEmail(context.Background(), &SendEmailRequest{
+		To:       "user@example.com",
+		From:     "hello@example.com",
+		Subject:  "Security code",
+		HTMLBody: `<p>Use code ABC12345</p><a href="https://app.example.com/login?t=login-token">Sign in</a>`,
+	})
+	if err != nil {
+		t.Fatalf("SendEmail() error = %v", err)
+	}
+
+	emails := provider.Inbox().List()
+	if len(emails) != 1 {
+		t.Fatalf("captured emails = %d, want 1", len(emails))
+	}
+	if !strings.Contains(emails[0].HTMLBody, "login-token") || !strings.Contains(emails[0].HTMLBody, "ABC12345") {
+		t.Fatalf("captured email body does not include login token and code")
+	}
+}

--- a/external/emailprovider/examples/examples.go
+++ b/external/emailprovider/examples/examples.go
@@ -61,8 +61,9 @@ func ExampleLoggingProvider() {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("Email logged via %s\n", result.Provider)
+	fmt.Printf("Email captured via %s\n", result.Provider)
 	fmt.Printf("Message ID: %s\n", result.MessageID)
+	fmt.Printf("Captured emails: %d\n", provider.Inbox().Count())
 }
 
 // Example 3: Provider health check

--- a/external/emailprovider/local_inbox.go
+++ b/external/emailprovider/local_inbox.go
@@ -1,0 +1,155 @@
+package emailprovider
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+const defaultLocalEmailStoreLimit = 50
+
+// LocalEmail is a captured email intended for local development previews.
+type LocalEmail struct {
+	MessageID string    `json:"messageId"`
+	To        string    `json:"to"`
+	From      string    `json:"from"`
+	ReplyTo   string    `json:"replyTo,omitempty"`
+	Subject   string    `json:"subject"`
+	HTMLBody  string    `json:"htmlBody"`
+	TextBody  string    `json:"textBody,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// LocalEmailStore keeps a bounded in-memory list of captured local emails.
+type LocalEmailStore struct {
+	mu     sync.RWMutex
+	limit  int
+	emails []LocalEmail
+}
+
+// NewLocalEmailStore creates an in-memory local email store.
+func NewLocalEmailStore(limit int) *LocalEmailStore {
+	if limit <= 0 {
+		limit = defaultLocalEmailStoreLimit
+	}
+
+	return &LocalEmailStore{
+		limit:  limit,
+		emails: make([]LocalEmail, 0, limit),
+	}
+}
+
+// Add stores an email and trims older entries when the store exceeds its limit.
+func (s *LocalEmailStore) Add(email LocalEmail) LocalEmail {
+	if s == nil {
+		return email
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.emails = append(s.emails, email)
+	if len(s.emails) > s.limit {
+		s.emails = append([]LocalEmail(nil), s.emails[len(s.emails)-s.limit:]...)
+	}
+
+	return email
+}
+
+// List returns captured emails newest-first.
+func (s *LocalEmailStore) List() []LocalEmail {
+	if s == nil {
+		return []LocalEmail{}
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type indexedEmail struct {
+		email LocalEmail
+		index int
+	}
+
+	emails := make([]indexedEmail, 0, len(s.emails))
+	for index, email := range s.emails {
+		emails = append(emails, indexedEmail{
+			email: email,
+			index: index,
+		})
+	}
+
+	sort.SliceStable(emails, func(i, j int) bool {
+		if emails[i].email.CreatedAt.Equal(emails[j].email.CreatedAt) {
+			return emails[i].index > emails[j].index
+		}
+		return emails[i].email.CreatedAt.After(emails[j].email.CreatedAt)
+	})
+
+	result := make([]LocalEmail, 0, len(emails))
+	for _, item := range emails {
+		result = append(result, item.email)
+	}
+
+	return result
+}
+
+// Get returns a captured email by message ID.
+func (s *LocalEmailStore) Get(messageID string) (LocalEmail, bool) {
+	if s == nil {
+		return LocalEmail{}, false
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, email := range s.emails {
+		if email.MessageID == messageID {
+			return email, true
+		}
+	}
+
+	return LocalEmail{}, false
+}
+
+// Delete removes a captured email by message ID.
+func (s *LocalEmailStore) Delete(messageID string) bool {
+	if s == nil {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, email := range s.emails {
+		if email.MessageID == messageID {
+			s.emails = append(s.emails[:i], s.emails[i+1:]...)
+			return true
+		}
+	}
+
+	return false
+}
+
+// Clear removes all captured emails.
+func (s *LocalEmailStore) Clear() {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.emails = s.emails[:0]
+}
+
+// Count returns the number of captured emails.
+func (s *LocalEmailStore) Count() int {
+	if s == nil {
+		return 0
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.emails)
+}

--- a/external/emailprovider/local_inbox_routes.go
+++ b/external/emailprovider/local_inbox_routes.go
@@ -24,9 +24,16 @@ var emailLinkPattern = regexp.MustCompile(`(?i)href\s*=\s*(?:"([^"]*)"|'([^']*)'
 
 // AttachLocalInboxRoutesRequest holds local email inbox route configuration.
 type AttachLocalInboxRoutesRequest struct {
-	Router   *router.Router
+	// Router is the GHATD router that will receive the local inbox routes.
+	Router *router.Router
+
+	// Provider is the local logging email provider whose captured emails will be rendered.
 	Provider *LoggingEmailProvider
-	Prefix   string
+
+	// Prefix optionally overrides the local inbox route prefix.
+	// It defaults to DefaultLocalInboxRoutePrefix when left empty.
+	Prefix string
+
 	// AllowRemote permits non-loopback clients to access the inbox.
 	// Keep this false unless another trusted local proxy protects the route.
 	AllowRemote bool
@@ -63,6 +70,7 @@ func AttachLocalInboxRoutes(request *AttachLocalInboxRoutesRequest) error {
 	inboxRouter.HandleFunc("/api/emails", handlers.apiList).Methods(http.MethodGet)
 	inboxRouter.HandleFunc("/{messageID}", handlers.detail).Methods(http.MethodGet)
 	inboxRouter.HandleFunc("/{messageID}/html", handlers.rawHTML).Methods(http.MethodGet)
+	inboxRouter.Use(localInboxNoStoreMiddleware)
 	if !request.AllowRemote {
 		inboxRouter.Use(localInboxLocalOnlyMiddleware)
 	}
@@ -98,6 +106,7 @@ type localInboxEmailSummary struct {
 	Links      []string `json:"links"`
 }
 
+// index renders the local email inbox list page.
 func (h *localInboxHandlers) index(w http.ResponseWriter, r *http.Request) {
 	emails := h.emailSummaries()
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -107,6 +116,7 @@ func (h *localInboxHandlers) index(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// detail renders a captured email detail page with metadata, preview, and links.
 func (h *localInboxHandlers) detail(w http.ResponseWriter, r *http.Request) {
 	email, ok := h.emailByRequest(w, r)
 	if !ok {
@@ -123,6 +133,7 @@ func (h *localInboxHandlers) detail(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// rawHTML renders the captured email HTML body for previewing in a browser.
 func (h *localInboxHandlers) rawHTML(w http.ResponseWriter, r *http.Request) {
 	email, ok := h.emailByRequest(w, r)
 	if !ok {
@@ -139,16 +150,19 @@ func (h *localInboxHandlers) rawHTML(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprintf(w, "<!doctype html><html><body><pre>%s</pre></body></html>", template.HTMLEscapeString(email.TextBody))
 }
 
+// clear removes all captured local emails and redirects back to the inbox list.
 func (h *localInboxHandlers) clear(w http.ResponseWriter, r *http.Request) {
 	h.provider.Inbox().Clear()
 	http.Redirect(w, r, h.prefix, http.StatusSeeOther)
 }
 
+// apiList writes JSON summaries for the captured local emails.
 func (h *localInboxHandlers) apiList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_ = json.NewEncoder(w).Encode(h.emailSummaries())
 }
 
+// emailByRequest resolves the route message ID to a captured local email.
 func (h *localInboxHandlers) emailByRequest(w http.ResponseWriter, r *http.Request) (LocalEmail, bool) {
 	messageID := mux.Vars(r)["messageID"]
 	email, ok := h.provider.Inbox().Get(messageID)
@@ -159,6 +173,7 @@ func (h *localInboxHandlers) emailByRequest(w http.ResponseWriter, r *http.Reque
 	return email, true
 }
 
+// emailSummaries converts captured local emails into list and API summaries.
 func (h *localInboxHandlers) emailSummaries() []localInboxEmailSummary {
 	emails := h.provider.Inbox().List()
 	summaries := make([]localInboxEmailSummary, 0, len(emails))
@@ -176,14 +191,17 @@ func (h *localInboxHandlers) emailSummaries() []localInboxEmailSummary {
 	return summaries
 }
 
+// detailPath returns the inbox detail path for a captured email message ID.
 func (h *localInboxHandlers) detailPath(messageID string) string {
 	return h.prefix + "/" + url.PathEscape(messageID)
 }
 
+// rawHTMLPath returns the raw rendered-email path for a captured email message ID.
 func (h *localInboxHandlers) rawHTMLPath(messageID string) string {
 	return h.detailPath(messageID) + "/html"
 }
 
+// normaliseLocalInboxPrefix normalises a configured route prefix for mux routing.
 func normaliseLocalInboxPrefix(prefix string) string {
 	prefix = strings.TrimSpace(prefix)
 	if prefix == "" {
@@ -199,6 +217,15 @@ func normaliseLocalInboxPrefix(prefix string) string {
 	return prefix
 }
 
+// localInboxNoStoreMiddleware marks local inbox responses as uncacheable.
+func localInboxNoStoreMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		setLocalInboxNoStoreHeaders(w)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// localInboxLocalOnlyMiddleware rejects requests that do not originate from loopback.
 func localInboxLocalOnlyMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !isLocalInboxRequest(r) {
@@ -209,6 +236,14 @@ func localInboxLocalOnlyMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// setLocalInboxNoStoreHeaders prevents stale local inbox pages and summaries.
+func setLocalInboxNoStoreHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+}
+
+// isLocalInboxRequest reports whether a request remote address is localhost or loopback.
 func isLocalInboxRequest(r *http.Request) bool {
 	host := r.RemoteAddr
 	if splitHost, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
@@ -222,6 +257,7 @@ func isLocalInboxRequest(r *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// formatLocalEmailTime formats a captured email timestamp for inbox display.
 func formatLocalEmailTime(value time.Time) string {
 	if value.IsZero() {
 		return ""
@@ -229,6 +265,7 @@ func formatLocalEmailTime(value time.Time) string {
 	return value.Format("2006-01-02 15:04:05 MST")
 }
 
+// extractEmailLinks extracts unique web links from a captured HTML email body.
 func extractEmailLinks(htmlBody string) []string {
 	matches := emailLinkPattern.FindAllStringSubmatch(htmlBody, -1)
 	links := make([]string, 0, len(matches))
@@ -251,6 +288,7 @@ func extractEmailLinks(htmlBody string) []string {
 	return links
 }
 
+// isLocalInboxWebLink reports whether a link is safe to expose as a web action.
 func isLocalInboxWebLink(link string) bool {
 	parsed, err := url.Parse(link)
 	if err != nil {

--- a/external/emailprovider/local_inbox_routes.go
+++ b/external/emailprovider/local_inbox_routes.go
@@ -13,7 +13,10 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/ghatd/external/router"
+	"go.uber.org/zap"
 )
 
 const DefaultLocalInboxRoutePrefix = "/_ghatd/local/emails"
@@ -109,6 +112,13 @@ type localInboxEmailSummary struct {
 // index renders the local email inbox list page.
 func (h *localInboxHandlers) index(w http.ResponseWriter, r *http.Request) {
 	emails := h.emailSummaries()
+	logger := logger.AcquirePackageFrom(r.Context(), "external/emailprovider")
+	logger.Debug("local-email-inbox-index-rendered",
+		zap.String("operation", "local-email-inbox-index"),
+		zap.Int("local-email-count", len(emails)),
+		zap.String("prefix", h.prefix),
+	)
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = localInboxIndexTemplate.Execute(w, localInboxIndexView{
 		Prefix: h.prefix,
@@ -122,6 +132,16 @@ func (h *localInboxHandlers) detail(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	logger := logger.AcquirePackageFrom(r.Context(), "external/emailprovider")
+	links := extractEmailLinks(email.HTMLBody)
+	logger.Debug("local-email-inbox-detail-rendered",
+		zap.String("operation", "local-email-inbox-detail"),
+		zap.String("message-id", email.MessageID),
+		zap.Bool("has-html-body", strings.TrimSpace(email.HTMLBody) != ""),
+		zap.Bool("has-text-body", strings.TrimSpace(email.TextBody) != ""),
+		zap.Int("link-count", len(links)),
+		zap.String("prefix", h.prefix),
+	)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = localInboxDetailTemplate.Execute(w, localInboxDetailView{
@@ -129,7 +149,7 @@ func (h *localInboxHandlers) detail(w http.ResponseWriter, r *http.Request) {
 		Email:       email,
 		CreatedAt:   formatLocalEmailTime(email.CreatedAt),
 		RawHTMLPath: h.rawHTMLPath(email.MessageID),
-		Links:       extractEmailLinks(email.HTMLBody),
+		Links:       links,
 	})
 }
 
@@ -139,6 +159,14 @@ func (h *localInboxHandlers) rawHTML(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	logger := logger.AcquirePackageFrom(r.Context(), "external/emailprovider")
+	logger.Debug("local-email-inbox-raw-html-rendered",
+		zap.String("operation", "local-email-inbox-raw-html"),
+		zap.String("message-id", email.MessageID),
+		zap.Bool("has-html-body", strings.TrimSpace(email.HTMLBody) != ""),
+		zap.Bool("has-text-body", strings.TrimSpace(email.TextBody) != ""),
+		zap.String("prefix", h.prefix),
+	)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Content-Security-Policy", localInboxRawHTMLContentSecurityPolicy)
@@ -152,14 +180,30 @@ func (h *localInboxHandlers) rawHTML(w http.ResponseWriter, r *http.Request) {
 
 // clear removes all captured local emails and redirects back to the inbox list.
 func (h *localInboxHandlers) clear(w http.ResponseWriter, r *http.Request) {
+	previousCount := h.provider.Inbox().Count()
 	h.provider.Inbox().Clear()
+	logger := logger.AcquirePackageFrom(r.Context(), "external/emailprovider")
+	logger.Debug("local-email-inbox-cleared",
+		zap.String("operation", "local-email-inbox-clear"),
+		zap.Int("previous-local-email-count", previousCount),
+		zap.String("prefix", h.prefix),
+	)
+
 	http.Redirect(w, r, h.prefix, http.StatusSeeOther)
 }
 
 // apiList writes JSON summaries for the captured local emails.
 func (h *localInboxHandlers) apiList(w http.ResponseWriter, r *http.Request) {
+	emails := h.emailSummaries()
+	logger := logger.AcquirePackageFrom(r.Context(), "external/emailprovider")
+	logger.Debug("local-email-inbox-api-listed",
+		zap.String("operation", "local-email-inbox-api-list"),
+		zap.Int("local-email-count", len(emails)),
+		zap.String("prefix", h.prefix),
+	)
+
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	_ = json.NewEncoder(w).Encode(h.emailSummaries())
+	_ = json.NewEncoder(w).Encode(emails)
 }
 
 // emailByRequest resolves the route message ID to a captured local email.
@@ -167,6 +211,13 @@ func (h *localInboxHandlers) emailByRequest(w http.ResponseWriter, r *http.Reque
 	messageID := mux.Vars(r)["messageID"]
 	email, ok := h.provider.Inbox().Get(messageID)
 	if !ok {
+		logger := logger.AcquirePackageFrom(r.Context(), "external/emailprovider")
+		logger.Debug("local-email-inbox-email-not-found",
+			zap.String("operation", "local-email-inbox-email-lookup"),
+			zap.String("message-id", messageID),
+			zap.String("prefix", h.prefix),
+		)
+
 		http.NotFound(w, r)
 		return LocalEmail{}, false
 	}
@@ -241,6 +292,7 @@ func setLocalInboxNoStoreHeaders(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "0")
+	w.Header().Set(common.CacheSkipHttpResponseHeader, "true")
 }
 
 // isLocalInboxRequest reports whether a request remote address is localhost or loopback.

--- a/external/emailprovider/local_inbox_routes.go
+++ b/external/emailprovider/local_inbox_routes.go
@@ -1,0 +1,375 @@
+package emailprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	stdhtml "html"
+	"html/template"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/ooaklee/ghatd/external/router"
+)
+
+const DefaultLocalInboxRoutePrefix = "/_ghatd/local/emails"
+
+const localInboxRawHTMLContentSecurityPolicy = "sandbox allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+
+var emailLinkPattern = regexp.MustCompile(`(?i)href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))`)
+
+// AttachLocalInboxRoutesRequest holds local email inbox route configuration.
+type AttachLocalInboxRoutesRequest struct {
+	Router   *router.Router
+	Provider *LoggingEmailProvider
+	Prefix   string
+	// AllowRemote permits non-loopback clients to access the inbox.
+	// Keep this false unless another trusted local proxy protects the route.
+	AllowRemote bool
+}
+
+// AttachLocalInboxRoutes attaches opt-in local email inbox routes.
+// These routes render raw local email bodies and should only be enabled in
+// trusted local development environments.
+func AttachLocalInboxRoutes(request *AttachLocalInboxRoutesRequest) error {
+	if request == nil {
+		return fmt.Errorf("emailprovider/local-inbox-routes-nil-request")
+	}
+	if request.Router == nil {
+		return fmt.Errorf("emailprovider/local-inbox-routes-missing-router")
+	}
+	if request.Provider == nil {
+		return fmt.Errorf("emailprovider/local-inbox-routes-missing-provider")
+	}
+
+	prefix := normaliseLocalInboxPrefix(request.Prefix)
+	httpRouter := request.Router.GetRouter()
+	if httpRouter == nil {
+		return fmt.Errorf("emailprovider/local-inbox-routes-missing-http-router")
+	}
+
+	inboxRouter := httpRouter.PathPrefix(prefix).Subrouter()
+	handlers := &localInboxHandlers{
+		provider: request.Provider,
+		prefix:   prefix,
+	}
+	inboxRouter.HandleFunc("", handlers.index).Methods(http.MethodGet)
+	inboxRouter.HandleFunc("/", handlers.index).Methods(http.MethodGet)
+	inboxRouter.HandleFunc("/clear", handlers.clear).Methods(http.MethodPost)
+	inboxRouter.HandleFunc("/api/emails", handlers.apiList).Methods(http.MethodGet)
+	inboxRouter.HandleFunc("/{messageID}", handlers.detail).Methods(http.MethodGet)
+	inboxRouter.HandleFunc("/{messageID}/html", handlers.rawHTML).Methods(http.MethodGet)
+	if !request.AllowRemote {
+		inboxRouter.Use(localInboxLocalOnlyMiddleware)
+	}
+
+	return nil
+}
+
+type localInboxHandlers struct {
+	provider *LoggingEmailProvider
+	prefix   string
+}
+
+type localInboxIndexView struct {
+	Prefix string
+	Emails []localInboxEmailSummary
+}
+
+type localInboxDetailView struct {
+	Prefix      string
+	Email       LocalEmail
+	CreatedAt   string
+	RawHTMLPath string
+	Links       []string
+}
+
+type localInboxEmailSummary struct {
+	MessageID  string   `json:"messageId"`
+	To         string   `json:"to"`
+	From       string   `json:"from"`
+	Subject    string   `json:"subject"`
+	CreatedAt  string   `json:"createdAt"`
+	DetailPath string   `json:"detailPath"`
+	Links      []string `json:"links"`
+}
+
+func (h *localInboxHandlers) index(w http.ResponseWriter, r *http.Request) {
+	emails := h.emailSummaries()
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = localInboxIndexTemplate.Execute(w, localInboxIndexView{
+		Prefix: h.prefix,
+		Emails: emails,
+	})
+}
+
+func (h *localInboxHandlers) detail(w http.ResponseWriter, r *http.Request) {
+	email, ok := h.emailByRequest(w, r)
+	if !ok {
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = localInboxDetailTemplate.Execute(w, localInboxDetailView{
+		Prefix:      h.prefix,
+		Email:       email,
+		CreatedAt:   formatLocalEmailTime(email.CreatedAt),
+		RawHTMLPath: h.rawHTMLPath(email.MessageID),
+		Links:       extractEmailLinks(email.HTMLBody),
+	})
+}
+
+func (h *localInboxHandlers) rawHTML(w http.ResponseWriter, r *http.Request) {
+	email, ok := h.emailByRequest(w, r)
+	if !ok {
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Content-Security-Policy", localInboxRawHTMLContentSecurityPolicy)
+	if strings.TrimSpace(email.HTMLBody) != "" {
+		_, _ = w.Write([]byte(email.HTMLBody))
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "<!doctype html><html><body><pre>%s</pre></body></html>", template.HTMLEscapeString(email.TextBody))
+}
+
+func (h *localInboxHandlers) clear(w http.ResponseWriter, r *http.Request) {
+	h.provider.Inbox().Clear()
+	http.Redirect(w, r, h.prefix, http.StatusSeeOther)
+}
+
+func (h *localInboxHandlers) apiList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode(h.emailSummaries())
+}
+
+func (h *localInboxHandlers) emailByRequest(w http.ResponseWriter, r *http.Request) (LocalEmail, bool) {
+	messageID := mux.Vars(r)["messageID"]
+	email, ok := h.provider.Inbox().Get(messageID)
+	if !ok {
+		http.NotFound(w, r)
+		return LocalEmail{}, false
+	}
+	return email, true
+}
+
+func (h *localInboxHandlers) emailSummaries() []localInboxEmailSummary {
+	emails := h.provider.Inbox().List()
+	summaries := make([]localInboxEmailSummary, 0, len(emails))
+	for _, email := range emails {
+		summaries = append(summaries, localInboxEmailSummary{
+			MessageID:  email.MessageID,
+			To:         email.To,
+			From:       email.From,
+			Subject:    email.Subject,
+			CreatedAt:  formatLocalEmailTime(email.CreatedAt),
+			DetailPath: h.detailPath(email.MessageID),
+			Links:      extractEmailLinks(email.HTMLBody),
+		})
+	}
+	return summaries
+}
+
+func (h *localInboxHandlers) detailPath(messageID string) string {
+	return h.prefix + "/" + url.PathEscape(messageID)
+}
+
+func (h *localInboxHandlers) rawHTMLPath(messageID string) string {
+	return h.detailPath(messageID) + "/html"
+}
+
+func normaliseLocalInboxPrefix(prefix string) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		prefix = DefaultLocalInboxRoutePrefix
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	prefix = strings.TrimRight(prefix, "/")
+	if prefix == "" {
+		return "/"
+	}
+	return prefix
+}
+
+func localInboxLocalOnlyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isLocalInboxRequest(r) {
+			http.Error(w, "local email inbox is only available from localhost", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isLocalInboxRequest(r *http.Request) bool {
+	host := r.RemoteAddr
+	if splitHost, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		host = splitHost
+	}
+	host = strings.TrimSpace(host)
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func formatLocalEmailTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.Format("2006-01-02 15:04:05 MST")
+}
+
+func extractEmailLinks(htmlBody string) []string {
+	matches := emailLinkPattern.FindAllStringSubmatch(htmlBody, -1)
+	links := make([]string, 0, len(matches))
+	seen := map[string]bool{}
+	for _, match := range matches {
+		link := ""
+		for i := 1; i < len(match); i++ {
+			if match[i] != "" {
+				link = match[i]
+				break
+			}
+		}
+		link = strings.TrimSpace(stdhtml.UnescapeString(link))
+		if link == "" || !isLocalInboxWebLink(link) || seen[link] {
+			continue
+		}
+		seen[link] = true
+		links = append(links, link)
+	}
+	return links
+}
+
+func isLocalInboxWebLink(link string) bool {
+	parsed, err := url.Parse(link)
+	if err != nil {
+		return false
+	}
+	if parsed.Scheme == "" {
+		return strings.HasPrefix(link, "/") && !strings.HasPrefix(link, "//")
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+		return true
+	default:
+		return false
+	}
+}
+
+var localInboxIndexTemplate = template.Must(template.New("local-email-inbox-index").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GHATD Local Email Inbox</title>
+  <style>
+    :root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f7f7f4; color: #1d2528; }
+    main { max-width: 1040px; margin: 0 auto; padding: 28px 20px 48px; }
+    header { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 20px; }
+    h1 { font-size: 24px; line-height: 1.2; margin: 0; font-weight: 720; }
+    p { margin: 4px 0 0; color: #5d666b; }
+    form { margin: 0; }
+    button, .button { border: 1px solid #cfd7d8; background: #fff; color: #1d2528; border-radius: 6px; padding: 8px 11px; text-decoration: none; font: inherit; cursor: pointer; }
+    button:hover, .button:hover { border-color: #94a3a6; }
+    table { width: 100%; border-collapse: collapse; background: #fff; border: 1px solid #d9e0e1; }
+    th, td { border-bottom: 1px solid #e5eaeb; padding: 12px; text-align: left; vertical-align: top; font-size: 14px; }
+    th { background: #eef3f3; font-size: 12px; text-transform: uppercase; color: #546064; letter-spacing: .06em; }
+    tr:last-child td { border-bottom: 0; }
+    .muted { color: #687477; }
+    .subject { font-weight: 650; }
+    .links { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+    .links a { font-size: 12px; }
+    .empty { background: #fff; border: 1px solid #d9e0e1; padding: 28px; border-radius: 6px; }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>GHATD Local Email Inbox</h1>
+        <p>Captured local emails are kept in memory and reset when the process restarts.</p>
+      </div>
+      <form method="post" action="{{.Prefix}}/clear"><button type="submit">Clear</button></form>
+    </header>
+    {{if .Emails}}
+    <table>
+      <thead><tr><th>Sent</th><th>Subject</th><th>Recipient</th><th>Actions</th></tr></thead>
+      <tbody>
+      {{range .Emails}}
+        <tr>
+          <td class="muted">{{.CreatedAt}}</td>
+          <td><div class="subject">{{.Subject}}</div><div class="muted">{{.From}}</div></td>
+          <td>{{.To}}</td>
+          <td>
+            <a class="button" href="{{.DetailPath}}">Open</a>
+            {{if .Links}}<div class="links">{{range .Links}}<a class="button" href="{{.}}" target="_blank" rel="noreferrer">Link</a>{{end}}</div>{{end}}
+          </td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+    {{else}}
+    <div class="empty">No local emails captured yet.</div>
+    {{end}}
+  </main>
+</body>
+</html>`))
+
+var localInboxDetailTemplate = template.Must(template.New("local-email-inbox-detail").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{.Email.Subject}} - GHATD Local Email Inbox</title>
+  <style>
+    :root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f7f7f4; color: #1d2528; }
+    main { max-width: 1180px; margin: 0 auto; padding: 24px 20px 48px; }
+    nav { margin-bottom: 18px; }
+    a { color: #0f6664; }
+    h1 { font-size: 22px; line-height: 1.25; margin: 0 0 12px; }
+    dl { display: grid; grid-template-columns: 110px 1fr; gap: 8px 14px; background: #fff; border: 1px solid #d9e0e1; padding: 14px; margin: 0 0 16px; }
+    dt { color: #607074; font-weight: 650; }
+    dd { margin: 0; overflow-wrap: anywhere; }
+    .actions { display: flex; gap: 8px; flex-wrap: wrap; margin: 14px 0 18px; }
+    .button { border: 1px solid #cfd7d8; background: #fff; color: #1d2528; border-radius: 6px; padding: 8px 11px; text-decoration: none; font: inherit; }
+    .button:hover { border-color: #94a3a6; }
+    iframe { width: 100%; min-height: 620px; border: 1px solid #cfd7d8; background: #fff; }
+    textarea, pre { width: 100%; box-sizing: border-box; min-height: 180px; border: 1px solid #cfd7d8; background: #fff; color: #1d2528; padding: 12px; overflow: auto; }
+    .links { display: flex; flex-wrap: wrap; gap: 8px; }
+  </style>
+</head>
+<body>
+  <main>
+    <nav><a href="{{.Prefix}}">Back to inbox</a></nav>
+    <h1>{{.Email.Subject}}</h1>
+    <dl>
+      <dt>To</dt><dd>{{.Email.To}}</dd>
+      <dt>From</dt><dd>{{.Email.From}}</dd>
+      <dt>Reply To</dt><dd>{{.Email.ReplyTo}}</dd>
+      <dt>Sent</dt><dd>{{.CreatedAt}}</dd>
+      <dt>Message ID</dt><dd>{{.Email.MessageID}}</dd>
+    </dl>
+    <div class="actions">
+      <a class="button" href="{{.RawHTMLPath}}" target="_blank" rel="noreferrer">Open rendered email</a>
+      {{range .Links}}<a class="button" href="{{.}}" target="_blank" rel="noreferrer">Open link</a>{{end}}
+    </div>
+    <iframe title="Rendered email" src="{{.RawHTMLPath}}" sandbox=""></iframe>
+    <h2>HTML</h2>
+    <textarea readonly>{{.Email.HTMLBody}}</textarea>
+    {{if .Email.TextBody}}<h2>Text</h2><pre>{{.Email.TextBody}}</pre>{{end}}
+  </main>
+</body>
+</html>`))

--- a/external/emailprovider/local_inbox_routes_test.go
+++ b/external/emailprovider/local_inbox_routes_test.go
@@ -1,0 +1,131 @@
+package emailprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ooaklee/ghatd/external/router"
+)
+
+func TestAttachLocalInboxRoutes(t *testing.T) {
+	provider := NewLoggingEmailProvider(&LoggingEmailProviderConfig{
+		TimeProvider: func() time.Time {
+			return time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+		},
+	})
+	result, err := provider.Send(context.Background(), &Email{
+		To:       "dev@example.com",
+		From:     "noreply@example.com",
+		Subject:  "Login",
+		HTMLBody: `<html><body><a href="https://app.example.com/login?t=token">Sign in</a></body></html>`,
+	})
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	httpRouter := router.NewRouter(nil, nil)
+	if err := AttachLocalInboxRoutes(&AttachLocalInboxRoutesRequest{
+		Router:      httpRouter,
+		Provider:    provider,
+		Prefix:      "/dev/emails",
+		AllowRemote: true,
+	}); err != nil {
+		t.Fatalf("AttachLocalInboxRoutes() error = %v", err)
+	}
+
+	index := httptest.NewRecorder()
+	httpRouter.GetRouter().ServeHTTP(index, httptest.NewRequest(http.MethodGet, "/dev/emails", nil))
+	if index.Code != http.StatusOK {
+		t.Fatalf("index status = %d, want %d", index.Code, http.StatusOK)
+	}
+	if body := index.Body.String(); !strings.Contains(body, "GHATD Local Email Inbox") || !strings.Contains(body, result.MessageID) {
+		t.Fatalf("index body did not include inbox title and message ID: %s", body)
+	}
+
+	detail := httptest.NewRecorder()
+	httpRouter.GetRouter().ServeHTTP(detail, httptest.NewRequest(http.MethodGet, "/dev/emails/"+result.MessageID, nil))
+	if detail.Code != http.StatusOK {
+		t.Fatalf("detail status = %d, want %d", detail.Code, http.StatusOK)
+	}
+	if body := detail.Body.String(); !strings.Contains(body, "Open rendered email") || !strings.Contains(body, `sandbox=""`) || !strings.Contains(body, "https://app.example.com/login?t=token") {
+		t.Fatalf("detail body did not include rendered action and link: %s", body)
+	}
+
+	raw := httptest.NewRecorder()
+	httpRouter.GetRouter().ServeHTTP(raw, httptest.NewRequest(http.MethodGet, "/dev/emails/"+result.MessageID+"/html", nil))
+	if raw.Code != http.StatusOK {
+		t.Fatalf("raw status = %d, want %d", raw.Code, http.StatusOK)
+	}
+	if got := raw.Header().Get("Content-Security-Policy"); !strings.Contains(got, "sandbox") || strings.Contains(got, "allow-scripts") {
+		t.Fatalf("raw Content-Security-Policy = %q, want sandbox without script allowance", got)
+	}
+	if body := raw.Body.String(); !strings.Contains(body, `<a href="https://app.example.com/login?t=token">`) {
+		t.Fatalf("raw body did not include original HTML: %s", body)
+	}
+
+	api := httptest.NewRecorder()
+	httpRouter.GetRouter().ServeHTTP(api, httptest.NewRequest(http.MethodGet, "/dev/emails/api/emails", nil))
+	if api.Code != http.StatusOK {
+		t.Fatalf("api status = %d, want %d", api.Code, http.StatusOK)
+	}
+	var summaries []localInboxEmailSummary
+	if err := json.Unmarshal(api.Body.Bytes(), &summaries); err != nil {
+		t.Fatalf("api JSON error = %v", err)
+	}
+	if len(summaries) != 1 || summaries[0].MessageID != result.MessageID {
+		t.Fatalf("api summaries = %+v, want captured message", summaries)
+	}
+}
+
+func TestExtractEmailLinksOnlyIncludesWebLinks(t *testing.T) {
+	got := extractEmailLinks(`
+		<a href="https://app.example.com/login?t=token&amp;next=/dashboard">Sign in</a>
+		<a href='http://localhost:3000/auth?code=123'>Code</a>
+		<a href="/local/auth?token=abc">Relative</a>
+		<a href="javascript:alert(1)">Script</a>
+		<a href="mailto:support@example.com">Mail</a>
+		<a href="//example.com/protocol-relative">Protocol relative</a>
+		<a href="https://app.example.com/login?t=token&amp;next=/dashboard">Duplicate</a>
+	`)
+	want := []string{
+		"https://app.example.com/login?t=token&next=/dashboard",
+		"http://localhost:3000/auth?code=123",
+		"/local/auth?token=abc",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("extractEmailLinks() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAttachLocalInboxRoutesRejectsRemoteByDefault(t *testing.T) {
+	provider := NewLoggingEmailProvider(nil)
+	httpRouter := router.NewRouter(nil, nil)
+	if err := AttachLocalInboxRoutes(&AttachLocalInboxRoutesRequest{
+		Router:   httpRouter,
+		Provider: provider,
+	}); err != nil {
+		t.Fatalf("AttachLocalInboxRoutes() error = %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, DefaultLocalInboxRoutePrefix, nil)
+	request.RemoteAddr = "203.0.113.10:52222"
+	response := httptest.NewRecorder()
+	httpRouter.GetRouter().ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("remote status = %d, want %d", response.Code, http.StatusForbidden)
+	}
+
+	request = httptest.NewRequest(http.MethodGet, DefaultLocalInboxRoutePrefix, nil)
+	request.RemoteAddr = "127.0.0.1:52222"
+	response = httptest.NewRecorder()
+	httpRouter.GetRouter().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("localhost status = %d, want %d", response.Code, http.StatusOK)
+	}
+}

--- a/external/emailprovider/local_inbox_routes_test.go
+++ b/external/emailprovider/local_inbox_routes_test.go
@@ -44,6 +44,9 @@ func TestAttachLocalInboxRoutes(t *testing.T) {
 	if index.Code != http.StatusOK {
 		t.Fatalf("index status = %d, want %d", index.Code, http.StatusOK)
 	}
+	if got := index.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
+		t.Fatalf("index Cache-Control = %q, want no-store", got)
+	}
 	if body := index.Body.String(); !strings.Contains(body, "GHATD Local Email Inbox") || !strings.Contains(body, result.MessageID) {
 		t.Fatalf("index body did not include inbox title and message ID: %s", body)
 	}
@@ -62,6 +65,9 @@ func TestAttachLocalInboxRoutes(t *testing.T) {
 	if raw.Code != http.StatusOK {
 		t.Fatalf("raw status = %d, want %d", raw.Code, http.StatusOK)
 	}
+	if got := raw.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
+		t.Fatalf("raw Cache-Control = %q, want no-store", got)
+	}
 	if got := raw.Header().Get("Content-Security-Policy"); !strings.Contains(got, "sandbox") || strings.Contains(got, "allow-scripts") {
 		t.Fatalf("raw Content-Security-Policy = %q, want sandbox without script allowance", got)
 	}
@@ -73,6 +79,9 @@ func TestAttachLocalInboxRoutes(t *testing.T) {
 	httpRouter.GetRouter().ServeHTTP(api, httptest.NewRequest(http.MethodGet, "/dev/emails/api/emails", nil))
 	if api.Code != http.StatusOK {
 		t.Fatalf("api status = %d, want %d", api.Code, http.StatusOK)
+	}
+	if got := api.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
+		t.Fatalf("api Cache-Control = %q, want no-store", got)
 	}
 	var summaries []localInboxEmailSummary
 	if err := json.Unmarshal(api.Body.Bytes(), &summaries); err != nil {

--- a/external/emailprovider/local_inbox_routes_test.go
+++ b/external/emailprovider/local_inbox_routes_test.go
@@ -47,6 +47,9 @@ func TestAttachLocalInboxRoutes(t *testing.T) {
 	if got := index.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
 		t.Fatalf("index Cache-Control = %q, want no-store", got)
 	}
+	if got := index.Header().Get("X-Cache-Skip"); got != "true" {
+		t.Fatalf("index X-Cache-Skip = %q, want true", got)
+	}
 	if body := index.Body.String(); !strings.Contains(body, "GHATD Local Email Inbox") || !strings.Contains(body, result.MessageID) {
 		t.Fatalf("index body did not include inbox title and message ID: %s", body)
 	}
@@ -68,6 +71,9 @@ func TestAttachLocalInboxRoutes(t *testing.T) {
 	if got := raw.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
 		t.Fatalf("raw Cache-Control = %q, want no-store", got)
 	}
+	if got := raw.Header().Get("X-Cache-Skip"); got != "true" {
+		t.Fatalf("raw X-Cache-Skip = %q, want true", got)
+	}
 	if got := raw.Header().Get("Content-Security-Policy"); !strings.Contains(got, "sandbox") || strings.Contains(got, "allow-scripts") {
 		t.Fatalf("raw Content-Security-Policy = %q, want sandbox without script allowance", got)
 	}
@@ -82,6 +88,9 @@ func TestAttachLocalInboxRoutes(t *testing.T) {
 	}
 	if got := api.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
 		t.Fatalf("api Cache-Control = %q, want no-store", got)
+	}
+	if got := api.Header().Get("X-Cache-Skip"); got != "true" {
+		t.Fatalf("api X-Cache-Skip = %q, want true", got)
 	}
 	var summaries []localInboxEmailSummary
 	if err := json.Unmarshal(api.Body.Bytes(), &summaries); err != nil {

--- a/external/emailprovider/logging.go
+++ b/external/emailprovider/logging.go
@@ -41,7 +41,7 @@ func (p *LoggingEmailProvider) Send(ctx context.Context, email *Email) (*SendRes
 	}
 
 	// Get logger from context
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/emailprovider")
 
 	// Log the email details
 	var logFields []zap.Field = []zap.Field{
@@ -51,13 +51,13 @@ func (p *LoggingEmailProvider) Send(ctx context.Context, email *Email) (*SendRes
 		zap.String("subject", email.Subject),
 	}
 
-	if p.config != nil && p.config.DisableFullHtmlBodyPreview {
+	if p.config == nil || p.config.DisableFullHtmlBodyPreview {
 		logFields = append(logFields, zap.String("html_body_preview", truncateString(email.HTMLBody, 200)))
 	} else {
 		logFields = append(logFields, zap.String("html_body_preview", email.HTMLBody))
 	}
 
-	log.Info("email-outputted-locally--not-sent",
+	logger.Info("email-outputted-locally--not-sent",
 		logFields...,
 	)
 

--- a/external/emailprovider/logging.go
+++ b/external/emailprovider/logging.go
@@ -3,8 +3,11 @@ package emailprovider
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // LoggingEmailProviderConfig holds configuration for the logging email provider
@@ -12,24 +15,50 @@ type LoggingEmailProviderConfig struct {
 	// DisableFullHtmlBodyPreview is retained for compatibility.
 	// Email bodies are never written to logs.
 	DisableFullHtmlBodyPreview bool
+
+	// Store optionally supplies the local inbox store used to capture emails.
+	Store *LocalEmailStore
+
+	// MaxStoredEmails caps the default in-memory local inbox size.
+	MaxStoredEmails int
+
+	// TimeProvider optionally supplies message timestamps for tests.
+	TimeProvider func() time.Time
 }
 
-// LoggingEmailProvider is an email provider that logs emails instead of sending them
-// This is useful for development and testing environments
+// LoggingEmailProvider is an email provider that captures emails locally instead
+// of sending them. This is useful for development and testing environments.
 type LoggingEmailProvider struct {
-	name   string
-	config *LoggingEmailProviderConfig
+	name         string
+	store        *LocalEmailStore
+	timeProvider func() time.Time
+	counter      atomic.Uint64
 }
 
-// NewLoggingEmailProvider creates a new logging email provider
+// NewLoggingEmailProvider creates a new local email capture provider.
 func NewLoggingEmailProvider(config *LoggingEmailProviderConfig) *LoggingEmailProvider {
+	if config == nil {
+		config = &LoggingEmailProviderConfig{}
+	}
+
+	store := config.Store
+	if store == nil {
+		store = NewLocalEmailStore(config.MaxStoredEmails)
+	}
+
+	timeProvider := config.TimeProvider
+	if timeProvider == nil {
+		timeProvider = time.Now
+	}
+
 	return &LoggingEmailProvider{
-		name:   "LOCAL",
-		config: config,
+		name:         "LOCAL",
+		store:        store,
+		timeProvider: timeProvider,
 	}
 }
 
-// Send handles logging the email instead of sending it
+// Send captures an email locally instead of sending it to a remote provider.
 func (p *LoggingEmailProvider) Send(ctx context.Context, email *Email) (*SendResult, error) {
 	// Validate email
 	if err := validateEmail(email); err != nil {
@@ -43,14 +72,26 @@ func (p *LoggingEmailProvider) Send(ctx context.Context, email *Email) (*SendRes
 	// Get logger from context
 	logger := logger.AcquirePackageFrom(ctx, "external/emailprovider")
 
-	logFields := emailLogFields(p.Name(), email)
+	messageID := p.nextMessageID()
+	p.store.Add(LocalEmail{
+		MessageID: messageID,
+		To:        email.To,
+		From:      email.From,
+		ReplyTo:   email.ReplyTo,
+		Subject:   email.Subject,
+		HTMLBody:  email.HTMLBody,
+		TextBody:  email.TextBody,
+		CreatedAt: p.now(),
+	})
+
+	logFields := append(emailLogFields(p.Name(), email),
+		zap.String("message-id", messageID),
+		zap.Int("local-email-count", p.store.Count()),
+	)
 
 	logger.Info("email-outputted-locally--not-sent",
 		logFields...,
 	)
-
-	// Generate a fake message ID for consistency
-	messageID := fmt.Sprintf("local-%d", generateRandomID())
 
 	return &SendResult{
 		MessageID: messageID,
@@ -71,8 +112,24 @@ func (p *LoggingEmailProvider) IsHealthy(ctx context.Context) bool {
 	return true
 }
 
-// generateRandomID generates a simple random ID for local message IDs
-func generateRandomID() int64 {
-	// Simple implementation - in production you might want something more sophisticated
-	return int64(len("local")) * 1000
+// Inbox returns the provider's captured local email store.
+func (p *LoggingEmailProvider) Inbox() *LocalEmailStore {
+	return p.store
+}
+
+// IsLocalOutputProvider identifies this provider as safe to call when an
+// EmailManager is configured not to send real email.
+func (p *LoggingEmailProvider) IsLocalOutputProvider() bool {
+	return true
+}
+
+func (p *LoggingEmailProvider) now() time.Time {
+	if p.timeProvider == nil {
+		return time.Now().UTC()
+	}
+	return p.timeProvider().UTC()
+}
+
+func (p *LoggingEmailProvider) nextMessageID() string {
+	return fmt.Sprintf("local-%d-%06d", p.now().UnixNano(), p.counter.Add(1))
 }

--- a/external/emailprovider/logging.go
+++ b/external/emailprovider/logging.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/ooaklee/ghatd/external/logger"
-	"go.uber.org/zap"
 )
 
 // LoggingEmailProviderConfig holds configuration for the logging email provider
 type LoggingEmailProviderConfig struct {
-	// DisableFullHtmlBodyPreview determines if the HTML body preview should be truncated
+	// DisableFullHtmlBodyPreview is retained for compatibility.
+	// Email bodies are never written to logs.
 	DisableFullHtmlBodyPreview bool
 }
 
@@ -43,19 +43,7 @@ func (p *LoggingEmailProvider) Send(ctx context.Context, email *Email) (*SendRes
 	// Get logger from context
 	logger := logger.AcquirePackageFrom(ctx, "external/emailprovider")
 
-	// Log the email details
-	var logFields []zap.Field = []zap.Field{
-		zap.String("provider", p.Name()),
-		zap.String("to", email.To),
-		zap.String("from", email.From),
-		zap.String("subject", email.Subject),
-	}
-
-	if p.config == nil || p.config.DisableFullHtmlBodyPreview {
-		logFields = append(logFields, zap.String("html_body_preview", truncateString(email.HTMLBody, 200)))
-	} else {
-		logFields = append(logFields, zap.String("html_body_preview", email.HTMLBody))
-	}
+	logFields := emailLogFields(p.Name(), email)
 
 	logger.Info("email-outputted-locally--not-sent",
 		logFields...,
@@ -81,14 +69,6 @@ func (p *LoggingEmailProvider) Name() string {
 // The Logging email provider is always healthy
 func (p *LoggingEmailProvider) IsHealthy(ctx context.Context) bool {
 	return true
-}
-
-// truncateString truncates a string to the specified length
-func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
 }
 
 // generateRandomID generates a simple random ID for local message IDs

--- a/external/emailprovider/logging_helpers.go
+++ b/external/emailprovider/logging_helpers.go
@@ -1,0 +1,27 @@
+package emailprovider
+
+import (
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
+)
+
+func emailLogFields(provider string, email *Email) []zap.Field {
+	fields := []zap.Field{
+		zap.String("provider", provider),
+	}
+	if email == nil {
+		return append(fields, zap.Bool("email-present", false))
+	}
+
+	return append(fields,
+		zap.Bool("email-present", true),
+		zap.String("recipient-domain", logger.EmailDomainForLog(email.To)),
+		zap.String("sender-domain", logger.EmailDomainForLog(email.From)),
+		zap.Bool("has-reply-to", strings.TrimSpace(email.ReplyTo) != ""),
+		zap.Bool("has-html-body", strings.TrimSpace(email.HTMLBody) != ""),
+		zap.Bool("has-text-body", strings.TrimSpace(email.TextBody) != ""),
+		zap.Int("subject-length", len(strings.TrimSpace(email.Subject))),
+	)
+}

--- a/external/emailprovider/logging_test.go
+++ b/external/emailprovider/logging_test.go
@@ -1,0 +1,65 @@
+package emailprovider
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoggingEmailProviderCapturesLocalEmail(t *testing.T) {
+	provider := NewLoggingEmailProvider(&LoggingEmailProviderConfig{
+		TimeProvider: func() time.Time {
+			return time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+		},
+	})
+
+	result, err := provider.Send(context.Background(), &Email{
+		To:       "dev@example.com",
+		From:     "noreply@example.com",
+		ReplyTo:  "support@example.com",
+		Subject:  "Login",
+		HTMLBody: `<a href="https://app.example.com/login?t=token">Sign in</a>`,
+		TextBody: "Use code ABC12345",
+	})
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if result.MessageID == "" || !strings.HasPrefix(result.MessageID, "local-") {
+		t.Fatalf("MessageID = %q, want local ID", result.MessageID)
+	}
+
+	emails := provider.Inbox().List()
+	if len(emails) != 1 {
+		t.Fatalf("captured emails = %d, want 1", len(emails))
+	}
+	if emails[0].MessageID != result.MessageID {
+		t.Fatalf("captured MessageID = %q, want %q", emails[0].MessageID, result.MessageID)
+	}
+	if emails[0].HTMLBody == "" || !strings.Contains(emails[0].HTMLBody, "login?t=token") {
+		t.Fatalf("captured HTMLBody = %q, want login link", emails[0].HTMLBody)
+	}
+	if emails[0].TextBody != "Use code ABC12345" {
+		t.Fatalf("captured TextBody = %q", emails[0].TextBody)
+	}
+}
+
+func TestLocalEmailStoreKeepsNewestWithinLimit(t *testing.T) {
+	store := NewLocalEmailStore(2)
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	store.Add(LocalEmail{MessageID: "one", CreatedAt: base})
+	store.Add(LocalEmail{MessageID: "two", CreatedAt: base})
+	store.Add(LocalEmail{MessageID: "three", CreatedAt: base})
+
+	emails := store.List()
+	if len(emails) != 2 {
+		t.Fatalf("List() length = %d, want 2", len(emails))
+	}
+	if emails[0].MessageID != "three" || emails[1].MessageID != "two" {
+		t.Fatalf("List() order = %v, want newest retained first", []string{emails[0].MessageID, emails[1].MessageID})
+	}
+	if _, ok := store.Get("one"); ok {
+		t.Fatal("oldest email should be trimmed")
+	}
+}

--- a/external/emailprovider/sparkpost.go
+++ b/external/emailprovider/sparkpost.go
@@ -2,7 +2,6 @@ package emailprovider
 
 import (
 	"context"
-	"strings"
 
 	sp "github.com/SparkPost/gosparkpost"
 	"github.com/ooaklee/ghatd/external/logger"
@@ -31,11 +30,11 @@ func NewSparkPostEmailProvider(client SparkPostClient) *SparkPostEmailProvider {
 // Send handles sending an email via SparkPost
 func (p *SparkPostEmailProvider) Send(ctx context.Context, email *Email) (*SendResult, error) {
 	logger := logger.AcquireOperationFrom(ctx, "external/emailprovider", "sparkpost-send")
-	logger.Info("sparkpost-email-send-started", sparkPostEmailLogFields(p.Name(), email)...)
+	logger.Info("sparkpost-email-send-started", emailLogFields(p.Name(), email)...)
 
 	// Validate email
 	if err := validateEmail(email); err != nil {
-		logger.Warn("sparkpost-email-validation-failed", append(sparkPostEmailLogFields(p.Name(), email), zap.Error(err))...)
+		logger.Warn("sparkpost-email-validation-failed", append(emailLogFields(p.Name(), email), zap.Error(err))...)
 		return &SendResult{
 			Provider: p.Name(),
 			Success:  false,
@@ -57,7 +56,7 @@ func (p *SparkPostEmailProvider) Send(ctx context.Context, email *Email) (*SendR
 	// Send via SparkPost
 	messageID, _, err := p.client.Send(transmission)
 	if err != nil {
-		logger.Error("sparkpost-email-send-failed", append(sparkPostEmailLogFields(p.Name(), email), zap.Error(err))...)
+		logger.Error("sparkpost-email-send-failed", append(emailLogFields(p.Name(), email), zap.Error(err))...)
 		return &SendResult{
 			Provider: p.Name(),
 			Success:  false,
@@ -65,7 +64,7 @@ func (p *SparkPostEmailProvider) Send(ctx context.Context, email *Email) (*SendR
 		}, ErrEmailProviderSendFailed
 	}
 
-	logger.Info("sparkpost-email-sent", append(sparkPostEmailLogFields(p.Name(), email), zap.String("message-id", messageID))...)
+	logger.Info("sparkpost-email-sent", append(emailLogFields(p.Name(), email), zap.String("message-id", messageID))...)
 	return &SendResult{
 		MessageID: messageID,
 		Provider:  p.Name(),
@@ -103,30 +102,4 @@ func validateEmail(email *Email) error {
 		return ErrEmailProviderMissingBody
 	}
 	return nil
-}
-
-func sparkPostEmailLogFields(provider string, email *Email) []zap.Field {
-	fields := []zap.Field{
-		zap.String("provider", provider),
-	}
-	if email == nil {
-		return append(fields, zap.Bool("email-present", false))
-	}
-
-	return append(fields,
-		zap.Bool("email-present", true),
-		zap.String("recipient-domain", emailDomainForLog(email.To)),
-		zap.String("sender-domain", emailDomainForLog(email.From)),
-		zap.Bool("has-reply-to", strings.TrimSpace(email.ReplyTo) != ""),
-		zap.Bool("has-html-body", strings.TrimSpace(email.HTMLBody) != ""),
-		zap.Bool("has-text-body", strings.TrimSpace(email.TextBody) != ""),
-	)
-}
-
-func emailDomainForLog(value string) string {
-	parts := strings.Split(strings.TrimSpace(value), "@")
-	if len(parts) != 2 {
-		return ""
-	}
-	return strings.ToLower(parts[1])
 }

--- a/external/emailprovider/sparkpost.go
+++ b/external/emailprovider/sparkpost.go
@@ -2,8 +2,11 @@ package emailprovider
 
 import (
 	"context"
+	"strings"
 
 	sp "github.com/SparkPost/gosparkpost"
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // SparkPostClient is the interface for SparkPost email client
@@ -27,8 +30,12 @@ func NewSparkPostEmailProvider(client SparkPostClient) *SparkPostEmailProvider {
 
 // Send handles sending an email via SparkPost
 func (p *SparkPostEmailProvider) Send(ctx context.Context, email *Email) (*SendResult, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/emailprovider", "sparkpost-send")
+	logger.Info("sparkpost-email-send-started", sparkPostEmailLogFields(p.Name(), email)...)
+
 	// Validate email
 	if err := validateEmail(email); err != nil {
+		logger.Warn("sparkpost-email-validation-failed", append(sparkPostEmailLogFields(p.Name(), email), zap.Error(err))...)
 		return &SendResult{
 			Provider: p.Name(),
 			Success:  false,
@@ -50,6 +57,7 @@ func (p *SparkPostEmailProvider) Send(ctx context.Context, email *Email) (*SendR
 	// Send via SparkPost
 	messageID, _, err := p.client.Send(transmission)
 	if err != nil {
+		logger.Error("sparkpost-email-send-failed", append(sparkPostEmailLogFields(p.Name(), email), zap.Error(err))...)
 		return &SendResult{
 			Provider: p.Name(),
 			Success:  false,
@@ -57,6 +65,7 @@ func (p *SparkPostEmailProvider) Send(ctx context.Context, email *Email) (*SendR
 		}, ErrEmailProviderSendFailed
 	}
 
+	logger.Info("sparkpost-email-sent", append(sparkPostEmailLogFields(p.Name(), email), zap.String("message-id", messageID))...)
 	return &SendResult{
 		MessageID: messageID,
 		Provider:  p.Name(),
@@ -73,7 +82,10 @@ func (p *SparkPostEmailProvider) Name() string {
 // IsHealthy handles health checks for the provider.
 // For SparkPost, we assume it's healthy if the client is initialised
 func (p *SparkPostEmailProvider) IsHealthy(ctx context.Context) bool {
-	return p.client != nil
+	logger := logger.AcquireOperationFrom(ctx, "external/emailprovider", "sparkpost-health")
+	healthy := p.client != nil
+	logger.Debug("sparkpost-health-checked", zap.String("provider", p.Name()), zap.Bool("healthy", healthy))
+	return healthy
 }
 
 // validateEmail validates that an email has all required fields
@@ -91,4 +103,30 @@ func validateEmail(email *Email) error {
 		return ErrEmailProviderMissingBody
 	}
 	return nil
+}
+
+func sparkPostEmailLogFields(provider string, email *Email) []zap.Field {
+	fields := []zap.Field{
+		zap.String("provider", provider),
+	}
+	if email == nil {
+		return append(fields, zap.Bool("email-present", false))
+	}
+
+	return append(fields,
+		zap.Bool("email-present", true),
+		zap.String("recipient-domain", emailDomainForLog(email.To)),
+		zap.String("sender-domain", emailDomainForLog(email.From)),
+		zap.Bool("has-reply-to", strings.TrimSpace(email.ReplyTo) != ""),
+		zap.Bool("has-html-body", strings.TrimSpace(email.HTMLBody) != ""),
+		zap.Bool("has-text-body", strings.TrimSpace(email.TextBody) != ""),
+	)
+}
+
+func emailDomainForLog(value string) string {
+	parts := strings.Split(strings.TrimSpace(value), "@")
+	if len(parts) != 2 {
+		return ""
+	}
+	return strings.ToLower(parts[1])
 }

--- a/external/emailtemplater/emailtemplater.go
+++ b/external/emailtemplater/emailtemplater.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/mailgun/raymond/v2"
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // EmailTemplater handles generating email templates
@@ -39,11 +41,16 @@ func NewEmailTemplater(config *Config) (*EmailTemplater, error) {
 
 // GenerateFromBaseTemplate generates a custom email from the base dynamic template
 func (t *EmailTemplater) GenerateFromBaseTemplate(ctx context.Context, req *GenerateFromBaseTemplateRequest) (*RenderedEmail, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/emailtemplater", "generate-from-base-template")
+	logger.Debug("email-template-render-started", zap.Bool("footer-enabled", req.WithFooter))
+
 	if err := req.Validate(); err != nil {
+		logger.Warn("email-template-validation-failed", zap.Error(err))
 		return nil, err
 	}
 
 	if t.dynamicTemplates == nil || t.dynamicTemplates[EmailTemplateTypeBase] == nil {
+		logger.Error("email-template-dynamic-template-not-found", zap.String("template-type", string(EmailTemplateTypeBase)))
 		return nil, ErrEmailTemplaterDynamicTemplateNotFound
 	}
 
@@ -72,6 +79,8 @@ func (t *EmailTemplater) GenerateFromBaseTemplate(ctx context.Context, req *Gene
 		t.config.BusinessEntityWebsite,
 	)
 
+	logger.Debug("email-template-render-completed", zap.String("template-type", string(EmailTemplateTypeBase)))
+
 	return &RenderedEmail{
 		To:       req.EmailTo,
 		From:     emailFrom,
@@ -84,11 +93,16 @@ func (t *EmailTemplater) GenerateFromBaseTemplate(ctx context.Context, req *Gene
 
 // GenerateVerificationEmail generates an email for email verification
 func (t *EmailTemplater) GenerateVerificationEmail(ctx context.Context, req *GenerateVerificationEmailRequest) (*RenderedEmail, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/emailtemplater", "generate-verification-email")
+	logger.Debug("email-template-render-started", zap.String("template-type", string(EmailTemplateTypeVerification)), zap.Bool("dashboard-request", req.IsDashboardRequest))
+
 	if err := req.Validate(); err != nil {
+		logger.Warn("email-template-validation-failed", zap.Error(err))
 		return nil, err
 	}
 
 	if t.templates == nil || t.templates[EmailTemplateTypeVerification] == "" {
+		logger.Error("email-template-not-found", zap.String("template-type", string(EmailTemplateTypeVerification)))
 		return nil, ErrEmailTemplaterTemplateNotFound
 	}
 
@@ -105,11 +119,14 @@ func (t *EmailTemplater) GenerateVerificationEmail(ctx context.Context, req *Gen
 	// Render template with substitutes
 	renderedHTML, err := t.renderTemplate(t.templates[EmailTemplateTypeVerification], substitutes)
 	if err != nil {
+		logger.Error("email-template-render-failed", zap.String("template-type", string(EmailTemplateTypeVerification)), zap.Error(err))
 		return nil, ErrEmailTemplaterTemplateRenderingFailed
 	}
 
 	// Adjust subject for environment
 	emailSubject := t.config.AdjustSubjectForEnvironment(t.config.WelcomeEmailSubject)
+
+	logger.Debug("email-template-render-completed", zap.String("template-type", string(EmailTemplateTypeVerification)))
 
 	return &RenderedEmail{
 		To:       req.Email,
@@ -123,11 +140,16 @@ func (t *EmailTemplater) GenerateVerificationEmail(ctx context.Context, req *Gen
 
 // GenerateLoginEmail generates an email for login
 func (t *EmailTemplater) GenerateLoginEmail(ctx context.Context, req *GenerateLoginEmailRequest) (*RenderedEmail, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/emailtemplater", "generate-login-email")
+	logger.Debug("email-template-render-started", zap.String("template-type", string(EmailTemplateTypeLogin)), zap.Bool("dashboard-request", req.IsDashboardRequest))
+
 	if err := req.Validate(); err != nil {
+		logger.Warn("email-template-validation-failed", zap.Error(err))
 		return nil, err
 	}
 
 	if t.templates == nil || t.templates[EmailTemplateTypeLogin] == "" {
+		logger.Error("email-template-not-found", zap.String("template-type", string(EmailTemplateTypeLogin)))
 		return nil, ErrEmailTemplaterTemplateNotFound
 	}
 
@@ -142,11 +164,14 @@ func (t *EmailTemplater) GenerateLoginEmail(ctx context.Context, req *GenerateLo
 	// Render template with substitutes
 	renderedHTML, err := t.renderTemplate(t.templates[EmailTemplateTypeLogin], substitutes)
 	if err != nil {
+		logger.Error("email-template-render-failed", zap.String("template-type", string(EmailTemplateTypeLogin)), zap.Error(err))
 		return nil, ErrEmailTemplaterTemplateRenderingFailed
 	}
 
 	// Adjust subject for environment
 	emailSubject := t.config.AdjustSubjectForEnvironment(t.config.LoginEmailSubject)
+
+	logger.Debug("email-template-render-completed", zap.String("template-type", string(EmailTemplateTypeLogin)))
 
 	return &RenderedEmail{
 		To:       req.Email,

--- a/external/ephemeral/redis_runtime.go
+++ b/external/ephemeral/redis_runtime.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/go-redis/redis/v7"
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // RedisRuntime groups a Redis client with the GHATD ephemeral store built from it.
@@ -30,13 +32,17 @@ type NewRedisRuntimeRequest struct {
 // NewRedisRuntime creates a Redis client, attaches hooks, optionally pings it,
 // and builds the GHATD ephemeral store.
 func NewRedisRuntime(ctx context.Context, request *NewRedisRuntimeRequest) (*RedisRuntime, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "new-redis-runtime")
 	if request == nil {
+		logger.Warn("redis-runtime-nil-request")
 		return nil, fmt.Errorf("ephemeral/redis-runtime-nil-request")
 	}
 	if request.Options == nil {
+		logger.Warn("redis-runtime-missing-options")
 		return nil, fmt.Errorf("ephemeral/redis-runtime-missing-options")
 	}
 
+	logger.Info("redis-runtime-initialising", zap.String("addr", request.Options.Addr), zap.Int("db", request.Options.DB), zap.Int("hooks", len(request.Hooks)), zap.Bool("skip-ping", request.SkipPing))
 	redisClient := redis.NewClient(request.Options)
 	for _, hook := range request.Hooks {
 		if hook != nil {
@@ -47,10 +53,12 @@ func NewRedisRuntime(ctx context.Context, request *NewRedisRuntimeRequest) (*Red
 	if !request.SkipPing {
 		if _, err := redisClient.Ping().Result(); err != nil {
 			_ = redisClient.Close()
+			logger.Error("redis-runtime-ping-failed", zap.String("addr", request.Options.Addr), zap.Error(err))
 			return nil, fmt.Errorf("ephemeral/redis-runtime-ping: %w", err)
 		}
 	}
 
+	logger.Info("redis-runtime-ready", zap.String("addr", request.Options.Addr), zap.Int("db", request.Options.DB))
 	return &RedisRuntime{
 		Client: redisClient,
 		Store: NewRedisStore(
@@ -64,9 +72,17 @@ func NewRedisRuntime(ctx context.Context, request *NewRedisRuntimeRequest) (*Red
 
 // Close closes the underlying Redis client.
 func (r *RedisRuntime) Close(ctx context.Context) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "close-redis-runtime")
 	if r == nil || r.Client == nil {
+		logger.Debug("redis-runtime-close-skipped")
 		return nil
 	}
 
-	return r.Client.Close()
+	if err := r.Client.Close(); err != nil {
+		logger.Error("redis-runtime-close-failed", zap.Error(err))
+		return err
+	}
+
+	logger.Info("redis-runtime-closed")
+	return nil
 }

--- a/external/ephemeral/redisstore.go
+++ b/external/ephemeral/redisstore.go
@@ -76,99 +76,157 @@ func NewRedisStore(client PersistentClient, maxUnauthedRequestAllowance int64, a
 // Creates entry in Store using the combinedUUID as a key.
 // TODO: Create tests
 func (c *Client) StoreToken(ctx context.Context, tokenUUID string, userID string, ttl time.Duration) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "store-token")
 
 	combinedID := toolbox.CombinedUuidFormat(userID, tokenUUID)
 
 	completeKey := c.keyPrefix + combinedID
 
-	return c.client.Set(completeKey, userID, ttl).Err()
+	if err := c.client.Set(completeKey, userID, ttl).Err(); err != nil {
+		logger.Error("ephemeral-token-store-failed", zap.String("user-id", userID), zap.Duration("ttl", ttl), zap.Error(err))
+		return err
+	}
+
+	logger.Debug("ephemeral-token-stored", zap.String("user-id", userID), zap.Duration("ttl", ttl))
+	return nil
 }
 
 // CreateAuth saves token metadata to persistent storage
 // TODO: Create tests
 func (c *Client) CreateAuth(ctx context.Context, userID string, tokenDetails TokenDetailsAuth) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "create-auth")
+	logger.Debug("ephemeral-auth-create-started", zap.String("user-id", userID))
 
 	// Store access token meta
 	if err := c.StoreToken(ctx, tokenDetails.GetTokenAccessUuid(), userID, tokenDetails.GetTokenAccessTimeToLive()); err != nil {
+		logger.Error("ephemeral-auth-create-access-token-store-failed", zap.String("user-id", userID), zap.Error(err))
 		return err
 	}
 
 	// Store refresh token meta
 	if err := c.StoreToken(ctx, tokenDetails.GetTokenRefreshUuid(), userID, tokenDetails.GetTokenRefreshTimeToLive()); err != nil {
+		logger.Error("ephemeral-auth-create-refresh-token-store-failed", zap.String("user-id", userID), zap.Error(err))
 		return err
 	}
 
+	logger.Debug("ephemeral-auth-created", zap.String("user-id", userID))
 	return nil
 }
 
 // AcquireRefreshTokenRotationLock tries to claim the rotation for a refresh token.
 func (c *Client) AcquireRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string, ttl time.Duration) (bool, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "acquire-refresh-token-rotation-lock")
 	completeKey := c.keyPrefix + refreshTokenRotationLockKey(userID, refreshTokenUUID)
 
-	return c.client.SetNX(completeKey, "1", ttl).Result()
+	acquired, err := c.client.SetNX(completeKey, "1", ttl).Result()
+	if err != nil {
+		logger.Error("ephemeral-refresh-rotation-lock-acquire-failed", zap.String("user-id", userID), zap.Duration("ttl", ttl), zap.Error(err))
+		return false, err
+	}
+
+	logger.Debug("ephemeral-refresh-rotation-lock-acquire-completed", zap.String("user-id", userID), zap.Bool("acquired", acquired), zap.Duration("ttl", ttl))
+	return acquired, nil
 }
 
 // ReleaseRefreshTokenRotationLock releases a previously acquired refresh rotation lock.
 func (c *Client) ReleaseRefreshTokenRotationLock(ctx context.Context, userID, refreshTokenUUID string) (int64, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "release-refresh-token-rotation-lock")
 	completeKey := c.keyPrefix + refreshTokenRotationLockKey(userID, refreshTokenUUID)
 
-	return c.client.Del(completeKey).Result()
+	deleted, err := c.client.Del(completeKey).Result()
+	if err != nil {
+		logger.Error("ephemeral-refresh-rotation-lock-release-failed", zap.String("user-id", userID), zap.Error(err))
+		return 0, err
+	}
+
+	logger.Debug("ephemeral-refresh-rotation-lock-released", zap.String("user-id", userID), zap.Int64("deleted", deleted))
+	return deleted, nil
 }
 
 // StoreRefreshTokenRotationResult stores the newly issued token pair for brief replay.
 func (c *Client) StoreRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string, result *RefreshTokenRotationResult, ttl time.Duration) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "store-refresh-token-rotation-result")
 	if result == nil {
+		logger.Warn("ephemeral-refresh-rotation-result-store-nil-result", zap.String("user-id", userID))
 		return fmt.Errorf("nil refresh token rotation result")
 	}
 
 	payload, err := json.Marshal(result)
 	if err != nil {
+		logger.Error("ephemeral-refresh-rotation-result-marshal-failed", zap.String("user-id", userID), zap.Error(err))
 		return err
 	}
 
 	completeKey := c.keyPrefix + refreshTokenRotationKey(userID, refreshTokenUUID)
-	return c.client.Set(completeKey, string(payload), ttl).Err()
+	if err := c.client.Set(completeKey, string(payload), ttl).Err(); err != nil {
+		logger.Error("ephemeral-refresh-rotation-result-store-failed", zap.String("user-id", userID), zap.Duration("ttl", ttl), zap.Error(err))
+		return err
+	}
+
+	logger.Debug("ephemeral-refresh-rotation-result-stored", zap.String("user-id", userID), zap.Duration("ttl", ttl))
+	return nil
 }
 
 // GetRefreshTokenRotationResult retrieves a recently rotated token pair.
 func (c *Client) GetRefreshTokenRotationResult(ctx context.Context, userID, refreshTokenUUID string) (*RefreshTokenRotationResult, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "get-refresh-token-rotation-result")
 	completeKey := c.keyPrefix + refreshTokenRotationKey(userID, refreshTokenUUID)
 
 	raw, err := c.client.Get(completeKey).Result()
 	if err == redis.Nil {
+		logger.Debug("ephemeral-refresh-rotation-result-not-found", zap.String("user-id", userID))
 		return nil, nil
 	}
 	if err != nil {
+		logger.Error("ephemeral-refresh-rotation-result-fetch-failed", zap.String("user-id", userID), zap.Error(err))
 		return nil, err
 	}
 
 	var result RefreshTokenRotationResult
 	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		logger.Error("ephemeral-refresh-rotation-result-unmarshal-failed", zap.String("user-id", userID), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("ephemeral-refresh-rotation-result-found", zap.String("user-id", userID))
 	return &result, nil
 }
 
 // AcquireLoginEmailCooldown tries to claim the login-email cooldown window.
 func (c *Client) AcquireLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string, ttl time.Duration) (bool, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "acquire-login-email-cooldown")
 	completeKey := c.keyPrefix + loginEmailCooldownKey(userID, isDashboardRequest, requestURL)
 
-	return c.client.SetNX(completeKey, "1", ttl).Result()
+	acquired, err := c.client.SetNX(completeKey, "1", ttl).Result()
+	if err != nil {
+		logger.Error("ephemeral-login-email-cooldown-acquire-failed", zap.String("user-id", userID), zap.Bool("dashboard-request", isDashboardRequest), zap.Duration("ttl", ttl), zap.Error(err))
+		return false, err
+	}
+
+	logger.Debug("ephemeral-login-email-cooldown-acquire-completed", zap.String("user-id", userID), zap.Bool("dashboard-request", isDashboardRequest), zap.Bool("acquired", acquired), zap.Duration("ttl", ttl))
+	return acquired, nil
 }
 
 // ReleaseLoginEmailCooldown releases a login-email cooldown claim.
 func (c *Client) ReleaseLoginEmailCooldown(ctx context.Context, userID string, isDashboardRequest bool, requestURL string) (int64, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "release-login-email-cooldown")
 	completeKey := c.keyPrefix + loginEmailCooldownKey(userID, isDashboardRequest, requestURL)
 
-	return c.client.Del(completeKey).Result()
+	deleted, err := c.client.Del(completeKey).Result()
+	if err != nil {
+		logger.Error("ephemeral-login-email-cooldown-release-failed", zap.String("user-id", userID), zap.Bool("dashboard-request", isDashboardRequest), zap.Error(err))
+		return 0, err
+	}
+
+	logger.Debug("ephemeral-login-email-cooldown-released", zap.String("user-id", userID), zap.Bool("dashboard-request", isDashboardRequest), zap.Int64("deleted", deleted))
+	return deleted, nil
 }
 
 // DeleteAllTokenExceptedSpecified deletes all keys except the ones specified
 //
 // Note, the exemptionKey should be in the format <userId>:<tokenUuid>
 func (c *Client) DeleteAllTokenExceptedSpecified(ctx context.Context, userId string, exemptionTokenIds []string) error {
-	logger := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/ephemeral")
 
 	var cursor uint64
 	var completeExemptionTokenIds []string
@@ -225,31 +283,44 @@ func (c *Client) DeleteAllTokenExceptedSpecified(ctx context.Context, userId str
 // FetchAuth retrieves tokendata from persistent storage using combinedUUID
 // TODO: Create tests
 func (c *Client) FetchAuth(ctx context.Context, accessDetails TokenDetailsAccess) (string, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "fetch-auth")
 
 	combinedID := toolbox.CombinedUuidFormat(accessDetails.GetUserId(), accessDetails.GetTokenAccessUuid())
 
 	completeKey := c.keyPrefix + combinedID
 
-	return c.client.Get(completeKey).Result()
+	userID := accessDetails.GetUserId()
+	userIDFromToken, err := c.client.Get(completeKey).Result()
+	if err != nil {
+		logger.Error("ephemeral-auth-fetch-failed", zap.String("user-id", userID), zap.Error(err))
+		return "", err
+	}
+
+	logger.Debug("ephemeral-auth-fetched", zap.String("user-id", userID))
+	return userIDFromToken, nil
 }
 
 // DeleteAuth deletes metadata with matching combinedUUID key
 // from persistent storage
 // TODO: Create tests
 func (c *Client) DeleteAuth(ctx context.Context, combinedUUID string) (int64, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "delete-auth")
 
 	completeKey := c.keyPrefix + combinedUUID
 
 	deleted, err := c.client.Del(completeKey).Result()
 	if err != nil {
+		logger.Error("ephemeral-auth-delete-failed", zap.Error(err))
 		return 0, err
 	}
+	logger.Debug("ephemeral-auth-deleted", zap.Int64("deleted", deleted))
 	return deleted, nil
 }
 
 // AddRequestCountEntry saves client making call and the number of request
 // TODO: Create tests
 func (c *Client) AddRequestCountEntry(ctx context.Context, clientIp string) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "add-request-count-entry")
 
 	requestorID := createRateLimitRequestorID(clientIp)
 
@@ -258,19 +329,28 @@ func (c *Client) AddRequestCountEntry(ctx context.Context, clientIp string) erro
 	// See if entry exists
 	_, err := c.fetchRequestCountEntry(ctx, completeKey)
 	if err != nil && err == redis.Nil {
+		logger.Debug("ephemeral-request-count-entry-missing-initialising", zap.String("clientip", clientIp))
 		return c.initiateRequestCountEntry(ctx, completeKey)
 	}
 
 	if err != nil {
+		logger.Error("ephemeral-request-count-entry-fetch-failed", zap.String("clientip", clientIp), zap.Error(err))
 		return err
 	}
 
 	err = c.countRequestCountEntry(ctx, completeKey, c.maxUnauthedRequestAllowance)
 	if err != nil {
+		logger.Warn("ephemeral-request-count-entry-limit-check-failed", zap.String("clientip", clientIp), zap.Int64("limit", c.maxUnauthedRequestAllowance), zap.Error(err))
 		return err
 	}
 
-	return c.incrementAndUpdateRequestCountEntry(ctx, completeKey)
+	if err := c.incrementAndUpdateRequestCountEntry(ctx, completeKey); err != nil {
+		logger.Error("ephemeral-request-count-entry-increment-failed", zap.String("clientip", clientIp), zap.Error(err))
+		return err
+	}
+
+	logger.Debug("ephemeral-request-count-entry-incremented", zap.String("clientip", clientIp))
+	return nil
 }
 
 // countRequestCountEntry checks to see how many requests have been made and returns error if limit exceeded
@@ -320,87 +400,130 @@ func createRateLimitRequestorID(clientIp string) string {
 // CodeExists checks whether a verification or login code already exists in persistent storage.
 // It returns true if the code is found, false if the code does not exist.
 func (c *Client) CodeExists(ctx context.Context, code string) (bool, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "code-exists")
 	completeKey := c.keyPrefix + "code:" + code
 
 	_, err := c.client.Get(completeKey).Result()
 	if err == redis.Nil {
+		logger.Debug("ephemeral-code-not-found")
 		return false, nil
 	}
 	if err != nil {
+		logger.Error("ephemeral-code-exists-check-failed", zap.Error(err))
 		return false, err
 	}
 
+	logger.Debug("ephemeral-code-found")
 	return true, nil
 }
 
 // StoreCode saves a verification or login code to persistent storage with the given TTL.
 func (c *Client) StoreCode(ctx context.Context, code string, ttl time.Duration) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "store-code")
 	completeKey := c.keyPrefix + "code:" + code
 
-	return c.client.Set(completeKey, 1, ttl).Err()
+	if err := c.client.Set(completeKey, 1, ttl).Err(); err != nil {
+		logger.Error("ephemeral-code-store-failed", zap.Duration("ttl", ttl), zap.Error(err))
+		return err
+	}
+
+	logger.Debug("ephemeral-code-stored", zap.Duration("ttl", ttl))
+	return nil
 }
 
 // StoreCodeMapping saves a code→token mapping to persistent storage with the given TTL.
 func (c *Client) StoreCodeMapping(ctx context.Context, code, token string, ttl time.Duration) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "store-code-mapping")
 	completeKey := c.keyPrefix + "codetoken:" + code
 
-	return c.client.Set(completeKey, token, ttl).Err()
+	if err := c.client.Set(completeKey, token, ttl).Err(); err != nil {
+		logger.Error("ephemeral-code-mapping-store-failed", zap.Duration("ttl", ttl), zap.Error(err))
+		return err
+	}
+
+	logger.Debug("ephemeral-code-mapping-stored", zap.Duration("ttl", ttl))
+	return nil
 }
 
 // GetCodeMapping retrieves the token associated with the given code.
 // Returns an error if the mapping does not exist.
 func (c *Client) GetCodeMapping(ctx context.Context, code string) (string, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "get-code-mapping")
 	completeKey := c.keyPrefix + "codetoken:" + code
 
-	return c.client.Get(completeKey).Result()
+	token, err := c.client.Get(completeKey).Result()
+	if err != nil {
+		logger.Error("ephemeral-code-mapping-fetch-failed", zap.Error(err))
+		return "", err
+	}
+
+	logger.Debug("ephemeral-code-mapping-fetched")
+	return token, nil
 }
 
 // TrackHardenedAttempt increments rate-limit counters for the given IP and optional code,
 // checking against the maximum allowed attempts within the configured time window.
 // It returns an error if the limit has been exceeded for either the IP or the code.
 func (c *Client) TrackHardenedAttempt(ctx context.Context, ip, code string, maxAttempts int, window time.Duration) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "track-hardened-attempt")
 	ipKey := c.keyPrefix + "hrl_ip:" + ip
 	if err := c.incrementAndCheckHardened(ctx, ipKey, maxAttempts, window); err != nil {
+		logger.Warn("ephemeral-hardened-attempt-ip-check-failed", zap.String("clientip", ip), zap.Int("max-attempts", maxAttempts), zap.Duration("window", window), zap.Error(err))
 		return err
 	}
 
 	if code != "" {
 		codeKey := c.keyPrefix + "hrl_code:" + code
 		if err := c.incrementAndCheckHardened(ctx, codeKey, maxAttempts, window); err != nil {
+			logger.Warn("ephemeral-hardened-attempt-code-check-failed", zap.String("clientip", ip), zap.Bool("has-code", true), zap.Int("max-attempts", maxAttempts), zap.Duration("window", window), zap.Error(err))
 			return err
 		}
 	}
 
+	logger.Debug("ephemeral-hardened-attempt-tracked", zap.String("clientip", ip), zap.Bool("has-code", code != ""), zap.Int("max-attempts", maxAttempts), zap.Duration("window", window))
 	return nil
 }
 
 // BlockIP stores a temporary block entry for the given IP address with the specified duration.
 func (c *Client) BlockIP(ctx context.Context, ip string, duration time.Duration) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "block-ip")
 	blockKey := c.keyPrefix + "hrl_block:" + ip
 
-	return c.client.Set(blockKey, "1", duration).Err()
+	if err := c.client.Set(blockKey, "1", duration).Err(); err != nil {
+		logger.Error("ephemeral-ip-block-store-failed", zap.String("clientip", ip), zap.Duration("duration", duration), zap.Error(err))
+		return err
+	}
+
+	logger.Warn("ephemeral-ip-blocked", zap.String("clientip", ip), zap.Duration("duration", duration))
+	return nil
 }
 
 // IsIPBlocked checks whether the given IP address is currently under a temporary block.
 func (c *Client) IsIPBlocked(ctx context.Context, ip string) (bool, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "is-ip-blocked")
 	blockKey := c.keyPrefix + "hrl_block:" + ip
 
 	_, err := c.client.Get(blockKey).Result()
 	if err == redis.Nil {
+		logger.Debug("ephemeral-ip-not-blocked", zap.String("clientip", ip))
 		return false, nil
 	}
 	if err != nil {
+		logger.Error("ephemeral-ip-block-check-failed", zap.String("clientip", ip), zap.Error(err))
 		return false, err
 	}
 
+	logger.Debug("ephemeral-ip-blocked-entry-found", zap.String("clientip", ip))
 	return true, nil
 }
 
 // incrementAndCheckHardened increments a rate-limit counter key, sets the TTL on first
 // increment, and returns an error if the counter exceeds maxAttempts.
 func (c *Client) incrementAndCheckHardened(ctx context.Context, key string, maxAttempts int, window time.Duration) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/ephemeral", "increment-and-check-hardened")
 	val, err := c.client.Incr(key).Result()
 	if err != nil {
+		logger.Error("ephemeral-hardened-counter-increment-failed", zap.Error(err))
 		return err
 	}
 
@@ -409,6 +532,7 @@ func (c *Client) incrementAndCheckHardened(ctx context.Context, key string, maxA
 	}
 
 	if int(val) > maxAttempts {
+		logger.Warn("ephemeral-hardened-counter-limit-exceeded", zap.Int64("attempts", val), zap.Int("max-attempts", maxAttempts), zap.Duration("window", window))
 		return ErrHardenedRateLimitExceeded
 	}
 

--- a/external/group/handler.go
+++ b/external/group/handler.go
@@ -2,10 +2,12 @@ package group
 
 import (
 	"context"
+	"github.com/ooaklee/ghatd/external/logger"
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/errormanifest"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // GroupService interface defines expected methods of a valid group service
@@ -69,14 +71,17 @@ func NewHandler(service GroupService, validator GroupValidator, errorMaps ...rep
 
 // CreateGroup handles group creation
 func (h *Handler) CreateGroup(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-create-group")
 	request, err := MapRequestToCreateGroupRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.CreateGroup(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -86,14 +91,17 @@ func (h *Handler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupByID handles getting a group by ID
 func (h *Handler) GetGroupByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-group-by-id")
 	request, err := MapRequestToGetGroupByIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupByID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -103,14 +111,17 @@ func (h *Handler) GetGroupByID(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupLineage handles getting a group's root-first lineage
 func (h *Handler) GetGroupLineage(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-group-lineage")
 	request, err := MapRequestToGetGroupLineageRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupLineage(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -120,14 +131,17 @@ func (h *Handler) GetGroupLineage(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupDescendants handles getting a group's descendants grouped by depth level
 func (h *Handler) GetGroupDescendants(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-group-descendants")
 	request, err := MapRequestToGetGroupDescendantsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupDescendants(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -137,14 +151,17 @@ func (h *Handler) GetGroupDescendants(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupByNanoID handles getting a group by nano ID
 func (h *Handler) GetGroupByNanoID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-group-by-nano-id")
 	request, err := MapRequestToGetGroupByNanoIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupByNanoID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -154,14 +171,17 @@ func (h *Handler) GetGroupByNanoID(w http.ResponseWriter, r *http.Request) {
 
 // GetGroups handles getting groups with filters and pagination
 func (h *Handler) GetGroups(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-groups")
 	request, err := MapRequestToGetGroupsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroups(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -177,14 +197,17 @@ func (h *Handler) GetGroups(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupsByUserID handles getting groups referenced by a user ID.
 func (h *Handler) GetGroupsByUserID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-groups-by-user-id")
 	request, err := MapRequestToGetGroupsByUserIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupsByUserID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -195,14 +218,17 @@ func (h *Handler) GetGroupsByUserID(w http.ResponseWriter, r *http.Request) {
 // GetGroupsAwaitingAnswerForInvitationsByMemberID handles getting groups
 // with pending invitations matching the provided member ID.
 func (h *Handler) GetGroupsAwaitingAnswerForInvitationsByMemberID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-groups-awaiting-answer-for-invitations-by-member-id")
 	request, err := MapRequestToGetGroupsAwaitingAnswerForInvitationsByMemberIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupsAwaitingAnswerForInvitationsByMemberID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -212,14 +238,17 @@ func (h *Handler) GetGroupsAwaitingAnswerForInvitationsByMemberID(w http.Respons
 
 // GetGroupsByMemberID handles getting groups by member ID with pagination
 func (h *Handler) GetGroupsByMemberID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-groups-by-member-id")
 	request, err := MapRequestToGetGroupsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupsByMemberID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -235,14 +264,17 @@ func (h *Handler) GetGroupsByMemberID(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupsByLeaderID handles getting groups by leader ID with pagination
 func (h *Handler) GetGroupsByLeaderID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-groups-by-leader-id")
 	request, err := MapRequestToGetGroupsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupsByLeaderID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -258,14 +290,17 @@ func (h *Handler) GetGroupsByLeaderID(w http.ResponseWriter, r *http.Request) {
 
 // SearchGroupsByExtension handles searching groups by extension field with pagination
 func (h *Handler) SearchGroupsByExtension(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-search-groups-by-extension")
 	request, err := MapRequestToGetGroupsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.SearchGroupsByExtension(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -281,14 +316,17 @@ func (h *Handler) SearchGroupsByExtension(w http.ResponseWriter, r *http.Request
 
 // UpdateGroup handles group updates
 func (h *Handler) UpdateGroup(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-update-group")
 	request, err := MapRequestToUpdateGroupRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateGroup(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -298,14 +336,17 @@ func (h *Handler) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 
 // DeleteGroup handles group deletion
 func (h *Handler) DeleteGroup(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-delete-group")
 	request, err := MapRequestToDeleteGroupRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	_, err = h.Service.DeleteGroup(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -315,14 +356,17 @@ func (h *Handler) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 
 // AddMember handles adding a member to a group
 func (h *Handler) AddMember(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-add-member")
 	request, err := MapRequestToAddMemberRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.AddMember(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -332,14 +376,17 @@ func (h *Handler) AddMember(w http.ResponseWriter, r *http.Request) {
 
 // InviteUser handles inviting a user to a group
 func (h *Handler) InviteUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-invite-user")
 	request, err := MapRequestToInviteUserRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.InviteUser(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -349,14 +396,17 @@ func (h *Handler) InviteUser(w http.ResponseWriter, r *http.Request) {
 
 // UninviteUser handles revoking a pending invite from a group
 func (h *Handler) UninviteUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-uninvite-user")
 	request, err := MapRequestToUninviteUserRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UninviteUser(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -366,14 +416,17 @@ func (h *Handler) UninviteUser(w http.ResponseWriter, r *http.Request) {
 
 // AcceptInvite handles accepting a pending invite for a group
 func (h *Handler) AcceptInvite(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-accept-invite")
 	request, err := MapRequestToAcceptInviteRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.AcceptInvite(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -383,14 +436,17 @@ func (h *Handler) AcceptInvite(w http.ResponseWriter, r *http.Request) {
 
 // RejectInvite handles rejecting a pending invite for a group
 func (h *Handler) RejectInvite(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-reject-invite")
 	request, err := MapRequestToRejectInviteRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RejectInvite(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -400,14 +456,17 @@ func (h *Handler) RejectInvite(w http.ResponseWriter, r *http.Request) {
 
 // RemoveMember handles removing a member from a group
 func (h *Handler) RemoveMember(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-remove-member")
 	request, err := MapRequestToRemoveMemberRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RemoveMember(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -417,14 +476,17 @@ func (h *Handler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 
 // UpdateMemberRole handles updating a member's role
 func (h *Handler) UpdateMemberRole(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-update-member-role")
 	request, err := MapRequestToUpdateMemberRoleRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateMemberRole(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -434,14 +496,17 @@ func (h *Handler) UpdateMemberRole(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupMembers handles getting group members
 func (h *Handler) GetGroupMembers(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-group-members")
 	request, err := MapRequestToGetGroupMembersRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupMembers(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -451,14 +516,17 @@ func (h *Handler) GetGroupMembers(w http.ResponseWriter, r *http.Request) {
 
 // UpdateOwner handles updating group owner
 func (h *Handler) UpdateOwner(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-update-owner")
 	request, err := MapRequestToUpdateOwnerRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateOwner(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -468,8 +536,10 @@ func (h *Handler) UpdateOwner(w http.ResponseWriter, r *http.Request) {
 
 // RepairInvalidMembers handles repairing groups that contain members with empty or null IDs.
 func (h *Handler) RepairInvalidMembers(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-repair-invalid-members")
 	response, err := h.Service.RepairInvalidMembers(r.Context())
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -479,14 +549,17 @@ func (h *Handler) RepairInvalidMembers(w http.ResponseWriter, r *http.Request) {
 
 // ArchiveGroup handles archiving a group
 func (h *Handler) ArchiveGroup(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-archive-group")
 	request, err := MapRequestToArchiveGroupRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ArchiveGroup(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -496,14 +569,17 @@ func (h *Handler) ArchiveGroup(w http.ResponseWriter, r *http.Request) {
 
 // RestoreGroup handles restoring an archived group
 func (h *Handler) RestoreGroup(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-restore-group")
 	request, err := MapRequestToRestoreGroupRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RestoreGroup(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -513,14 +589,17 @@ func (h *Handler) RestoreGroup(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupStats handles getting group statistics
 func (h *Handler) GetGroupStats(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-group-stats")
 	request, err := MapRequestToGetGroupStatsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupStats(r.Context(), request.ID)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -530,8 +609,10 @@ func (h *Handler) GetGroupStats(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupsStats handles getting aggregate stats across all groups
 func (h *Handler) GetGroupsStats(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-groups-stats")
 	response, err := h.Service.GetGroupsStats(r.Context(), &GetGroupsStatsRequest{})
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -541,8 +622,10 @@ func (h *Handler) GetGroupsStats(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupsConfig handles getting the group service config
 func (h *Handler) GetGroupsConfig(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-get-groups-config")
 	response, err := h.Service.GetGroupsConfig(r.Context(), &GetGroupsConfigRequest{})
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -553,14 +636,17 @@ func (h *Handler) GetGroupsConfig(w http.ResponseWriter, r *http.Request) {
 // ValidateGroupName handles validating a proposed group name without persisting anything.
 // Front-end forms can call this to preview what RawName and Name will be stored.
 func (h *Handler) ValidateGroupName(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-validate-group-name")
 	request, err := MapRequestToValidateGroupNameRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ValidateGroupName(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -570,14 +656,17 @@ func (h *Handler) ValidateGroupName(w http.ResponseWriter, r *http.Request) {
 
 // EnableGroupAutoJoinByEmailDomain enables auto-join for a group
 func (h *Handler) EnableGroupAutoJoinByEmailDomain(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-enable-group-auto-join-by-email-domain")
 	request, err := MapRequestToEnableGroupAutoJoinByEmailDomainRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.EnableGroupAutoJoinByEmailDomain(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -587,14 +676,17 @@ func (h *Handler) EnableGroupAutoJoinByEmailDomain(w http.ResponseWriter, r *htt
 
 // DisableGroupAutoJoinByEmailDomain disables auto-join for a group
 func (h *Handler) DisableGroupAutoJoinByEmailDomain(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-disable-group-auto-join-by-email-domain")
 	request, err := MapRequestToDisableGroupAutoJoinByEmailDomainRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.DisableGroupAutoJoinByEmailDomain(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -604,14 +696,17 @@ func (h *Handler) DisableGroupAutoJoinByEmailDomain(w http.ResponseWriter, r *ht
 
 // EnableGroupAutoInviteByEmailDomain enables auto-invite for a group
 func (h *Handler) EnableGroupAutoInviteByEmailDomain(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-enable-group-auto-invite-by-email-domain")
 	request, err := MapRequestToEnableGroupAutoInviteByEmailDomainRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.EnableGroupAutoInviteByEmailDomain(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -621,14 +716,17 @@ func (h *Handler) EnableGroupAutoInviteByEmailDomain(w http.ResponseWriter, r *h
 
 // DisableGroupAutoInviteByEmailDomain disables auto-invite for a group
 func (h *Handler) DisableGroupAutoInviteByEmailDomain(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/group", "handle-disable-group-auto-invite-by-email-domain")
 	request, err := MapRequestToDisableGroupAutoInviteByEmailDomainRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.DisableGroupAutoInviteByEmailDomain(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/group/logging.go
+++ b/external/group/logging.go
@@ -1,0 +1,7 @@
+package group
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/group/logging.go
+++ b/external/group/logging.go
@@ -1,7 +1,17 @@
 package group
 
-import "github.com/ooaklee/ghatd/external/logger"
+import (
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
+)
 
 func safeLogValue(value any) any {
 	return logger.SafeValue(value)
+}
+
+func emailLogFields(prefix, value string) []zap.Field {
+	return []zap.Field{
+		zap.Bool(prefix+"-present", logger.EmailPresentForLog(value)),
+		zap.String(prefix+"-domain", logger.EmailDomainForLog(value)),
+	}
 }

--- a/external/group/service.go
+++ b/external/group/service.go
@@ -111,13 +111,13 @@ func NewService(
 // validateHierarchyTreeConfig validates the configured group hierarchy tree
 // when hierarchy rules are explicitly defined on the service config.
 // It returns ErrKeyInvalidGroupHierarchyTree when validation fails.
-func (s *Service) validateHierarchyTreeConfig(log *zap.Logger) error {
+func (s *Service) validateHierarchyTreeConfig(logger *zap.Logger) error {
 	if s.Config == nil || len(s.Config.Tree) == 0 {
 		return nil
 	}
 
 	if err := s.Config.ValidateHierarchy(); err != nil {
-		log.Error("group-hierarchy-tree-validation-failed", zap.Error(err))
+		logger.Error("group-hierarchy-tree-validation-failed", zap.Error(err))
 		return ErrInvalidGroupHierarchyTree
 	}
 
@@ -126,10 +126,10 @@ func (s *Service) validateHierarchyTreeConfig(log *zap.Logger) error {
 
 // CreateGroup creates a new group
 func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*CreateGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "create-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("creating-group", zap.String("name", req.Name), zap.String("type", req.Type))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "create-group"))
+	logger.Debug("creating-group", zap.String("name", req.Name), zap.String("type", req.Type))
 
-	if err := s.validateHierarchyTreeConfig(log); err != nil {
+	if err := s.validateHierarchyTreeConfig(logger); err != nil {
 		return nil, err
 	}
 
@@ -137,7 +137,7 @@ func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Cr
 	if req.ParentGroupID != "" {
 		parentGroupResult, parentErr := s.GroupRepository.GetGroupByID(ctx, req.ParentGroupID)
 		if parentErr != nil {
-			log.Error("failed-to-get-parent-group", zap.Error(parentErr), zap.String("parent_group_id", req.ParentGroupID))
+			logger.Error("failed-to-get-parent-group", zap.Error(parentErr), zap.String("parent_group_id", req.ParentGroupID))
 			return nil, parentErr
 		}
 		parentGroup = parentGroupResult
@@ -149,11 +149,11 @@ func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Cr
 		ParentGroupID: req.ParentGroupID,
 	})
 	if err != nil {
-		log.Error("failed-to-validate-group-name", zap.Error(err), zap.String("name", req.Name))
+		logger.Error("failed-to-validate-group-name", zap.Error(err), zap.String("name", req.Name))
 		return nil, err
 	}
 	if !nameValidation.Available && nameValidation.IsRootType {
-		log.Debug("group-with-name-already-exists", zap.String("name", nameValidation.Name))
+		logger.Debug("group-with-name-already-exists", zap.String("name", nameValidation.Name))
 		return nil, ErrNameAlreadyExists
 	}
 
@@ -206,27 +206,27 @@ func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Cr
 	// Add initial members if provided
 	for _, memberReq := range req.InitialMembers {
 		if _, err := group.AddMember(memberReq.ID, memberReq.Type, memberReq.Role); err != nil {
-			log.Error("failed-to-add-initial-member", zap.Error(err), zap.String("member_id", memberReq.ID))
+			logger.Error("failed-to-add-initial-member", zap.Error(err), zap.String("member_id", memberReq.ID))
 			return nil, err
 		}
 	}
 
 	if group.OwnerID != "" {
 		if err := s.ensureOwnerMembershipAndAdminRole(ctx, group, group.OwnerID); err != nil {
-			log.Error("failed-to-ensure-owner-membership-on-create", zap.Error(err), zap.String("owner_id", group.OwnerID))
+			logger.Error("failed-to-ensure-owner-membership-on-create", zap.Error(err), zap.String("owner_id", group.OwnerID))
 			return nil, err
 		}
 	}
 
 	// Validate group
 	if err := group.Validate(); err != nil {
-		log.Error("group-validation-failed", zap.Error(err))
+		logger.Error("group-validation-failed", zap.Error(err))
 		return nil, err
 	}
 
 	if parentGroup != nil {
 		if !s.Config.CanHaveChildType(parentGroup.Type, group.Type) {
-			log.Error(
+			logger.Error(
 				"invalid-parent-child-group-relation",
 				zap.String("parent_group_id", parentGroup.ID),
 				zap.String("parent_group_type", parentGroup.Type),
@@ -239,7 +239,7 @@ func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Cr
 	// Create group in repository
 	createdGroup, err := s.GroupRepository.CreateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-create-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-create-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -262,12 +262,12 @@ func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Cr
 
 // GetGroupByID retrieves a group by ID
 func (s *Service) GetGroupByID(ctx context.Context, req *GetGroupByIDRequest) (*GetGroupByIDResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-by-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("getting-group-by-id", zap.String("id", req.ID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-by-id"))
+	logger.Debug("getting-group-by-id", zap.String("id", req.ID))
 
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-group-by-id", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-group-by-id", zap.Error(err), zap.String("id", req.ID))
 		return nil, err
 	}
 
@@ -282,13 +282,13 @@ func (s *Service) GetGroupByID(ctx context.Context, req *GetGroupByIDRequest) (*
 
 // GetGroupLineage retrieves the root-first lineage for a group, including the group itself.
 func (s *Service) GetGroupLineage(ctx context.Context, req *GetGroupLineageRequest) (*GetGroupLineageResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-lineage")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-lineage"))
 	asUserID := strings.TrimSpace(req.AsUserID)
-	log.Debug("getting-group-lineage", zap.String("id", req.ID), zap.String("as_user_id", asUserID))
+	logger.Debug("getting-group-lineage", zap.String("id", req.ID), zap.String("as_user_id", asUserID))
 
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-group-for-lineage", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-group-for-lineage", zap.Error(err), zap.String("id", req.ID))
 		return nil, err
 	}
 
@@ -300,7 +300,7 @@ func (s *Service) GetGroupLineage(ctx context.Context, req *GetGroupLineageReque
 	for _, groupID := range lineageIDs {
 		lineageGroup, lineageErr := s.GroupRepository.GetGroupByID(ctx, groupID)
 		if lineageErr != nil {
-			log.Warn("failed-to-get-lineage-group", zap.Error(lineageErr), zap.String("lineage_group_id", groupID))
+			logger.Warn("failed-to-get-lineage-group", zap.Error(lineageErr), zap.String("lineage_group_id", groupID))
 			continue
 		}
 
@@ -328,9 +328,9 @@ func (s *Service) GetGroupLineage(ctx context.Context, req *GetGroupLineageReque
 // GetGroupDescendants retrieves all descendants for a group grouped by depth level.
 // Index 0 contains direct children, index 1 grandchildren, and so on.
 func (s *Service) GetGroupDescendants(ctx context.Context, req *GetGroupDescendantsRequest) (*GetGroupDescendantsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-descendants")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-descendants"))
 	asUserID := strings.TrimSpace(req.AsUserID)
-	log.Debug(
+	logger.Debug(
 		"getting-group-descendants",
 		zap.String("id", req.ID),
 		zap.Int("max_depth", req.MaxDepth),
@@ -344,13 +344,13 @@ func (s *Service) GetGroupDescendants(ctx context.Context, req *GetGroupDescenda
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-group-for-descendants", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-group-for-descendants", zap.Error(err), zap.String("id", req.ID))
 		return nil, err
 	}
 
 	descendantGroups, err := s.GroupRepository.GetGroupsByLineageAncestor(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-descendant-groups", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-descendant-groups", zap.Error(err), zap.String("id", req.ID))
 		return nil, err
 	}
 
@@ -583,12 +583,12 @@ func (s *Service) groupVisibility(group *UniversalGroup) string {
 
 // GetGroupByNanoID retrieves a group by nano ID.
 func (s *Service) GetGroupByNanoID(ctx context.Context, req *GetGroupByNanoIDRequest) (*GetGroupByNanoIDResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-by-nano-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("getting-group-by-nano-id", zap.String("nano_id", req.NanoID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-by-nano-id"))
+	logger.Debug("getting-group-by-nano-id", zap.String("nano_id", req.NanoID))
 
 	group, err := s.GroupRepository.GetGroupByNanoID(ctx, req.NanoID)
 	if err != nil {
-		log.Error("failed-to-get-group-by-nano-id", zap.Error(err), zap.String("nano_id", req.NanoID))
+		logger.Error("failed-to-get-group-by-nano-id", zap.Error(err), zap.String("nano_id", req.NanoID))
 		return nil, err
 	}
 
@@ -603,10 +603,10 @@ func (s *Service) GetGroupByNanoID(ctx context.Context, req *GetGroupByNanoIDReq
 
 // UpdateGroup updates an existing group
 func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*UpdateGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("updating-group", zap.String("id", req.ID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "update-group"))
+	logger.Debug("updating-group", zap.String("id", req.ID))
 
-	if err := s.validateHierarchyTreeConfig(log); err != nil {
+	if err := s.validateHierarchyTreeConfig(logger); err != nil {
 		return nil, err
 	}
 
@@ -618,7 +618,7 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 	// Get existing group
 	group, err := s.GroupRepository.GetGroupByID(ctx, targetGroupID)
 	if err != nil {
-		log.Error("failed-to-get-group-for-update", zap.Error(err), zap.String("id", targetGroupID))
+		logger.Error("failed-to-get-group-for-update", zap.Error(err), zap.String("id", targetGroupID))
 		return nil, err
 	}
 
@@ -647,7 +647,7 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 					ParentGroupID: group.ParentGroupID,
 				})
 				if nameValidationErr != nil {
-					log.Error("failed-to-validate-group-name-for-update", zap.Error(nameValidationErr), zap.String("name", groupWithProvidedData.Name))
+					logger.Error("failed-to-validate-group-name-for-update", zap.Error(nameValidationErr), zap.String("name", groupWithProvidedData.Name))
 					return nil, nameValidationErr
 				}
 				if !nameValidation.Available && nameValidation.IsRootType {
@@ -693,7 +693,7 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 					ParentGroupID: group.ParentGroupID,
 				})
 				if nameValidationErr != nil {
-					log.Error("failed-to-validate-group-name-for-update", zap.Error(nameValidationErr), zap.String("name", *req.Name))
+					logger.Error("failed-to-validate-group-name-for-update", zap.Error(nameValidationErr), zap.String("name", *req.Name))
 					return nil, nameValidationErr
 				}
 				if !nameValidation.Available && nameValidation.IsRootType {
@@ -730,7 +730,7 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 		if req.Status != nil && *req.Status != group.Status {
 			_, err := group.UpdateStatus(*req.Status)
 			if err != nil {
-				log.Error("failed-to-update-group-status", zap.Error(err))
+				logger.Error("failed-to-update-group-status", zap.Error(err))
 				return nil, err
 			}
 			hasChanges = true
@@ -745,7 +745,7 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 		}
 
 		if !hasChanges {
-			log.Debug("no-changes-detected-for-group-update", zap.String("id", req.ID))
+			logger.Debug("no-changes-detected-for-group-update", zap.String("id", req.ID))
 			return &UpdateGroupResponse{Group: group}, nil
 		}
 	}
@@ -755,7 +755,7 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 
 	// Validate group
 	if err := group.Validate(); err != nil {
-		log.Error("group-validation-failed", zap.Error(err))
+		logger.Error("group-validation-failed", zap.Error(err))
 		return nil, err
 	}
 
@@ -765,7 +765,7 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 	// Update in repository
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-update-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -782,27 +782,27 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 		})
 	}
 
-	log.Info("group-updated-successfully", zap.String("group-id", updatedGroup.ID))
+	logger.Info("group-updated-successfully", zap.String("group-id", updatedGroup.ID))
 
 	return &UpdateGroupResponse{Group: updatedGroup}, nil
 }
 
 // DeleteGroup deletes a group
 func (s *Service) DeleteGroup(ctx context.Context, req *DeleteGroupRequest) (*DeleteGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "delete-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("deleting-group", zap.String("id", req.ID), zap.Bool("hard_delete", req.HardDelete))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "delete-group"))
+	logger.Debug("deleting-group", zap.String("id", req.ID), zap.Bool("hard_delete", req.HardDelete))
 
 	// Verify group exists and capture the root snapshot.
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
 	if err != nil {
-		log.Error("group-not-found-for-deletion", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("group-not-found-for-deletion", zap.Error(err), zap.String("id", req.ID))
 		return nil, err
 	}
 
 	// Cascade includes all active descendants for the target group.
 	descendants, err := s.GroupRepository.GetGroupsByLineageAncestor(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-groups-by-lineage-ancestor", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-groups-by-lineage-ancestor", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrDatabaseError
 	}
 
@@ -835,7 +835,7 @@ func (s *Service) DeleteGroup(ctx context.Context, req *DeleteGroupRequest) (*De
 		}
 
 		if err != nil {
-			log.Error("failed-to-delete-group", zap.String("group_id", groupSnapshot.ID), zap.Error(err))
+			logger.Error("failed-to-delete-group", zap.String("group_id", groupSnapshot.ID), zap.Error(err))
 			return nil, ErrDatabaseError
 		}
 
@@ -871,8 +871,8 @@ func (s *Service) DeleteGroup(ctx context.Context, req *DeleteGroupRequest) (*De
 
 // GetGroups retrieves groups with filters and pagination
 func (s *Service) GetGroups(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("getting-groups", zap.Int("page", req.Page), zap.Int("page_size", req.PageSize))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups"))
+	logger.Debug("getting-groups", zap.Int("page", req.Page), zap.Int("page_size", req.PageSize))
 
 	// Normalize PerPage to PageSize
 	if req.PerPage > 0 {
@@ -890,17 +890,17 @@ func (s *Service) GetGroups(ctx context.Context, req *GetGroupsRequest) (*GetGro
 	// Get total count
 	totalGroups, err := s.GroupRepository.GetTotalGroups(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-total-groups-count", zap.Error(err))
+		logger.Error("failed-to-get-total-groups-count", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
 	req.TotalCount = int(totalGroups)
-	log.Debug("handling-get-groups-request-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", req))
+	logger.Debug("handling-get-groups-request-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", safeLogValue(req)))
 
 	// Get groups
 	groups, err := s.GroupRepository.GetGroups(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-groups", zap.Error(err))
+		logger.Error("failed-to-get-groups", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -941,9 +941,9 @@ func (s *Service) GetGroups(ctx context.Context, req *GetGroupsRequest) (*GetGro
 
 // GetGroupsByUserID retrieves groups where the user is referenced as owner or member.
 func (s *Service) GetGroupsByUserID(ctx context.Context, req *GetGroupsByUserIDRequest) (*GetGroupsByUserIDResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups-by-user-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-by-user-id"))
 	userID := strings.TrimSpace(req.UserID)
-	log.Debug("getting-groups-by-user-id", zap.String("user_id", userID), zap.Bool("include_descendants", req.IncludeDescendants))
+	logger.Debug("getting-groups-by-user-id", zap.String("user_id", userID), zap.Bool("include_descendants", req.IncludeDescendants))
 
 	if userID == "" {
 		return nil, ErrInvalidQueryParam
@@ -951,7 +951,7 @@ func (s *Service) GetGroupsByUserID(ctx context.Context, req *GetGroupsByUserIDR
 
 	groups, err := s.GroupRepository.GetGroupsByReferencedUserID(ctx, userID)
 	if err != nil {
-		log.Error("failed-to-get-groups-by-user-id", zap.Error(err), zap.String("user_id", userID))
+		logger.Error("failed-to-get-groups-by-user-id", zap.Error(err), zap.String("user_id", userID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1004,7 +1004,7 @@ func (s *Service) GetGroupsByUserID(ctx context.Context, req *GetGroupsByUserIDR
 			PrefixName:  req.PrefixName,
 		})
 		if descendantsErr != nil || descendantsResp == nil {
-			log.Warn(
+			logger.Warn(
 				"failed-to-get-root-group-descendants",
 				zap.String("root_group_id", rootGroupID),
 				zap.Error(descendantsErr),
@@ -1022,6 +1022,9 @@ func (s *Service) GetGroupsByUserID(ctx context.Context, req *GetGroupsByUserIDR
 // getPrefixName prefixes a child group name with the root group's name.
 // Root group is derived from the first lineage element, with parent ID as a fallback.
 func (s *Service) getPrefixName(ctx context.Context, g *UniversalGroup, prefixNameByRootID map[string]string) string {
+	logger := logger.AcquireOperationFrom(ctx, "external/group", "get-prefix-name")
+	logger.Debug("handling-get-prefix-name-request")
+
 	if g == nil {
 		return ""
 	}
@@ -1069,9 +1072,9 @@ func (s *Service) getPrefixName(ctx context.Context, g *UniversalGroup, prefixNa
 // Admin privileges propagate from any directly-administered group down to all
 // descendants of that group.
 func (s *Service) GetUserGroupAccessMap(ctx context.Context, userID string) (map[string]UserGroupAccessSummary, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-user-group-access-map")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-user-group-access-map"))
 	trimmedUserID := strings.TrimSpace(userID)
-	log.Debug("building-user-group-access-map", zap.String("user_id", trimmedUserID))
+	logger.Debug("building-user-group-access-map", zap.String("user_id", trimmedUserID))
 
 	if trimmedUserID == "" {
 		return nil, ErrInvalidUserIDProvided
@@ -1082,7 +1085,7 @@ func (s *Service) GetUserGroupAccessMap(ctx context.Context, userID string) (map
 		IncludeDescendants: false,
 	})
 	if err != nil {
-		log.Error("failed-to-get-user-groups", zap.Error(err), zap.String("user_id", trimmedUserID))
+		logger.Error("failed-to-get-user-groups", zap.Error(err), zap.String("user_id", trimmedUserID))
 		return nil, err
 	}
 
@@ -1113,7 +1116,7 @@ func (s *Service) GetUserGroupAccessMap(ctx context.Context, userID string) (map
 	for adminGroupID := range adminSourceGroupIDs {
 		descendants, descendantsErr := s.GroupRepository.GetGroupsByLineageAncestor(ctx, adminGroupID)
 		if descendantsErr != nil {
-			log.Warn(
+			logger.Warn(
 				"failed-to-get-admin-group-descendants",
 				zap.String("admin_group_id", adminGroupID),
 				zap.Error(descendantsErr),
@@ -1140,13 +1143,13 @@ func (s *Service) GetUserGroupAccessMap(ctx context.Context, userID string) (map
 
 // AddMember adds a member to a group
 func (s *Service) AddMember(ctx context.Context, req *AddMemberRequest) (*AddMemberResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "add-member")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("adding-member-to-group", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "add-member"))
+	logger.Debug("adding-member-to-group", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-group", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, err
 	}
 
@@ -1155,27 +1158,27 @@ func (s *Service) AddMember(ctx context.Context, req *AddMemberRequest) (*AddMem
 
 	// Validate role against group type configuration
 	if err := s.isValidMemberRole(group.Type, req.Role); err != nil {
-		log.Error("invalid-member-role", zap.Error(err), zap.String("role", req.Role), zap.String("group_type", group.Type))
+		logger.Error("invalid-member-role", zap.Error(err), zap.String("role", req.Role), zap.String("group_type", group.Type))
 		return nil, err
 	}
 
 	if len(group.Lineage) > 0 {
 		if err := s.ensureRootMembership(ctx, group, req.MemberID, req.Type); err != nil {
-			log.Error("failed-to-ensure-root-membership", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+			logger.Error("failed-to-ensure-root-membership", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
 			return nil, err
 		}
 	}
 
 	// Add member
 	if _, err := group.AddMember(req.MemberID, req.Type, req.Role); err != nil {
-		log.Error("failed-to-add-member", zap.Error(err))
+		logger.Error("failed-to-add-member", zap.Error(err))
 		return nil, err
 	}
 
 	// Save to repository
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-update-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -1202,8 +1205,8 @@ func (s *Service) AddMember(ctx context.Context, req *AddMemberRequest) (*AddMem
 
 // InviteUser adds a pending invitation for an email address to a top-level group.
 func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*InviteUserResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "invite-user")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("inviting-user-to-group", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "invite-user"))
+	logger.Debug("inviting-user-to-group", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1212,7 +1215,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-target-group-for-invite", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-target-group-for-invite", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, err
 	}
 	targetGroup.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
@@ -1229,7 +1232,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 
 	targetAdded, err := s.addPendingInviteMember(targetGroup, inviteEmail, req.Role, req.InvitedByID)
 	if err != nil {
-		log.Error("failed-to-add-pending-invite-to-target-group", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("invite_email", inviteEmail))
+		logger.Error("failed-to-add-pending-invite-to-target-group", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("invite_email", inviteEmail))
 		return nil, err
 	}
 	if !targetAdded {
@@ -1238,7 +1241,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 
 	updatedTargetGroup, err := s.GroupRepository.UpdateGroup(ctx, targetGroup)
 	if err != nil {
-		log.Error("failed-to-persist-target-group-invite", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-persist-target-group-invite", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1264,8 +1267,8 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 
 // UninviteUser removes a pending invitation from a top-level group.
 func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*UninviteUserResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "uninvite-user")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("uninviting-user-from-group", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "uninvite-user"))
+	logger.Debug("uninviting-user-from-group", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1274,7 +1277,7 @@ func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-target-group-for-uninvite", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-target-group-for-uninvite", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, err
 	}
 	targetGroup.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
@@ -1289,7 +1292,7 @@ func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*
 
 	updatedTargetGroup, err := s.GroupRepository.UpdateGroup(ctx, targetGroup)
 	if err != nil {
-		log.Error("failed-to-persist-target-group-uninvite", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-persist-target-group-uninvite", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1312,8 +1315,8 @@ func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*
 
 // AcceptInvite accepts a pending invitation for a user and materialises membership.
 func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*AcceptInviteResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "accept-invite")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("accepting-group-invite", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail), zap.String("user_id", req.UserID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "accept-invite"))
+	logger.Debug("accepting-group-invite", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail), zap.String("user_id", req.UserID))
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1327,7 +1330,7 @@ func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-target-group-for-accept", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-target-group-for-accept", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, err
 	}
 	targetGroup.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
@@ -1346,7 +1349,7 @@ func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*
 
 	updatedTargetGroup, err := s.GroupRepository.UpdateGroup(ctx, targetGroup)
 	if err != nil {
-		log.Error("failed-to-persist-target-group-accept", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-persist-target-group-accept", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1370,8 +1373,8 @@ func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*
 
 // RejectInvite rejects a pending invitation from a top-level group.
 func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*RejectInviteResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "reject-invite")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("rejecting-group-invite", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "reject-invite"))
+	logger.Debug("rejecting-group-invite", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1380,7 +1383,7 @@ func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-target-group-for-reject", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-target-group-for-reject", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, err
 	}
 	targetGroup.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
@@ -1395,7 +1398,7 @@ func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*
 
 	updatedTargetGroup, err := s.GroupRepository.UpdateGroup(ctx, targetGroup)
 	if err != nil {
-		log.Error("failed-to-persist-target-group-reject", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-persist-target-group-reject", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1418,9 +1421,9 @@ func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*
 
 // RemoveUserFromAllGroups removes a user from all groups they are a member/owner of.
 func (s *Service) RemoveUserFromAllGroups(ctx context.Context, req *RemoveUserFromAllGroupsRequest) (*RemoveUserFromAllGroupsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "remove-user-from-all-groups")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "remove-user-from-all-groups"))
 	userID := strings.TrimSpace(req.UserID)
-	log.Debug("removing-user-from-all-groups", zap.String("user_id", userID))
+	logger.Debug("removing-user-from-all-groups", zap.String("user_id", userID))
 
 	if userID == "" {
 		return nil, ErrInvalidUserIDProvided
@@ -1482,7 +1485,7 @@ func (s *Service) RemoveUserFromAllGroups(ctx context.Context, req *RemoveUserFr
 		}
 	}
 
-	logger.Info(ctx,
+	logger.Info(
 		"completed-removing-user-from-all-groups",
 		zap.String("user-id", userID),
 		zap.Int("root-groups-count", len(rootGroupIDs)),
@@ -1498,13 +1501,13 @@ func (s *Service) RemoveUserFromAllGroups(ctx context.Context, req *RemoveUserFr
 
 // RemoveMember removes a member from a group
 func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*RemoveMemberResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "remove-member")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("removing-member-from-group", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "remove-member"))
+	logger.Debug("removing-member-from-group", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-group", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, err
 	}
 
@@ -1512,7 +1515,7 @@ func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*
 	group.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
 
 	if group.OwnerID == req.MemberID && !req.ConfirmOwnerRemoval {
-		log.Warn(
+		logger.Warn(
 			"owner-removal-requires-explicit-confirmation",
 			zap.String("group_id", req.GroupID),
 			zap.String("member_id", req.MemberID),
@@ -1522,7 +1525,7 @@ func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*
 
 	// Remove member
 	if group, err = group.RemoveMember(req.MemberID); err != nil {
-		log.Error("failed-to-remove-member", zap.Error(err))
+		logger.Error("failed-to-remove-member", zap.Error(err))
 		return nil, err
 	}
 
@@ -1531,7 +1534,7 @@ func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*
 
 		err = s.GroupRepository.ClearOwnerFromGroup(ctx, req.GroupID, req.MemberID)
 		if err != nil {
-			log.Error("failed-to-clear-owner-from-group-in-repository", zap.Error(err))
+			logger.Error("failed-to-clear-owner-from-group-in-repository", zap.Error(err))
 			return nil, ErrDatabaseError
 		}
 	}
@@ -1539,13 +1542,13 @@ func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*
 	// Persist removal directly so member-array updates do not depend on full-document $set behavior.
 	err = s.GroupRepository.RemoveMemberFromGroup(ctx, req.GroupID, req.MemberID)
 	if err != nil {
-		log.Error("failed-to-remove-member-from-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-remove-member-from-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
 	updatedGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-updated-group-after-member-removal", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-updated-group-after-member-removal", zap.Error(err), zap.String("group_id", req.GroupID))
 		return nil, err
 	}
 
@@ -1554,7 +1557,7 @@ func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*
 	if len(group.Lineage) == 0 {
 		removedCascadeGroupIDs, failedCascadeGroupIDs = s.cascadeRemoveMemberFromDescendants(ctx, req.GroupID, req.MemberID)
 		if len(failedCascadeGroupIDs) > 0 {
-			log.Warn(
+			logger.Warn(
 				"failed-to-remove-member-from-some-descendants",
 				zap.String("root_group_id", req.GroupID),
 				zap.String("member_id", req.MemberID),
@@ -1768,13 +1771,13 @@ func (s *Service) isNonTopLevelGroup(group *UniversalGroup) bool {
 
 // UpdateMemberRole updates a member's role in a group
 func (s *Service) UpdateMemberRole(ctx context.Context, req *UpdateMemberRoleRequest) (*UpdateMemberRoleResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-member-role")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("updating-member-role", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "update-member-role"))
+	logger.Debug("updating-member-role", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err))
+		logger.Error("failed-to-get-group", zap.Error(err))
 		return nil, err
 	}
 
@@ -1785,20 +1788,20 @@ func (s *Service) UpdateMemberRole(ctx context.Context, req *UpdateMemberRoleReq
 
 	// Validate new role against group type configuration
 	if err := s.isValidMemberRole(group.Type, req.NewRole); err != nil {
-		log.Error("invalid-member-role", zap.Error(err), zap.String("new_role", req.NewRole), zap.String("group_type", group.Type))
+		logger.Error("invalid-member-role", zap.Error(err), zap.String("new_role", req.NewRole), zap.String("group_type", group.Type))
 		return nil, err
 	}
 
 	// Update role
 	if group, err = group.UpdateMemberRole(req.MemberID, req.NewRole); err != nil {
-		log.Error("failed-to-update-member-role", zap.Error(err))
+		logger.Error("failed-to-update-member-role", zap.Error(err))
 		return nil, err
 	}
 
 	// Save to repository
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-update-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -1824,6 +1827,9 @@ func (s *Service) UpdateMemberRole(ctx context.Context, req *UpdateMemberRoleReq
 // target group and is assigned the ADMIN role. For nested groups it also ensures the
 // owner exists in the root group to preserve hierarchy membership invariants.
 func (s *Service) ensureOwnerMembershipAndAdminRole(ctx context.Context, group *UniversalGroup, ownerID string) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/group", "ensure-owner-membership-and-admin-role")
+	logger.Debug("handling-ensure-owner-membership-and-admin-role-request")
+
 	ownerID = strings.TrimSpace(ownerID)
 	if ownerID == "" {
 		return nil
@@ -1858,6 +1864,9 @@ func (s *Service) ensureOwnerMembershipAndAdminRole(ctx context.Context, group *
 // ensureRootMembership ensures the member exists in the root group of a nested hierarchy.
 // If absent, it adds the member to the root with an empty role and writes an audit event.
 func (s *Service) ensureRootMembership(ctx context.Context, group *UniversalGroup, memberID, memberType string) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/group", "ensure-root-membership")
+	logger.Debug("handling-ensure-root-membership-request")
+
 	rootGroupID, err := s.getRootGroupID(group.Lineage)
 	if err != nil {
 		return err
@@ -1904,7 +1913,7 @@ func (s *Service) ensureRootMembership(ctx context.Context, group *UniversalGrou
 func (s *Service) cascadeRemoveMemberFromDescendants(ctx context.Context, rootGroupID, memberID string) ([]string, []string) {
 	descendants, err := s.GroupRepository.GetGroupsByLineageAncestor(ctx, rootGroupID)
 	if err != nil {
-		logger.AcquireFrom(ctx).With(zap.String("method", "remove-member")).Warn(
+		logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "remove-member")).Warn(
 			"failed-to-load-descendants-for-member-removal",
 			zap.Error(err),
 			zap.String("root_group_id", rootGroupID),
@@ -2062,13 +2071,13 @@ func (s *Service) isValidMemberRole(groupType, role string) error {
 
 // GetGroupMembers retrieves members of a group with optional filters
 func (s *Service) GetGroupMembers(ctx context.Context, req *GetGroupMembersRequest) (*GetGroupMembersResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-members")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("getting-group-members", zap.String("group_id", req.GroupID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-members"))
+	logger.Debug("getting-group-members", zap.String("group_id", req.GroupID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err))
+		logger.Error("failed-to-get-group", zap.Error(err))
 		return nil, err
 	}
 
@@ -2102,13 +2111,13 @@ func (s *Service) GetGroupMembers(ctx context.Context, req *GetGroupMembersReque
 
 // UpdateOwner updates group ownership
 func (s *Service) UpdateOwner(ctx context.Context, req *UpdateOwnerRequest) (*UpdateOwnerResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-owner")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("updating-group-owner", zap.String("group_id", req.GroupID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "update-owner"))
+	logger.Debug("updating-group-owner", zap.String("group_id", req.GroupID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err))
+		logger.Error("failed-to-get-group", zap.Error(err))
 		return nil, err
 	}
 
@@ -2122,7 +2131,7 @@ func (s *Service) UpdateOwner(ctx context.Context, req *UpdateOwnerRequest) (*Up
 		if nextOwnerID != "" {
 			if len(group.Lineage) > 0 {
 				if err := s.ensureRootMembership(ctx, group, nextOwnerID, MemberTypeUser); err != nil {
-					log.Error("failed-to-ensure-owner-root-membership", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
+					logger.Error("failed-to-ensure-owner-root-membership", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
 					return nil, err
 				}
 			}
@@ -2130,19 +2139,19 @@ func (s *Service) UpdateOwner(ctx context.Context, req *UpdateOwnerRequest) (*Up
 			// Owner must be a member of the target group and hold ADMIN role.
 			if !group.HasMember(nextOwnerID) {
 				if _, err := group.AddMember(nextOwnerID, MemberTypeUser, MemberRoleAdmin); err != nil {
-					log.Error("failed-to-add-owner-to-group", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
+					logger.Error("failed-to-add-owner-to-group", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
 					return nil, err
 				}
 			} else {
 				memberInfo, memberErr := group.GetMemberByID(nextOwnerID)
 				if memberErr != nil {
-					log.Error("failed-to-get-owner-member", zap.Error(memberErr), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
+					logger.Error("failed-to-get-owner-member", zap.Error(memberErr), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
 					return nil, memberErr
 				}
 
 				if memberInfo.Role != MemberRoleAdmin {
 					if _, err := group.UpdateMemberRole(nextOwnerID, MemberRoleAdmin); err != nil {
-						log.Error("failed-to-promote-owner-member-to-admin", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
+						logger.Error("failed-to-promote-owner-member-to-admin", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
 						return nil, err
 					}
 				}
@@ -2163,7 +2172,7 @@ func (s *Service) UpdateOwner(ctx context.Context, req *UpdateOwnerRequest) (*Up
 	// Save to repository
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-update-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2182,13 +2191,13 @@ func (s *Service) UpdateOwner(ctx context.Context, req *UpdateOwnerRequest) (*Up
 
 // ArchiveGroup archives a group
 func (s *Service) ArchiveGroup(ctx context.Context, req *ArchiveGroupRequest) (*ArchiveGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "archive-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("archiving-group", zap.String("id", req.ID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "archive-group"))
+	logger.Debug("archiving-group", zap.String("id", req.ID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err))
+		logger.Error("failed-to-get-group", zap.Error(err))
 		return nil, err
 	}
 
@@ -2198,14 +2207,14 @@ func (s *Service) ArchiveGroup(ctx context.Context, req *ArchiveGroupRequest) (*
 	// Update status to archived
 	_, err = group.UpdateStatus(GroupStatusArchived)
 	if err != nil {
-		log.Error("failed-to-archive-group", zap.Error(err))
+		logger.Error("failed-to-archive-group", zap.Error(err))
 		return nil, err
 	}
 
 	// Save to repository
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-update-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2224,13 +2233,13 @@ func (s *Service) ArchiveGroup(ctx context.Context, req *ArchiveGroupRequest) (*
 
 // RestoreGroup restores an archived group
 func (s *Service) RestoreGroup(ctx context.Context, req *RestoreGroupRequest) (*RestoreGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "restore-group")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("restoring-group", zap.String("id", req.ID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "restore-group"))
+	logger.Debug("restoring-group", zap.String("id", req.ID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err))
+		logger.Error("failed-to-get-group", zap.Error(err))
 		return nil, err
 	}
 
@@ -2240,14 +2249,14 @@ func (s *Service) RestoreGroup(ctx context.Context, req *RestoreGroupRequest) (*
 	// Update status to active
 	_, err = group.UpdateStatus(GroupStatusActive)
 	if err != nil {
-		log.Error("failed-to-restore-group", zap.Error(err))
+		logger.Error("failed-to-restore-group", zap.Error(err))
 		return nil, err
 	}
 
 	// Save to repository
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-update-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2267,9 +2276,9 @@ func (s *Service) RestoreGroup(ctx context.Context, req *RestoreGroupRequest) (*
 // GetGroupsAwaitingAnswerForInvitationsByMemberID retrieves all groups with
 // pending invitations for the provided member ID.
 func (s *Service) GetGroupsAwaitingAnswerForInvitationsByMemberID(ctx context.Context, req *GetGroupsAwaitingAnswerForInvitationsByMemberIDRequest) (*GetGroupsAwaitingAnswerForInvitationsByMemberIDResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups-awaiting-answer-for-invitations-by-member-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-awaiting-answer-for-invitations-by-member-id"))
 	memberID := strings.TrimSpace(req.MemberID)
-	log.Debug("getting-groups-awaiting-answer-for-invitations-by-member-id", zap.String("member_id", memberID))
+	logger.Debug("getting-groups-awaiting-answer-for-invitations-by-member-id", zap.String("member_id", memberID))
 
 	if memberID == "" {
 		return nil, ErrInvalidMemberID
@@ -2277,7 +2286,7 @@ func (s *Service) GetGroupsAwaitingAnswerForInvitationsByMemberID(ctx context.Co
 
 	groups, err := s.GroupRepository.GetGroupsAwaitingAnswerForInvitationsByMemberID(ctx, memberID)
 	if err != nil {
-		log.Error("failed-to-get-groups-awaiting-answer-for-invitations-by-member-id", zap.Error(err), zap.String("member_id", memberID))
+		logger.Error("failed-to-get-groups-awaiting-answer-for-invitations-by-member-id", zap.Error(err), zap.String("member_id", memberID))
 		return nil, ErrDatabaseError
 	}
 
@@ -2311,7 +2320,7 @@ func (s *Service) GetGroupsAwaitingAnswerForInvitationsByMemberID(ctx context.Co
 
 // GetLatestNotificationOverviews returns latest invite notifications for the request user.
 func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *common.GetLatestNotificationOverviewsRequest) (*common.GetLatestNotificationOverviewsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-latest-notification-overviews")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-latest-notification-overviews"))
 	inviteEmail := strings.TrimSpace(req.UserEmail)
 	if inviteEmail == "" {
 		return &common.GetLatestNotificationOverviewsResponse{Overviews: []common.NotificationOverview{}}, nil
@@ -2339,7 +2348,7 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *commo
 		PrefixName: true,
 	})
 	if err != nil {
-		log.Error("failed-to-get-groups-awaiting-invite-answer-for-notifications", zap.Error(err), zap.String("invite_email", inviteEmail))
+		logger.Error("failed-to-get-groups-awaiting-invite-answer-for-notifications", zap.Error(err), zap.String("invite_email", inviteEmail))
 		return nil, err
 	}
 
@@ -2388,8 +2397,8 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *commo
 
 // GetGroupsByMemberID retrieves groups that contain a specific member
 func (s *Service) GetGroupsByMemberID(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups-by-member-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("getting-groups-by-member-id", zap.String("member_id", req.MemberID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-by-member-id"))
+	logger.Debug("getting-groups-by-member-id", zap.String("member_id", req.MemberID))
 
 	// Normalize PerPage to PageSize
 	if req.PerPage > 0 {
@@ -2407,16 +2416,16 @@ func (s *Service) GetGroupsByMemberID(ctx context.Context, req *GetGroupsRequest
 	// Get total count using GetTotalGroups
 	totalGroups, err := s.GroupRepository.GetTotalGroups(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-total-groups-count-by-member-id", zap.Error(err))
+		logger.Error("failed-to-get-total-groups-count-by-member-id", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
 	req.TotalCount = int(totalGroups)
-	log.Debug("handling-get-groups-by-member-id-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", req))
+	logger.Debug("handling-get-groups-by-member-id-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", safeLogValue(req)))
 
 	groups, err := s.GroupRepository.GetGroupsByMemberID(ctx, req.MemberID, req.MemberType, req.Page, req.PageSize)
 	if err != nil {
-		log.Error("failed-to-get-groups-by-member-id", zap.Error(err))
+		logger.Error("failed-to-get-groups-by-member-id", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2447,8 +2456,8 @@ func (s *Service) GetGroupsByMemberID(ctx context.Context, req *GetGroupsRequest
 
 // GetGroupsByLeaderID retrieves groups where user is a leader
 func (s *Service) GetGroupsByLeaderID(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups-by-leader-id")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("getting-groups-by-leader-id", zap.String("owner_id", req.OwnerID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-by-leader-id"))
+	logger.Debug("getting-groups-by-leader-id", zap.String("owner_id", req.OwnerID))
 
 	// Normalize PerPage to PageSize
 	if req.PerPage > 0 {
@@ -2466,18 +2475,18 @@ func (s *Service) GetGroupsByLeaderID(ctx context.Context, req *GetGroupsRequest
 	// Get total count using GetTotalGroups
 	totalGroups, err := s.GroupRepository.GetTotalGroups(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-total-groups-count-by-leader-id", zap.Error(err))
+		logger.Error("failed-to-get-total-groups-count-by-leader-id", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
 	req.TotalCount = int(totalGroups)
-	log.Debug("handling-get-groups-by-leader-id-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", req))
+	logger.Debug("handling-get-groups-by-leader-id-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", safeLogValue(req)))
 
 	leaderID := req.OwnerID
 
 	groups, err := s.GroupRepository.GetGroupsByLeaderID(ctx, leaderID, req.Page, req.PageSize)
 	if err != nil {
-		log.Error("failed-to-get-groups-by-leader-id", zap.Error(err))
+		logger.Error("failed-to-get-groups-by-leader-id", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2508,13 +2517,13 @@ func (s *Service) GetGroupsByLeaderID(ctx context.Context, req *GetGroupsRequest
 
 // GetGroupStats retrieves statistics for a group
 func (s *Service) GetGroupStats(ctx context.Context, groupID string) (*GetGroupStatsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-group-stats")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("getting-group-stats", zap.String("group_id", groupID))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-stats"))
+	logger.Debug("getting-group-stats", zap.String("group_id", groupID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err))
+		logger.Error("failed-to-get-group", zap.Error(err))
 		return nil, err
 	}
 
@@ -2536,11 +2545,11 @@ func (s *Service) GetGroupStats(ctx context.Context, groupID string) (*GetGroupS
 
 // GetGroupsStats retrieves aggregated statistics across all groups.
 func (s *Service) GetGroupsStats(ctx context.Context, _ *GetGroupsStatsRequest) (*GetGroupsStatsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-groups-stats")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-stats"))
 
 	stats, err := s.GroupRepository.GetGroupsStatsCounts(ctx)
 	if err != nil {
-		log.Error("failed-to-get-groups-stats-counts", zap.Error(err))
+		logger.Error("failed-to-get-groups-stats-counts", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2554,6 +2563,9 @@ func (s *Service) GetGroupsStats(ctx context.Context, _ *GetGroupsStatsRequest) 
 // without persisting anything.  It mirrors the name-resolution logic inside
 // CreateGroup so that front-end forms can show live feedback to the user.
 func (s *Service) ValidateGroupName(ctx context.Context, req *ValidateGroupNameRequest) (*ValidateGroupNameResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/group", "validate-group-name")
+	logger.Debug("handling-validate-group-name-request")
+
 	trimmedRawName := strings.TrimSpace(req.Name)
 	trimmedParentGroupID := strings.TrimSpace(req.ParentGroupID)
 	baseName, err := toolbox.StringConvertToKebabCase(trimmedRawName)
@@ -2647,22 +2659,22 @@ func (s *Service) GetGroupsConfig(_ context.Context, _ *GetGroupsConfigRequest) 
 // RepairInvalidMembers repairs groups that contain members with empty or null IDs
 // and returns affected group IDs before and after the repair.
 func (s *Service) RepairInvalidMembers(ctx context.Context) (*RepairInvalidMembersResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "repair-invalid-members")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "repair-invalid-members"))
 
 	beforeAffectedGroupIDs, err := s.GroupRepository.GetGroupIDsWithInvalidMembers(ctx)
 	if err != nil {
-		log.Error("failed-to-get-groups-with-invalid-members-before-repair", zap.Error(err))
+		logger.Error("failed-to-get-groups-with-invalid-members-before-repair", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
 	if err := s.GroupRepository.RepairInvalidMembers(ctx); err != nil {
-		log.Error("failed-to-repair-invalid-members", zap.Error(err))
+		logger.Error("failed-to-repair-invalid-members", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
 	afterAffectedGroupIDs, err := s.GroupRepository.GetGroupIDsWithInvalidMembers(ctx)
 	if err != nil {
-		log.Error("failed-to-get-groups-with-invalid-members-after-repair", zap.Error(err))
+		logger.Error("failed-to-get-groups-with-invalid-members-after-repair", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2703,13 +2715,13 @@ func (s *Service) RepairInvalidMembers(ctx context.Context) (*RepairInvalidMembe
 
 // SetGroupExtension sets an extension field value
 func (s *Service) SetGroupExtension(ctx context.Context, groupID, key string, value interface{}) (*UpdateGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "set-group-extension")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("setting-group-extension", zap.String("group_id", groupID), zap.String("key", key))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "set-group-extension"))
+	logger.Debug("setting-group-extension", zap.String("group_id", groupID), zap.String("key", key))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		log.Error("failed-to-get-group", zap.Error(err))
+		logger.Error("failed-to-get-group", zap.Error(err))
 		return nil, err
 	}
 
@@ -2722,7 +2734,7 @@ func (s *Service) SetGroupExtension(ctx context.Context, groupID, key string, va
 	// Save to repository
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group-in-repository", zap.Error(err))
+		logger.Error("failed-to-update-group-in-repository", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2731,8 +2743,8 @@ func (s *Service) SetGroupExtension(ctx context.Context, groupID, key string, va
 
 // SearchGroupsByExtension searches for groups by extension field value
 func (s *Service) SearchGroupsByExtension(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "search-groups-by-extension")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("searching-groups-by-extension", zap.Any("extension_filters", req.ExtensionFilters))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "search-groups-by-extension"))
+	logger.Debug("searching-groups-by-extension", zap.Any("extension_filters", safeLogValue(req.ExtensionFilters)))
 
 	// Normalize PerPage to PageSize
 	if req.PerPage > 0 {
@@ -2750,12 +2762,12 @@ func (s *Service) SearchGroupsByExtension(ctx context.Context, req *GetGroupsReq
 	// Get total count using GetTotalGroups
 	totalGroups, err := s.GroupRepository.GetTotalGroups(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-total-groups-count-by-extension", zap.Error(err))
+		logger.Error("failed-to-get-total-groups-count-by-extension", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
 	req.TotalCount = int(totalGroups)
-	log.Debug("handling-search-groups-by-extension-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", req))
+	logger.Debug("handling-search-groups-by-extension-total-groups-found", zap.Int64("total", totalGroups), zap.Any("request", safeLogValue(req)))
 
 	// Extract first extension filter for backward compatibility with repository method
 	var key string
@@ -2768,7 +2780,7 @@ func (s *Service) SearchGroupsByExtension(ctx context.Context, req *GetGroupsReq
 
 	groups, err := s.GroupRepository.SearchGroupsByExtension(ctx, key, value, req.Page, req.PageSize)
 	if err != nil {
-		log.Error("failed-to-search-groups-by-extension", zap.Error(err))
+		logger.Error("failed-to-search-groups-by-extension", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -2799,12 +2811,12 @@ func (s *Service) SearchGroupsByExtension(ctx context.Context, req *GetGroupsReq
 
 // BulkUpdateGroupsStatus updates status for multiple groups
 func (s *Service) BulkUpdateGroupsStatus(ctx context.Context, groupIDs []string, status string) error {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "bulk-update-groups-status")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("bulk-updating-group-status", zap.Int("count", len(groupIDs)), zap.String("status", status))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "bulk-update-groups-status"))
+	logger.Debug("bulk-updating-group-status", zap.Int("count", len(groupIDs)), zap.String("status", status))
 
 	err := s.GroupRepository.BulkUpdateGroupsStatus(ctx, groupIDs, status)
 	if err != nil {
-		log.Error("failed-to-bulk-update-groups-status", zap.Error(err))
+		logger.Error("failed-to-bulk-update-groups-status", zap.Error(err))
 		return ErrDatabaseError
 	}
 
@@ -2827,22 +2839,22 @@ func (s *Service) BulkUpdateGroupsStatus(ctx context.Context, groupIDs []string,
 // GetParentGroupsWithAutoJoinForEmail retrieves all parent groups that have
 // auto-join or auto-invite enabled for the email domain matching the provided email.
 func (s *Service) GetParentGroupsWithAutoJoinForEmail(ctx context.Context, email string) (*GetParentGroupsWithAutoJoinForEmailResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-parent-groups-with-auto-join-for-email")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-parent-groups-with-auto-join-for-email"))
 
 	trimmedEmail := strings.TrimSpace(email)
 	if trimmedEmail == "" {
-		log.Error("email-is-required")
+		logger.Error("email-is-required")
 		return nil, ErrGroupEmailIsRequired
 	}
 
 	// Extract domain from email
 	emailDomain := extractEmailDomain(trimmedEmail)
 	if emailDomain == "" {
-		log.Error("invalid-email-format", zap.String("email", trimmedEmail))
+		logger.Error("invalid-email-format", zap.String("email", trimmedEmail))
 		return nil, ErrGroupInvalidEmailFormat
 	}
 
-	log.Debug("querying-groups-with-auto-join", zap.String("email_domain", emailDomain))
+	logger.Debug("querying-groups-with-auto-join", zap.String("email_domain", emailDomain))
 
 	// Get all groups (this is a broad query; in production you might optimize this)
 	// by adding repository support for filtered queries on auto-join settings
@@ -2850,7 +2862,7 @@ func (s *Service) GetParentGroupsWithAutoJoinForEmail(ctx context.Context, email
 		Statuses: []string{GroupStatusActive},
 	})
 	if err != nil {
-		log.Error("failed-to-retrieve-groups", zap.Error(err))
+		logger.Error("failed-to-retrieve-groups", zap.Error(err))
 		return nil, err
 	}
 
@@ -2875,7 +2887,7 @@ func (s *Service) GetParentGroupsWithAutoJoinForEmail(ctx context.Context, email
 		}
 	}
 
-	log.Debug("found-matching-groups-with-auto-join", zap.Int("count", len(matchedGroups)))
+	logger.Debug("found-matching-groups-with-auto-join", zap.Int("count", len(matchedGroups)))
 
 	return &GetParentGroupsWithAutoJoinForEmailResponse{
 		Groups: matchedGroups,
@@ -2884,10 +2896,10 @@ func (s *Service) GetParentGroupsWithAutoJoinForEmail(ctx context.Context, email
 
 // EnableGroupAutoJoinByEmailDomain enables auto-join for a group with specified email domains.
 func (s *Service) EnableGroupAutoJoinByEmailDomain(ctx context.Context, req *EnableGroupAutoJoinByEmailDomainRequest) (*EnableGroupAutoJoinByEmailDomainResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "enable-group-auto-join-by-email-domain")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "enable-group-auto-join-by-email-domain"))
 
 	if req == nil || strings.TrimSpace(req.GroupID) == "" {
-		log.Error("group-id-is-required")
+		logger.Error("group-id-is-required")
 		return nil, ErrInvalidGroupID
 	}
 
@@ -2896,12 +2908,12 @@ func (s *Service) EnableGroupAutoJoinByEmailDomain(ctx context.Context, req *Ena
 	// Retrieve the group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		log.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
 		return nil, err
 	}
 
 	if group == nil {
-		log.Error("group-not-found", zap.String("group_id", groupID))
+		logger.Error("group-not-found", zap.String("group_id", groupID))
 		return nil, ErrResourceNotFound
 	}
 
@@ -2930,14 +2942,14 @@ func (s *Service) EnableGroupAutoJoinByEmailDomain(ctx context.Context, req *Ena
 
 	// Validate settings
 	if err := group.Settings.ValidateAutoActionConfig(); err != nil {
-		log.Error("validation-failed", zap.Error(err))
+		logger.Error("validation-failed", zap.Error(err))
 		return nil, err
 	}
 
 	// Update the group
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -2955,7 +2967,7 @@ func (s *Service) EnableGroupAutoJoinByEmailDomain(ctx context.Context, req *Ena
 		})
 	}
 
-	log.Debug("successfully-enabled-auto-join", zap.String("group_id", groupID))
+	logger.Debug("successfully-enabled-auto-join", zap.String("group_id", groupID))
 
 	return &EnableGroupAutoJoinByEmailDomainResponse{
 		Group: updatedGroup,
@@ -2964,10 +2976,10 @@ func (s *Service) EnableGroupAutoJoinByEmailDomain(ctx context.Context, req *Ena
 
 // DisableGroupAutoJoinByEmailDomain disables auto-join for a group.
 func (s *Service) DisableGroupAutoJoinByEmailDomain(ctx context.Context, req *DisableGroupAutoJoinByEmailDomainRequest) (*DisableGroupAutoJoinByEmailDomainResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "disable-group-auto-join-by-email-domain")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "disable-group-auto-join-by-email-domain"))
 
 	if req == nil || strings.TrimSpace(req.GroupID) == "" {
-		log.Error("group-id-is-required")
+		logger.Error("group-id-is-required")
 		return nil, ErrInvalidGroupID
 	}
 
@@ -2976,12 +2988,12 @@ func (s *Service) DisableGroupAutoJoinByEmailDomain(ctx context.Context, req *Di
 	// Retrieve the group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		log.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
 		return nil, err
 	}
 
 	if group == nil {
-		log.Error("group-not-found", zap.String("group_id", groupID))
+		logger.Error("group-not-found", zap.String("group_id", groupID))
 		return nil, ErrResourceNotFound
 	}
 
@@ -2998,7 +3010,7 @@ func (s *Service) DisableGroupAutoJoinByEmailDomain(ctx context.Context, req *Di
 	// Update the group
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -3012,7 +3024,7 @@ func (s *Service) DisableGroupAutoJoinByEmailDomain(ctx context.Context, req *Di
 		})
 	}
 
-	log.Debug("successfully-disabled-auto-join", zap.String("group_id", groupID))
+	logger.Debug("successfully-disabled-auto-join", zap.String("group_id", groupID))
 
 	return &DisableGroupAutoJoinByEmailDomainResponse{
 		Group: updatedGroup,
@@ -3021,10 +3033,10 @@ func (s *Service) DisableGroupAutoJoinByEmailDomain(ctx context.Context, req *Di
 
 // EnableGroupAutoInviteByEmailDomain enables auto-invite for a group with specified email domains.
 func (s *Service) EnableGroupAutoInviteByEmailDomain(ctx context.Context, req *EnableGroupAutoInviteByEmailDomainRequest) (*EnableGroupAutoInviteByEmailDomainResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "enable-group-auto-invite-by-email-domain")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "enable-group-auto-invite-by-email-domain"))
 
 	if req == nil || strings.TrimSpace(req.GroupID) == "" {
-		log.Error("group-id-is-required")
+		logger.Error("group-id-is-required")
 		return nil, ErrInvalidGroupID
 	}
 
@@ -3033,12 +3045,12 @@ func (s *Service) EnableGroupAutoInviteByEmailDomain(ctx context.Context, req *E
 	// Retrieve the group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		log.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
 		return nil, err
 	}
 
 	if group == nil {
-		log.Error("group-not-found", zap.String("group_id", groupID))
+		logger.Error("group-not-found", zap.String("group_id", groupID))
 		return nil, ErrResourceNotFound
 	}
 
@@ -3067,14 +3079,14 @@ func (s *Service) EnableGroupAutoInviteByEmailDomain(ctx context.Context, req *E
 
 	// Validate settings
 	if err := group.Settings.ValidateAutoActionConfig(); err != nil {
-		log.Error("validation-failed", zap.Error(err))
+		logger.Error("validation-failed", zap.Error(err))
 		return nil, err
 	}
 
 	// Update the group
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -3092,7 +3104,7 @@ func (s *Service) EnableGroupAutoInviteByEmailDomain(ctx context.Context, req *E
 		})
 	}
 
-	log.Debug("successfully-enabled-auto-invite", zap.String("group_id", groupID))
+	logger.Debug("successfully-enabled-auto-invite", zap.String("group_id", groupID))
 
 	return &EnableGroupAutoInviteByEmailDomainResponse{
 		Group: updatedGroup,
@@ -3101,10 +3113,10 @@ func (s *Service) EnableGroupAutoInviteByEmailDomain(ctx context.Context, req *E
 
 // DisableGroupAutoInviteByEmailDomain disables auto-invite for a group.
 func (s *Service) DisableGroupAutoInviteByEmailDomain(ctx context.Context, req *DisableGroupAutoInviteByEmailDomainRequest) (*DisableGroupAutoInviteByEmailDomainResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "disable-group-auto-invite-by-email-domain")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "disable-group-auto-invite-by-email-domain"))
 
 	if req == nil || strings.TrimSpace(req.GroupID) == "" {
-		log.Error("group-id-is-required")
+		logger.Error("group-id-is-required")
 		return nil, ErrInvalidGroupID
 	}
 
@@ -3113,12 +3125,12 @@ func (s *Service) DisableGroupAutoInviteByEmailDomain(ctx context.Context, req *
 	// Retrieve the group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		log.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
 		return nil, err
 	}
 
 	if group == nil {
-		log.Error("group-not-found", zap.String("group_id", groupID))
+		logger.Error("group-not-found", zap.String("group_id", groupID))
 		return nil, ErrResourceNotFound
 	}
 
@@ -3135,7 +3147,7 @@ func (s *Service) DisableGroupAutoInviteByEmailDomain(ctx context.Context, req *
 	// Update the group
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		log.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -3149,7 +3161,7 @@ func (s *Service) DisableGroupAutoInviteByEmailDomain(ctx context.Context, req *
 		})
 	}
 
-	log.Debug("successfully-disabled-auto-invite", zap.String("group_id", groupID))
+	logger.Debug("successfully-disabled-auto-invite", zap.String("group_id", groupID))
 
 	return &DisableGroupAutoInviteByEmailDomainResponse{
 		Group: updatedGroup,

--- a/external/group/service.go
+++ b/external/group/service.go
@@ -137,7 +137,7 @@ func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Cr
 	if req.ParentGroupID != "" {
 		parentGroupResult, parentErr := s.GroupRepository.GetGroupByID(ctx, req.ParentGroupID)
 		if parentErr != nil {
-			logger.Error("failed-to-get-parent-group", zap.Error(parentErr), zap.String("parent_group_id", req.ParentGroupID))
+			logger.Error("failed-to-get-parent-group", zap.Error(parentErr), zap.String("parent-group-id", req.ParentGroupID))
 			return nil, parentErr
 		}
 		parentGroup = parentGroupResult
@@ -206,14 +206,14 @@ func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Cr
 	// Add initial members if provided
 	for _, memberReq := range req.InitialMembers {
 		if _, err := group.AddMember(memberReq.ID, memberReq.Type, memberReq.Role); err != nil {
-			logger.Error("failed-to-add-initial-member", zap.Error(err), zap.String("member_id", memberReq.ID))
+			logger.Error("failed-to-add-initial-member", zap.Error(err), zap.String("member-id", memberReq.ID))
 			return nil, err
 		}
 	}
 
 	if group.OwnerID != "" {
 		if err := s.ensureOwnerMembershipAndAdminRole(ctx, group, group.OwnerID); err != nil {
-			logger.Error("failed-to-ensure-owner-membership-on-create", zap.Error(err), zap.String("owner_id", group.OwnerID))
+			logger.Error("failed-to-ensure-owner-membership-on-create", zap.Error(err), zap.String("owner-id", group.OwnerID))
 			return nil, err
 		}
 	}
@@ -228,9 +228,9 @@ func (s *Service) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Cr
 		if !s.Config.CanHaveChildType(parentGroup.Type, group.Type) {
 			logger.Error(
 				"invalid-parent-child-group-relation",
-				zap.String("parent_group_id", parentGroup.ID),
-				zap.String("parent_group_type", parentGroup.Type),
-				zap.String("child_group_type", group.Type),
+				zap.String("parent-group-id", parentGroup.ID),
+				zap.String("parent-group-type", parentGroup.Type),
+				zap.String("child-group-type", group.Type),
 			)
 			return nil, ErrInvalidParentChildRelation
 		}
@@ -284,7 +284,7 @@ func (s *Service) GetGroupByID(ctx context.Context, req *GetGroupByIDRequest) (*
 func (s *Service) GetGroupLineage(ctx context.Context, req *GetGroupLineageRequest) (*GetGroupLineageResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-lineage"))
 	asUserID := strings.TrimSpace(req.AsUserID)
-	logger.Debug("getting-group-lineage", zap.String("id", req.ID), zap.String("as_user_id", asUserID))
+	logger.Debug("getting-group-lineage", zap.String("id", req.ID), zap.String("as-user-id", asUserID))
 
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
 	if err != nil {
@@ -300,7 +300,7 @@ func (s *Service) GetGroupLineage(ctx context.Context, req *GetGroupLineageReque
 	for _, groupID := range lineageIDs {
 		lineageGroup, lineageErr := s.GroupRepository.GetGroupByID(ctx, groupID)
 		if lineageErr != nil {
-			logger.Warn("failed-to-get-lineage-group", zap.Error(lineageErr), zap.String("lineage_group_id", groupID))
+			logger.Warn("failed-to-get-lineage-group", zap.Error(lineageErr), zap.String("lineage-group-id", groupID))
 			continue
 		}
 
@@ -333,9 +333,9 @@ func (s *Service) GetGroupDescendants(ctx context.Context, req *GetGroupDescenda
 	logger.Debug(
 		"getting-group-descendants",
 		zap.String("id", req.ID),
-		zap.Int("max_depth", req.MaxDepth),
-		zap.Bool("include_self", req.IncludeSelf),
-		zap.String("as_user_id", asUserID),
+		zap.Int("max-depth", req.MaxDepth),
+		zap.Bool("include-self", req.IncludeSelf),
+		zap.String("as-user-id", asUserID),
 	)
 
 	if req.MaxDepth < 0 {
@@ -584,11 +584,11 @@ func (s *Service) groupVisibility(group *UniversalGroup) string {
 // GetGroupByNanoID retrieves a group by nano ID.
 func (s *Service) GetGroupByNanoID(ctx context.Context, req *GetGroupByNanoIDRequest) (*GetGroupByNanoIDResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-by-nano-id"))
-	logger.Debug("getting-group-by-nano-id", zap.String("nano_id", req.NanoID))
+	logger.Debug("getting-group-by-nano-id", zap.String("nano-id", req.NanoID))
 
 	group, err := s.GroupRepository.GetGroupByNanoID(ctx, req.NanoID)
 	if err != nil {
-		logger.Error("failed-to-get-group-by-nano-id", zap.Error(err), zap.String("nano_id", req.NanoID))
+		logger.Error("failed-to-get-group-by-nano-id", zap.Error(err), zap.String("nano-id", req.NanoID))
 		return nil, err
 	}
 
@@ -790,7 +790,7 @@ func (s *Service) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*Up
 // DeleteGroup deletes a group
 func (s *Service) DeleteGroup(ctx context.Context, req *DeleteGroupRequest) (*DeleteGroupResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "delete-group"))
-	logger.Debug("deleting-group", zap.String("id", req.ID), zap.Bool("hard_delete", req.HardDelete))
+	logger.Debug("deleting-group", zap.String("id", req.ID), zap.Bool("hard-delete", req.HardDelete))
 
 	// Verify group exists and capture the root snapshot.
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.ID)
@@ -835,7 +835,7 @@ func (s *Service) DeleteGroup(ctx context.Context, req *DeleteGroupRequest) (*De
 		}
 
 		if err != nil {
-			logger.Error("failed-to-delete-group", zap.String("group_id", groupSnapshot.ID), zap.Error(err))
+			logger.Error("failed-to-delete-group", zap.String("group-id", groupSnapshot.ID), zap.Error(err))
 			return nil, ErrDatabaseError
 		}
 
@@ -872,7 +872,7 @@ func (s *Service) DeleteGroup(ctx context.Context, req *DeleteGroupRequest) (*De
 // GetGroups retrieves groups with filters and pagination
 func (s *Service) GetGroups(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups"))
-	logger.Debug("getting-groups", zap.Int("page", req.Page), zap.Int("page_size", req.PageSize))
+	logger.Debug("getting-groups", zap.Int("page", req.Page), zap.Int("page-size", req.PageSize))
 
 	// Normalize PerPage to PageSize
 	if req.PerPage > 0 {
@@ -943,7 +943,7 @@ func (s *Service) GetGroups(ctx context.Context, req *GetGroupsRequest) (*GetGro
 func (s *Service) GetGroupsByUserID(ctx context.Context, req *GetGroupsByUserIDRequest) (*GetGroupsByUserIDResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-by-user-id"))
 	userID := strings.TrimSpace(req.UserID)
-	logger.Debug("getting-groups-by-user-id", zap.String("user_id", userID), zap.Bool("include_descendants", req.IncludeDescendants))
+	logger.Debug("getting-groups-by-user-id", zap.String("user-id", userID), zap.Bool("include-descendants", req.IncludeDescendants))
 
 	if userID == "" {
 		return nil, ErrInvalidQueryParam
@@ -951,7 +951,7 @@ func (s *Service) GetGroupsByUserID(ctx context.Context, req *GetGroupsByUserIDR
 
 	groups, err := s.GroupRepository.GetGroupsByReferencedUserID(ctx, userID)
 	if err != nil {
-		logger.Error("failed-to-get-groups-by-user-id", zap.Error(err), zap.String("user_id", userID))
+		logger.Error("failed-to-get-groups-by-user-id", zap.Error(err), zap.String("user-id", userID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1006,7 +1006,7 @@ func (s *Service) GetGroupsByUserID(ctx context.Context, req *GetGroupsByUserIDR
 		if descendantsErr != nil || descendantsResp == nil {
 			logger.Warn(
 				"failed-to-get-root-group-descendants",
-				zap.String("root_group_id", rootGroupID),
+				zap.String("root-group-id", rootGroupID),
 				zap.Error(descendantsErr),
 			)
 			continue
@@ -1074,7 +1074,7 @@ func (s *Service) getPrefixName(ctx context.Context, g *UniversalGroup, prefixNa
 func (s *Service) GetUserGroupAccessMap(ctx context.Context, userID string) (map[string]UserGroupAccessSummary, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-user-group-access-map"))
 	trimmedUserID := strings.TrimSpace(userID)
-	logger.Debug("building-user-group-access-map", zap.String("user_id", trimmedUserID))
+	logger.Debug("building-user-group-access-map", zap.String("user-id", trimmedUserID))
 
 	if trimmedUserID == "" {
 		return nil, ErrInvalidUserIDProvided
@@ -1085,7 +1085,7 @@ func (s *Service) GetUserGroupAccessMap(ctx context.Context, userID string) (map
 		IncludeDescendants: false,
 	})
 	if err != nil {
-		logger.Error("failed-to-get-user-groups", zap.Error(err), zap.String("user_id", trimmedUserID))
+		logger.Error("failed-to-get-user-groups", zap.Error(err), zap.String("user-id", trimmedUserID))
 		return nil, err
 	}
 
@@ -1118,7 +1118,7 @@ func (s *Service) GetUserGroupAccessMap(ctx context.Context, userID string) (map
 		if descendantsErr != nil {
 			logger.Warn(
 				"failed-to-get-admin-group-descendants",
-				zap.String("admin_group_id", adminGroupID),
+				zap.String("admin-group-id", adminGroupID),
 				zap.Error(descendantsErr),
 			)
 			continue
@@ -1144,12 +1144,12 @@ func (s *Service) GetUserGroupAccessMap(ctx context.Context, userID string) (map
 // AddMember adds a member to a group
 func (s *Service) AddMember(ctx context.Context, req *AddMemberRequest) (*AddMemberResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "add-member"))
-	logger.Debug("adding-member-to-group", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+	logger.Debug("adding-member-to-group", zap.String("group-id", req.GroupID), zap.String("member-id", req.MemberID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		logger.Error("failed-to-get-group", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-group", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, err
 	}
 
@@ -1158,13 +1158,13 @@ func (s *Service) AddMember(ctx context.Context, req *AddMemberRequest) (*AddMem
 
 	// Validate role against group type configuration
 	if err := s.isValidMemberRole(group.Type, req.Role); err != nil {
-		logger.Error("invalid-member-role", zap.Error(err), zap.String("role", req.Role), zap.String("group_type", group.Type))
+		logger.Error("invalid-member-role", zap.Error(err), zap.String("role", req.Role), zap.String("group-type", group.Type))
 		return nil, err
 	}
 
 	if len(group.Lineage) > 0 {
 		if err := s.ensureRootMembership(ctx, group, req.MemberID, req.Type); err != nil {
-			logger.Error("failed-to-ensure-root-membership", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+			logger.Error("failed-to-ensure-root-membership", zap.Error(err), zap.String("group-id", req.GroupID), zap.String("member-id", req.MemberID))
 			return nil, err
 		}
 	}
@@ -1206,7 +1206,7 @@ func (s *Service) AddMember(ctx context.Context, req *AddMemberRequest) (*AddMem
 // InviteUser adds a pending invitation for an email address to a top-level group.
 func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*InviteUserResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "invite-user"))
-	logger.Debug("inviting-user-to-group", append([]zap.Field{zap.String("group_id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
+	logger.Debug("inviting-user-to-group", append([]zap.Field{zap.String("group-id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1215,7 +1215,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		logger.Error("failed-to-get-target-group-for-invite", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-target-group-for-invite", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, err
 	}
 	targetGroup.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
@@ -1232,7 +1232,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 
 	targetAdded, err := s.addPendingInviteMember(targetGroup, inviteEmail, req.Role, req.InvitedByID)
 	if err != nil {
-		logger.Error("failed-to-add-pending-invite-to-target-group", append([]zap.Field{zap.Error(err), zap.String("group_id", req.GroupID)}, emailLogFields("invite-email", inviteEmail)...)...)
+		logger.Error("failed-to-add-pending-invite-to-target-group", append([]zap.Field{zap.Error(err), zap.String("group-id", req.GroupID)}, emailLogFields("invite-email", inviteEmail)...)...)
 		return nil, err
 	}
 	if !targetAdded {
@@ -1241,7 +1241,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 
 	updatedTargetGroup, err := s.GroupRepository.UpdateGroup(ctx, targetGroup)
 	if err != nil {
-		logger.Error("failed-to-persist-target-group-invite", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-persist-target-group-invite", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1268,7 +1268,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 // UninviteUser removes a pending invitation from a top-level group.
 func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*UninviteUserResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "uninvite-user"))
-	logger.Debug("uninviting-user-from-group", append([]zap.Field{zap.String("group_id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
+	logger.Debug("uninviting-user-from-group", append([]zap.Field{zap.String("group-id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1277,7 +1277,7 @@ func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		logger.Error("failed-to-get-target-group-for-uninvite", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-target-group-for-uninvite", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, err
 	}
 	targetGroup.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
@@ -1292,7 +1292,7 @@ func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*
 
 	updatedTargetGroup, err := s.GroupRepository.UpdateGroup(ctx, targetGroup)
 	if err != nil {
-		logger.Error("failed-to-persist-target-group-uninvite", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-persist-target-group-uninvite", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1316,7 +1316,7 @@ func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*
 // AcceptInvite accepts a pending invitation for a user and materialises membership.
 func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*AcceptInviteResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "accept-invite"))
-	logger.Debug("accepting-group-invite", append([]zap.Field{zap.String("group_id", req.GroupID), zap.String("user_id", req.UserID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
+	logger.Debug("accepting-group-invite", append([]zap.Field{zap.String("group-id", req.GroupID), zap.String("user-id", req.UserID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1330,7 +1330,7 @@ func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		logger.Error("failed-to-get-target-group-for-accept", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-target-group-for-accept", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, err
 	}
 	targetGroup.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
@@ -1349,7 +1349,7 @@ func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*
 
 	updatedTargetGroup, err := s.GroupRepository.UpdateGroup(ctx, targetGroup)
 	if err != nil {
-		logger.Error("failed-to-persist-target-group-accept", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-persist-target-group-accept", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1374,7 +1374,7 @@ func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*
 // RejectInvite rejects a pending invitation from a top-level group.
 func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*RejectInviteResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "reject-invite"))
-	logger.Debug("rejecting-group-invite", append([]zap.Field{zap.String("group_id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
+	logger.Debug("rejecting-group-invite", append([]zap.Field{zap.String("group-id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1383,7 +1383,7 @@ func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*
 
 	targetGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		logger.Error("failed-to-get-target-group-for-reject", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-target-group-for-reject", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, err
 	}
 	targetGroup.SetDependencies(s.Config, s.IDGenerator, s.TimeProvider, s.StringUtils)
@@ -1398,7 +1398,7 @@ func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*
 
 	updatedTargetGroup, err := s.GroupRepository.UpdateGroup(ctx, targetGroup)
 	if err != nil {
-		logger.Error("failed-to-persist-target-group-reject", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-persist-target-group-reject", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, ErrDatabaseError
 	}
 
@@ -1423,7 +1423,7 @@ func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*
 func (s *Service) RemoveUserFromAllGroups(ctx context.Context, req *RemoveUserFromAllGroupsRequest) (*RemoveUserFromAllGroupsResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "remove-user-from-all-groups"))
 	userID := strings.TrimSpace(req.UserID)
-	logger.Debug("removing-user-from-all-groups", zap.String("user_id", userID))
+	logger.Debug("removing-user-from-all-groups", zap.String("user-id", userID))
 
 	if userID == "" {
 		return nil, ErrInvalidUserIDProvided
@@ -1502,12 +1502,12 @@ func (s *Service) RemoveUserFromAllGroups(ctx context.Context, req *RemoveUserFr
 // RemoveMember removes a member from a group
 func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*RemoveMemberResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "remove-member"))
-	logger.Debug("removing-member-from-group", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+	logger.Debug("removing-member-from-group", zap.String("group-id", req.GroupID), zap.String("member-id", req.MemberID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		logger.Error("failed-to-get-group", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-group", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, err
 	}
 
@@ -1517,8 +1517,8 @@ func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*
 	if group.OwnerID == req.MemberID && !req.ConfirmOwnerRemoval {
 		logger.Warn(
 			"owner-removal-requires-explicit-confirmation",
-			zap.String("group_id", req.GroupID),
-			zap.String("member_id", req.MemberID),
+			zap.String("group-id", req.GroupID),
+			zap.String("member-id", req.MemberID),
 		)
 		return nil, ErrOwnerRemovalRequiresConfirm
 	}
@@ -1548,7 +1548,7 @@ func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*
 
 	updatedGroup, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
 	if err != nil {
-		logger.Error("failed-to-get-updated-group-after-member-removal", zap.Error(err), zap.String("group_id", req.GroupID))
+		logger.Error("failed-to-get-updated-group-after-member-removal", zap.Error(err), zap.String("group-id", req.GroupID))
 		return nil, err
 	}
 
@@ -1559,9 +1559,9 @@ func (s *Service) RemoveMember(ctx context.Context, req *RemoveMemberRequest) (*
 		if len(failedCascadeGroupIDs) > 0 {
 			logger.Warn(
 				"failed-to-remove-member-from-some-descendants",
-				zap.String("root_group_id", req.GroupID),
-				zap.String("member_id", req.MemberID),
-				zap.Strings("failed_descendant_group_ids", failedCascadeGroupIDs),
+				zap.String("root-group-id", req.GroupID),
+				zap.String("member-id", req.MemberID),
+				zap.Strings("failed-descendant-group-ids", failedCascadeGroupIDs),
 			)
 		}
 	}
@@ -1772,7 +1772,7 @@ func (s *Service) isNonTopLevelGroup(group *UniversalGroup) bool {
 // UpdateMemberRole updates a member's role in a group
 func (s *Service) UpdateMemberRole(ctx context.Context, req *UpdateMemberRoleRequest) (*UpdateMemberRoleResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "update-member-role"))
-	logger.Debug("updating-member-role", zap.String("group_id", req.GroupID), zap.String("member_id", req.MemberID))
+	logger.Debug("updating-member-role", zap.String("group-id", req.GroupID), zap.String("member-id", req.MemberID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
@@ -1788,7 +1788,7 @@ func (s *Service) UpdateMemberRole(ctx context.Context, req *UpdateMemberRoleReq
 
 	// Validate new role against group type configuration
 	if err := s.isValidMemberRole(group.Type, req.NewRole); err != nil {
-		logger.Error("invalid-member-role", zap.Error(err), zap.String("new_role", req.NewRole), zap.String("group_type", group.Type))
+		logger.Error("invalid-member-role", zap.Error(err), zap.String("new-role", req.NewRole), zap.String("group-type", group.Type))
 		return nil, err
 	}
 
@@ -1916,8 +1916,8 @@ func (s *Service) cascadeRemoveMemberFromDescendants(ctx context.Context, rootGr
 		logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "remove-member")).Warn(
 			"failed-to-load-descendants-for-member-removal",
 			zap.Error(err),
-			zap.String("root_group_id", rootGroupID),
-			zap.String("member_id", memberID),
+			zap.String("root-group-id", rootGroupID),
+			zap.String("member-id", memberID),
 		)
 		return []string{}, []string{rootGroupID}
 	}
@@ -2072,7 +2072,7 @@ func (s *Service) isValidMemberRole(groupType, role string) error {
 // GetGroupMembers retrieves members of a group with optional filters
 func (s *Service) GetGroupMembers(ctx context.Context, req *GetGroupMembersRequest) (*GetGroupMembersResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-members"))
-	logger.Debug("getting-group-members", zap.String("group_id", req.GroupID))
+	logger.Debug("getting-group-members", zap.String("group-id", req.GroupID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
@@ -2112,7 +2112,7 @@ func (s *Service) GetGroupMembers(ctx context.Context, req *GetGroupMembersReque
 // UpdateOwner updates group ownership
 func (s *Service) UpdateOwner(ctx context.Context, req *UpdateOwnerRequest) (*UpdateOwnerResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "update-owner"))
-	logger.Debug("updating-group-owner", zap.String("group_id", req.GroupID))
+	logger.Debug("updating-group-owner", zap.String("group-id", req.GroupID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, req.GroupID)
@@ -2131,7 +2131,7 @@ func (s *Service) UpdateOwner(ctx context.Context, req *UpdateOwnerRequest) (*Up
 		if nextOwnerID != "" {
 			if len(group.Lineage) > 0 {
 				if err := s.ensureRootMembership(ctx, group, nextOwnerID, MemberTypeUser); err != nil {
-					logger.Error("failed-to-ensure-owner-root-membership", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
+					logger.Error("failed-to-ensure-owner-root-membership", zap.Error(err), zap.String("group-id", req.GroupID), zap.String("owner-id", nextOwnerID))
 					return nil, err
 				}
 			}
@@ -2139,19 +2139,19 @@ func (s *Service) UpdateOwner(ctx context.Context, req *UpdateOwnerRequest) (*Up
 			// Owner must be a member of the target group and hold ADMIN role.
 			if !group.HasMember(nextOwnerID) {
 				if _, err := group.AddMember(nextOwnerID, MemberTypeUser, MemberRoleAdmin); err != nil {
-					logger.Error("failed-to-add-owner-to-group", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
+					logger.Error("failed-to-add-owner-to-group", zap.Error(err), zap.String("group-id", req.GroupID), zap.String("owner-id", nextOwnerID))
 					return nil, err
 				}
 			} else {
 				memberInfo, memberErr := group.GetMemberByID(nextOwnerID)
 				if memberErr != nil {
-					logger.Error("failed-to-get-owner-member", zap.Error(memberErr), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
+					logger.Error("failed-to-get-owner-member", zap.Error(memberErr), zap.String("group-id", req.GroupID), zap.String("owner-id", nextOwnerID))
 					return nil, memberErr
 				}
 
 				if memberInfo.Role != MemberRoleAdmin {
 					if _, err := group.UpdateMemberRole(nextOwnerID, MemberRoleAdmin); err != nil {
-						logger.Error("failed-to-promote-owner-member-to-admin", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("owner_id", nextOwnerID))
+						logger.Error("failed-to-promote-owner-member-to-admin", zap.Error(err), zap.String("group-id", req.GroupID), zap.String("owner-id", nextOwnerID))
 						return nil, err
 					}
 				}
@@ -2278,7 +2278,7 @@ func (s *Service) RestoreGroup(ctx context.Context, req *RestoreGroupRequest) (*
 func (s *Service) GetGroupsAwaitingAnswerForInvitationsByMemberID(ctx context.Context, req *GetGroupsAwaitingAnswerForInvitationsByMemberIDRequest) (*GetGroupsAwaitingAnswerForInvitationsByMemberIDResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-awaiting-answer-for-invitations-by-member-id"))
 	memberID := strings.TrimSpace(req.MemberID)
-	logger.Debug("getting-groups-awaiting-answer-for-invitations-by-member-id", zap.String("member_id", memberID))
+	logger.Debug("getting-groups-awaiting-answer-for-invitations-by-member-id", zap.String("member-id", memberID))
 
 	if memberID == "" {
 		return nil, ErrInvalidMemberID
@@ -2286,7 +2286,7 @@ func (s *Service) GetGroupsAwaitingAnswerForInvitationsByMemberID(ctx context.Co
 
 	groups, err := s.GroupRepository.GetGroupsAwaitingAnswerForInvitationsByMemberID(ctx, memberID)
 	if err != nil {
-		logger.Error("failed-to-get-groups-awaiting-answer-for-invitations-by-member-id", zap.Error(err), zap.String("member_id", memberID))
+		logger.Error("failed-to-get-groups-awaiting-answer-for-invitations-by-member-id", zap.Error(err), zap.String("member-id", memberID))
 		return nil, ErrDatabaseError
 	}
 
@@ -2398,7 +2398,7 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *commo
 // GetGroupsByMemberID retrieves groups that contain a specific member
 func (s *Service) GetGroupsByMemberID(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-by-member-id"))
-	logger.Debug("getting-groups-by-member-id", zap.String("member_id", req.MemberID))
+	logger.Debug("getting-groups-by-member-id", zap.String("member-id", req.MemberID))
 
 	// Normalize PerPage to PageSize
 	if req.PerPage > 0 {
@@ -2457,7 +2457,7 @@ func (s *Service) GetGroupsByMemberID(ctx context.Context, req *GetGroupsRequest
 // GetGroupsByLeaderID retrieves groups where user is a leader
 func (s *Service) GetGroupsByLeaderID(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-groups-by-leader-id"))
-	logger.Debug("getting-groups-by-leader-id", zap.String("owner_id", req.OwnerID))
+	logger.Debug("getting-groups-by-leader-id", zap.String("owner-id", req.OwnerID))
 
 	// Normalize PerPage to PageSize
 	if req.PerPage > 0 {
@@ -2518,7 +2518,7 @@ func (s *Service) GetGroupsByLeaderID(ctx context.Context, req *GetGroupsRequest
 // GetGroupStats retrieves statistics for a group
 func (s *Service) GetGroupStats(ctx context.Context, groupID string) (*GetGroupStatsResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "get-group-stats"))
-	logger.Debug("getting-group-stats", zap.String("group_id", groupID))
+	logger.Debug("getting-group-stats", zap.String("group-id", groupID))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
@@ -2716,7 +2716,7 @@ func (s *Service) RepairInvalidMembers(ctx context.Context) (*RepairInvalidMembe
 // SetGroupExtension sets an extension field value
 func (s *Service) SetGroupExtension(ctx context.Context, groupID, key string, value interface{}) (*UpdateGroupResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "set-group-extension"))
-	logger.Debug("setting-group-extension", zap.String("group_id", groupID), zap.String("key", key))
+	logger.Debug("setting-group-extension", zap.String("group-id", groupID), zap.String("key", key))
 
 	// Get group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
@@ -2744,7 +2744,7 @@ func (s *Service) SetGroupExtension(ctx context.Context, groupID, key string, va
 // SearchGroupsByExtension searches for groups by extension field value
 func (s *Service) SearchGroupsByExtension(ctx context.Context, req *GetGroupsRequest) (*GetGroupsResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "search-groups-by-extension"))
-	logger.Debug("searching-groups-by-extension", zap.Any("extension_filters", safeLogValue(req.ExtensionFilters)))
+	logger.Debug("searching-groups-by-extension", zap.Any("extension-filters", safeLogValue(req.ExtensionFilters)))
 
 	// Normalize PerPage to PageSize
 	if req.PerPage > 0 {
@@ -2854,7 +2854,7 @@ func (s *Service) GetParentGroupsWithAutoJoinForEmail(ctx context.Context, email
 		return nil, ErrGroupInvalidEmailFormat
 	}
 
-	logger.Debug("querying-groups-with-auto-join", zap.String("email_domain", emailDomain))
+	logger.Debug("querying-groups-with-auto-join", zap.String("email-domain", emailDomain))
 
 	// Get all groups (this is a broad query; in production you might optimize this)
 	// by adding repository support for filtered queries on auto-join settings
@@ -2908,12 +2908,12 @@ func (s *Service) EnableGroupAutoJoinByEmailDomain(ctx context.Context, req *Ena
 	// Retrieve the group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		logger.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-retrieve-group", zap.String("group-id", groupID), zap.Error(err))
 		return nil, err
 	}
 
 	if group == nil {
-		logger.Error("group-not-found", zap.String("group_id", groupID))
+		logger.Error("group-not-found", zap.String("group-id", groupID))
 		return nil, ErrResourceNotFound
 	}
 
@@ -2949,7 +2949,7 @@ func (s *Service) EnableGroupAutoJoinByEmailDomain(ctx context.Context, req *Ena
 	// Update the group
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		logger.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group-id", groupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -2967,7 +2967,7 @@ func (s *Service) EnableGroupAutoJoinByEmailDomain(ctx context.Context, req *Ena
 		})
 	}
 
-	logger.Debug("successfully-enabled-auto-join", zap.String("group_id", groupID))
+	logger.Debug("successfully-enabled-auto-join", zap.String("group-id", groupID))
 
 	return &EnableGroupAutoJoinByEmailDomainResponse{
 		Group: updatedGroup,
@@ -2988,12 +2988,12 @@ func (s *Service) DisableGroupAutoJoinByEmailDomain(ctx context.Context, req *Di
 	// Retrieve the group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		logger.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-retrieve-group", zap.String("group-id", groupID), zap.Error(err))
 		return nil, err
 	}
 
 	if group == nil {
-		logger.Error("group-not-found", zap.String("group_id", groupID))
+		logger.Error("group-not-found", zap.String("group-id", groupID))
 		return nil, ErrResourceNotFound
 	}
 
@@ -3010,7 +3010,7 @@ func (s *Service) DisableGroupAutoJoinByEmailDomain(ctx context.Context, req *Di
 	// Update the group
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		logger.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group-id", groupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -3024,7 +3024,7 @@ func (s *Service) DisableGroupAutoJoinByEmailDomain(ctx context.Context, req *Di
 		})
 	}
 
-	logger.Debug("successfully-disabled-auto-join", zap.String("group_id", groupID))
+	logger.Debug("successfully-disabled-auto-join", zap.String("group-id", groupID))
 
 	return &DisableGroupAutoJoinByEmailDomainResponse{
 		Group: updatedGroup,
@@ -3045,12 +3045,12 @@ func (s *Service) EnableGroupAutoInviteByEmailDomain(ctx context.Context, req *E
 	// Retrieve the group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		logger.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-retrieve-group", zap.String("group-id", groupID), zap.Error(err))
 		return nil, err
 	}
 
 	if group == nil {
-		logger.Error("group-not-found", zap.String("group_id", groupID))
+		logger.Error("group-not-found", zap.String("group-id", groupID))
 		return nil, ErrResourceNotFound
 	}
 
@@ -3086,7 +3086,7 @@ func (s *Service) EnableGroupAutoInviteByEmailDomain(ctx context.Context, req *E
 	// Update the group
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		logger.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group-id", groupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -3104,7 +3104,7 @@ func (s *Service) EnableGroupAutoInviteByEmailDomain(ctx context.Context, req *E
 		})
 	}
 
-	logger.Debug("successfully-enabled-auto-invite", zap.String("group_id", groupID))
+	logger.Debug("successfully-enabled-auto-invite", zap.String("group-id", groupID))
 
 	return &EnableGroupAutoInviteByEmailDomainResponse{
 		Group: updatedGroup,
@@ -3125,12 +3125,12 @@ func (s *Service) DisableGroupAutoInviteByEmailDomain(ctx context.Context, req *
 	// Retrieve the group
 	group, err := s.GroupRepository.GetGroupByID(ctx, groupID)
 	if err != nil {
-		logger.Error("failed-to-retrieve-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-retrieve-group", zap.String("group-id", groupID), zap.Error(err))
 		return nil, err
 	}
 
 	if group == nil {
-		logger.Error("group-not-found", zap.String("group_id", groupID))
+		logger.Error("group-not-found", zap.String("group-id", groupID))
 		return nil, ErrResourceNotFound
 	}
 
@@ -3147,7 +3147,7 @@ func (s *Service) DisableGroupAutoInviteByEmailDomain(ctx context.Context, req *
 	// Update the group
 	updatedGroup, err := s.GroupRepository.UpdateGroup(ctx, group)
 	if err != nil {
-		logger.Error("failed-to-update-group", zap.String("group_id", groupID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group-id", groupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -3161,7 +3161,7 @@ func (s *Service) DisableGroupAutoInviteByEmailDomain(ctx context.Context, req *
 		})
 	}
 
-	logger.Debug("successfully-disabled-auto-invite", zap.String("group_id", groupID))
+	logger.Debug("successfully-disabled-auto-invite", zap.String("group-id", groupID))
 
 	return &DisableGroupAutoInviteByEmailDomainResponse{
 		Group: updatedGroup,

--- a/external/group/service.go
+++ b/external/group/service.go
@@ -1206,7 +1206,7 @@ func (s *Service) AddMember(ctx context.Context, req *AddMemberRequest) (*AddMem
 // InviteUser adds a pending invitation for an email address to a top-level group.
 func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*InviteUserResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "invite-user"))
-	logger.Debug("inviting-user-to-group", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
+	logger.Debug("inviting-user-to-group", append([]zap.Field{zap.String("group_id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1232,7 +1232,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 
 	targetAdded, err := s.addPendingInviteMember(targetGroup, inviteEmail, req.Role, req.InvitedByID)
 	if err != nil {
-		logger.Error("failed-to-add-pending-invite-to-target-group", zap.Error(err), zap.String("group_id", req.GroupID), zap.String("invite_email", inviteEmail))
+		logger.Error("failed-to-add-pending-invite-to-target-group", append([]zap.Field{zap.Error(err), zap.String("group_id", req.GroupID)}, emailLogFields("invite-email", inviteEmail)...)...)
 		return nil, err
 	}
 	if !targetAdded {
@@ -1268,7 +1268,7 @@ func (s *Service) InviteUser(ctx context.Context, req *InviteUserRequest) (*Invi
 // UninviteUser removes a pending invitation from a top-level group.
 func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*UninviteUserResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "uninvite-user"))
-	logger.Debug("uninviting-user-from-group", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
+	logger.Debug("uninviting-user-from-group", append([]zap.Field{zap.String("group_id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1316,7 +1316,7 @@ func (s *Service) UninviteUser(ctx context.Context, req *UninviteUserRequest) (*
 // AcceptInvite accepts a pending invitation for a user and materialises membership.
 func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*AcceptInviteResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "accept-invite"))
-	logger.Debug("accepting-group-invite", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail), zap.String("user_id", req.UserID))
+	logger.Debug("accepting-group-invite", append([]zap.Field{zap.String("group_id", req.GroupID), zap.String("user_id", req.UserID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -1374,7 +1374,7 @@ func (s *Service) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*
 // RejectInvite rejects a pending invitation from a top-level group.
 func (s *Service) RejectInvite(ctx context.Context, req *RejectInviteRequest) (*RejectInviteResponse, error) {
 	logger := logger.AcquirePackageFrom(ctx, "external/group").With(zap.String("operation", "reject-invite"))
-	logger.Debug("rejecting-group-invite", zap.String("group_id", req.GroupID), zap.String("invite_email", req.InviteEmail))
+	logger.Debug("rejecting-group-invite", append([]zap.Field{zap.String("group_id", req.GroupID)}, emailLogFields("invite-email", req.InviteEmail)...)...)
 
 	inviteEmail, err := toolbox.NormaliseEmail(req.InviteEmail)
 	if err != nil {
@@ -2348,7 +2348,7 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *commo
 		PrefixName: true,
 	})
 	if err != nil {
-		logger.Error("failed-to-get-groups-awaiting-invite-answer-for-notifications", zap.Error(err), zap.String("invite_email", inviteEmail))
+		logger.Error("failed-to-get-groups-awaiting-invite-answer-for-notifications", append([]zap.Field{zap.Error(err)}, emailLogFields("invite-email", inviteEmail)...)...)
 		return nil, err
 	}
 
@@ -2850,7 +2850,7 @@ func (s *Service) GetParentGroupsWithAutoJoinForEmail(ctx context.Context, email
 	// Extract domain from email
 	emailDomain := extractEmailDomain(trimmedEmail)
 	if emailDomain == "" {
-		logger.Error("invalid-email-format", zap.String("email", trimmedEmail))
+		logger.Error("invalid-email-format", emailLogFields("email", trimmedEmail)...)
 		return nil, ErrGroupInvalidEmailFormat
 	}
 

--- a/external/http/server/server.go
+++ b/external/http/server/server.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // StartServerWithRequest contains the configuration and optional hooks used to start an HTTP server.
@@ -68,6 +71,13 @@ func StartServerWith(req *StartServerWithRequest) error {
 		return ErrNonPositiveTimeout
 	}
 
+	ctx := req.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	logger := logger.AcquireOperationFrom(ctx, "external/http/server", "start-server")
+	logger.Debug("server-start-requested", zap.String("addr", resolvedAddr))
+
 	srv := &http.Server{
 		Addr:              resolvedAddr,
 		Handler:           req.Handler,
@@ -104,25 +114,22 @@ func StartServerWith(req *StartServerWithRequest) error {
 		}
 	}
 
-	log := req.Log
-	if log == nil {
-		log = func(level, message string) {}
+	emitServerEvent := req.Log
+	if emitServerEvent == nil {
+		emitServerEvent = func(level, message string) {}
 	}
 
 	serverErrCh := make(chan error, 1)
 	go func() {
-		log("info", fmt.Sprintf("server listening on %s", resolvedAddr))
+		emitServerEvent("info", fmt.Sprintf("server listening on %s", resolvedAddr))
+		logger.Info("server-listening", zap.String("addr", resolvedAddr))
 		if err := listenAndServe(srv); err != nil {
+			logger.Error("server-listen-failed", zap.String("addr", resolvedAddr), zap.Error(err))
 			serverErrCh <- err
 			return
 		}
 		serverErrCh <- nil
 	}()
-
-	ctx := req.Context
-	if ctx == nil {
-		ctx = context.Background()
-	}
 
 	select {
 	case err := <-serverErrCh:
@@ -131,17 +138,21 @@ func StartServerWith(req *StartServerWithRequest) error {
 		}
 		return nil
 	case sig := <-signals:
-		log("info", fmt.Sprintf("received signal %s, shutting down gracefully", sig))
+		emitServerEvent("info", fmt.Sprintf("received signal %s, shutting down gracefully", sig))
+		logger.Info("server-shutdown-signal-received", zap.String("signal", sig.String()))
 	case <-ctx.Done():
-		log("info", "context done, shutting down gracefully")
+		emitServerEvent("info", "context done, shutting down gracefully")
+		logger.Info("server-context-done", zap.Error(ctx.Err()))
 	}
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), req.GracefulShutdownTimeout)
 	defer cancel()
 
 	if err := shutdown(srv, shutdownCtx); err != nil {
+		logger.Error("server-shutdown-failed", zap.Error(err))
 		return fmt.Errorf("%w: %v", ErrShutdownFailure, err)
 	}
 
+	logger.Info("server-shutdown-completed")
 	return nil
 }

--- a/external/logger/helpers.go
+++ b/external/logger/helpers.go
@@ -2,33 +2,77 @@ package logger
 
 import (
 	"context"
+	"runtime"
+	"strings"
 
 	"go.uber.org/zap"
 )
 
+const modulePath = "github.com/ooaklee/ghatd"
+
 // Debug logs a debug-level message using the logger from context.
 func Debug(ctx context.Context, msg string, fields ...zap.Field) {
-	Get(ctx).Debug(msg, fields...)
+	loggerForCaller(ctx, 2).Debug(msg, fields...)
 }
 
 // Info logs an info-level message using the logger from context.
 func Info(ctx context.Context, msg string, fields ...zap.Field) {
-	Get(ctx).Info(msg, fields...)
+	loggerForCaller(ctx, 2).Info(msg, fields...)
 }
 
 // Warn logs a warning-level message using the logger from context.
 func Warn(ctx context.Context, msg string, fields ...zap.Field) {
-	Get(ctx).Warn(msg, fields...)
+	loggerForCaller(ctx, 2).Warn(msg, fields...)
 }
 
 // Error logs an error-level message using the logger from context.
 func Error(ctx context.Context, msg string, fields ...zap.Field) {
-	Get(ctx).Error(msg, fields...)
+	loggerForCaller(ctx, 2).Error(msg, fields...)
 }
 
 // With returns a new logger with the provided fields added.
 // The new logger is attached to a new context which is returned.
 func With(ctx context.Context, fields ...zap.Field) context.Context {
-	logger := Get(ctx).With(fields...)
+	logger := loggerForCaller(ctx, 2).With(fields...)
 	return TransitWith(ctx, logger)
+}
+
+func loggerForCaller(ctx context.Context, skip int) *zap.Logger {
+	if packageName := packageNameFromCaller(skip + 1); packageName != "" {
+		return AcquirePackageFrom(ctx, packageName)
+	}
+
+	return Get(ctx)
+}
+
+func packageNameFromCaller(skip int) string {
+	for i := skip; i < skip+8; i++ {
+		pc, _, _, ok := runtime.Caller(i)
+		if !ok {
+			continue
+		}
+
+		fn := runtime.FuncForPC(pc)
+		if fn == nil {
+			continue
+		}
+
+		name := strings.TrimPrefix(fn.Name(), modulePath+"/")
+		if name == fn.Name() {
+			continue
+		}
+
+		if strings.HasPrefix(name, "external/logger.") || strings.HasPrefix(name, "external/logger/") {
+			continue
+		}
+
+		if idx := strings.Index(name, ".("); idx >= 0 {
+			return name[:idx]
+		}
+		if idx := strings.LastIndex(name, "."); idx >= 0 {
+			return name[:idx]
+		}
+	}
+
+	return ""
 }

--- a/external/logger/logger.go
+++ b/external/logger/logger.go
@@ -8,6 +8,7 @@ package logger
 
 import (
 	"context"
+	"strings"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -17,6 +18,18 @@ import (
 type contextKey string
 
 const loggerKey contextKey = "ContextLogger"
+
+const (
+	// FieldSource identifies logs emitted by GHATD framework code rather than
+	// host application code.
+	FieldSource = "source"
+	// FieldPackage identifies the GHATD package responsible for a log event.
+	FieldPackage = "ghatd-package"
+	// FieldOperation identifies the package operation responsible for a log event.
+	FieldOperation = "operation"
+	// SourceGHATD is the stable value used in FieldSource for GHATD logs.
+	SourceGHATD = "ghatd"
+)
 
 // NewLogger creates a structured logger with the specified level and configuration.
 //
@@ -77,4 +90,43 @@ func AcquireFrom(ctx context.Context) *zap.Logger {
 // It retrieves the current logger for the context.
 func Get(ctx context.Context) *zap.Logger {
 	return AcquireFrom(ctx)
+}
+
+// AcquirePackageFrom retrieves a logger from context and adds standard GHATD
+// package attribution fields. Use this inside GHATD package code when the
+// current operation is implied by the log message or surrounding helper.
+func AcquirePackageFrom(ctx context.Context, packageName string, fields ...zap.Field) *zap.Logger {
+	return AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel)).With(packageFields(packageName, "", fields...)...)
+}
+
+// AcquireOperationFrom retrieves a logger from context and adds standard
+// GHATD package and operation attribution fields.
+func AcquireOperationFrom(ctx context.Context, packageName string, operation string, fields ...zap.Field) *zap.Logger {
+	return AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel)).With(packageFields(packageName, operation, fields...)...)
+}
+
+// WithPackage returns a new context whose logger carries standard GHATD
+// package attribution fields.
+func WithPackage(ctx context.Context, packageName string, fields ...zap.Field) context.Context {
+	return TransitWith(ctx, AcquirePackageFrom(ctx, packageName, fields...))
+}
+
+// WithOperation returns a new context whose logger carries standard GHATD
+// package and operation attribution fields.
+func WithOperation(ctx context.Context, packageName string, operation string, fields ...zap.Field) context.Context {
+	return TransitWith(ctx, AcquireOperationFrom(ctx, packageName, operation, fields...))
+}
+
+func packageFields(packageName string, operation string, fields ...zap.Field) []zap.Field {
+	result := []zap.Field{zap.String(FieldSource, SourceGHATD)}
+
+	if packageName = strings.TrimSpace(packageName); packageName != "" {
+		result = append(result, zap.String(FieldPackage, packageName))
+	}
+
+	if operation = strings.TrimSpace(operation); operation != "" {
+		result = append(result, zap.String(FieldOperation, operation))
+	}
+
+	return append(result, fields...)
 }

--- a/external/logger/logger_test.go
+++ b/external/logger/logger_test.go
@@ -3,18 +3,86 @@ package logger_test
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/ooaklee/ghatd/external/logger"
+	ghatdlogger "github.com/ooaklee/ghatd/external/logger"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestAcquireFrom(t *testing.T) {
 	testLogger := zap.NewExample()
 
-	ctx := logger.TransitWith(context.Background(), testLogger)
+	ctx := ghatdlogger.TransitWith(context.Background(), testLogger)
 
-	retrievedLogger := logger.AcquireFrom(ctx)
+	retrievedLogger := ghatdlogger.AcquireFrom(ctx)
 
 	assert.Samef(t, testLogger, retrievedLogger, "Logger are not the same")
+}
+
+func TestAcquirePackageFromAddsGHATDAttribution(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	testLogger := zap.New(core)
+	ctx := ghatdlogger.TransitWith(context.Background(), testLogger)
+
+	logger := ghatdlogger.AcquirePackageFrom(ctx, "external/notifier")
+	logger.Debug("package-log")
+
+	entries := observed.All()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, ghatdlogger.SourceGHATD, entries[0].ContextMap()[ghatdlogger.FieldSource])
+	assert.Equal(t, "external/notifier", entries[0].ContextMap()[ghatdlogger.FieldPackage])
+}
+
+func TestAcquireOperationFromAddsOperationAttribution(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	testLogger := zap.New(core)
+	ctx := ghatdlogger.TransitWith(context.Background(), testLogger)
+
+	logger := ghatdlogger.AcquireOperationFrom(ctx, "external/notifier", "notify-user")
+	logger.Debug("operation-log")
+
+	entries := observed.All()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, ghatdlogger.SourceGHATD, entries[0].ContextMap()[ghatdlogger.FieldSource])
+	assert.Equal(t, "external/notifier", entries[0].ContextMap()[ghatdlogger.FieldPackage])
+	assert.Equal(t, "notify-user", entries[0].ContextMap()[ghatdlogger.FieldOperation])
+}
+
+func TestSafeValueKeepsOperationalFieldsAndRedactsPayloads(t *testing.T) {
+	createdAt := time.Date(2026, 5, 27, 12, 30, 0, 0, time.UTC)
+	value := struct {
+		UserID    string
+		Email     string
+		Token     string
+		Payload   map[string]string
+		Page      int
+		Enabled   bool
+		CreatedAt time.Time
+	}{
+		UserID:    "user_123",
+		Email:     "person@example.com",
+		Token:     "secret-token",
+		Payload:   map[string]string{"safe-key": "raw-value"},
+		Page:      2,
+		Enabled:   true,
+		CreatedAt: createdAt,
+	}
+
+	safeValue, ok := ghatdlogger.SafeValue(value).(map[string]any)
+
+	assert.True(t, ok)
+	assert.Equal(t, "user_123", safeValue["user-id"])
+	assert.Equal(t, int64(2), safeValue["page"])
+	assert.Equal(t, true, safeValue["enabled"])
+	assert.Equal(t, "2026-05-27T12:30:00Z", safeValue["created-at"])
+	assert.Equal(t, true, safeValue["email-present"])
+	assert.Equal(t, true, safeValue["token-present"])
+	assert.Equal(t, true, safeValue["payload-present"])
+	assert.Equal(t, 1, safeValue["payload-count"])
+	assert.NotContains(t, safeValue, "email")
+	assert.NotContains(t, safeValue, "token")
+	assert.NotContains(t, safeValue, "payload")
 }

--- a/external/logger/middleware/middleware.go
+++ b/external/logger/middleware/middleware.go
@@ -64,6 +64,9 @@ func (m *Middleware) HTTPLogger(handler http.Handler) http.Handler {
 		// Log request data
 		reqLogger.Info(
 			fmt.Sprintf("concluded request for %s [correlation-id: %s]", req.URL.RequestURI(), fetchedCorrelationId),
+			zap.String(logger.FieldSource, logger.SourceGHATD),
+			zap.String(logger.FieldPackage, "external/logger/middleware"),
+			zap.String(logger.FieldOperation, "http-request"),
 			zap.Int("status", responseWriter.statusCode),
 			zap.String("method", req.Method),
 			zap.String("clientip", req.RemoteAddr),
@@ -106,6 +109,9 @@ func (m *Middleware) HTTPLoggerWithCustomUriIgnoreList(handler http.Handler) htt
 		// Log request data
 		reqLogger.Info(
 			fmt.Sprintf("concluded request for %s [correlation-id: %s]", req.URL.RequestURI(), fetchedCorrelationId),
+			zap.String(logger.FieldSource, logger.SourceGHATD),
+			zap.String(logger.FieldPackage, "external/logger/middleware"),
+			zap.String(logger.FieldOperation, "http-request"),
 			zap.Int("status", responseWriter.statusCode),
 			zap.String("method", req.Method),
 			zap.String("clientip", req.RemoteAddr),

--- a/external/logger/safe.go
+++ b/external/logger/safe.go
@@ -1,0 +1,380 @@
+package logger
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"go.uber.org/zap"
+)
+
+const (
+	maxSafeStringLength = 160
+	maxSafeMapKeys      = 24
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+// SafeAny logs a value after reducing it to non-secret operational fields.
+func SafeAny(key string, value any) zap.Field {
+	return zap.Any(key, SafeValue(value))
+}
+
+// SafeValue reduces request, payload, and model values to fields that are
+// useful for diagnostics without logging raw bodies, secrets, or free text.
+func SafeValue(value any) any {
+	return safeValue(reflect.ValueOf(value), 0)
+}
+
+func safeValue(value reflect.Value, depth int) any {
+	value = indirectValue(value)
+	if !value.IsValid() {
+		return nil
+	}
+
+	if value.Type() == timeType {
+		return formatTime(value)
+	}
+
+	if depth > 2 {
+		return typeSummary(value)
+	}
+
+	switch value.Kind() {
+	case reflect.Struct:
+		return safeStructValue(value, depth)
+	case reflect.Map:
+		return safeMapSummary(value)
+	case reflect.Slice, reflect.Array:
+		return safeSequenceSummary(value)
+	case reflect.String:
+		return truncateString(value.String())
+	case reflect.Bool:
+		return value.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return value.Uint()
+	case reflect.Float32, reflect.Float64:
+		return value.Float()
+	default:
+		if value.CanInterface() {
+			return value.Interface()
+		}
+		return typeSummary(value)
+	}
+}
+
+func safeStructValue(value reflect.Value, depth int) map[string]any {
+	result := map[string]any{
+		"type": shortTypeName(value.Type()),
+	}
+	omitted := 0
+
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Type().Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+
+		fieldValue := value.Field(i)
+		key := fieldLogKey(field.Name)
+		switch {
+		case isSensitiveFieldName(field.Name):
+			addPresenceSummary(result, key, fieldValue)
+		case isSafeFieldName(field.Name, fieldValue):
+			result[key] = safeFieldValue(field.Name, fieldValue, depth+1)
+		default:
+			omitted++
+		}
+	}
+
+	if omitted > 0 {
+		result["omitted-fields"] = omitted
+	}
+
+	return result
+}
+
+func safeFieldValue(fieldName string, value reflect.Value, depth int) any {
+	value = indirectValue(value)
+	if !value.IsValid() {
+		return nil
+	}
+
+	if value.Type() == timeType {
+		return formatTime(value)
+	}
+
+	switch value.Kind() {
+	case reflect.Map:
+		return safeMapSummary(value)
+	case reflect.Slice, reflect.Array:
+		return safeSequenceSummary(value)
+	case reflect.Struct:
+		return safeValue(value, depth)
+	case reflect.String:
+		return truncateString(value.String())
+	case reflect.Bool:
+		return value.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return value.Uint()
+	case reflect.Float32, reflect.Float64:
+		return value.Float()
+	default:
+		if value.CanInterface() {
+			return value.Interface()
+		}
+		return typeSummary(value)
+	}
+}
+
+func safeMapSummary(value reflect.Value) map[string]any {
+	value = indirectValue(value)
+	if !value.IsValid() {
+		return nil
+	}
+
+	result := map[string]any{
+		"type":  value.Type().String(),
+		"count": value.Len(),
+	}
+
+	keys, truncated := safeMapKeys(value)
+	if len(keys) > 0 {
+		result["keys"] = keys
+	}
+	if truncated {
+		result["truncated-keys"] = true
+	}
+
+	return result
+}
+
+func safeSequenceSummary(value reflect.Value) map[string]any {
+	value = indirectValue(value)
+	if !value.IsValid() {
+		return nil
+	}
+
+	return map[string]any{
+		"type":  value.Type().String(),
+		"count": value.Len(),
+	}
+}
+
+func addPresenceSummary(result map[string]any, key string, value reflect.Value) {
+	value = indirectValue(value)
+	present := value.IsValid() && !value.IsZero()
+	result[key+"-present"] = present
+	if !present {
+		return
+	}
+
+	switch value.Kind() {
+	case reflect.Map:
+		result[key+"-count"] = value.Len()
+		keys, truncated := safeMapKeys(value)
+		if len(keys) > 0 {
+			result[key+"-keys"] = keys
+		}
+		if truncated {
+			result[key+"-truncated-keys"] = true
+		}
+	case reflect.Slice, reflect.Array:
+		result[key+"-count"] = value.Len()
+	case reflect.String:
+		result[key+"-length"] = len(value.String())
+	}
+}
+
+func safeMapKeys(value reflect.Value) ([]string, bool) {
+	keys := make([]string, 0, value.Len())
+	for _, key := range value.MapKeys() {
+		if key.Kind() == reflect.String {
+			keys = append(keys, truncateString(key.String()))
+			continue
+		}
+		if key.CanInterface() {
+			keys = append(keys, truncateString(fmt.Sprint(key.Interface())))
+			continue
+		}
+		keys = append(keys, key.Type().String())
+	}
+	sort.Strings(keys)
+
+	if len(keys) <= maxSafeMapKeys {
+		return keys, false
+	}
+
+	return keys[:maxSafeMapKeys], true
+}
+
+func isSensitiveFieldName(name string) bool {
+	normalized := strings.ToLower(name)
+	sensitiveParts := []string{
+		"authorization",
+		"body",
+		"content",
+		"cookie",
+		"data",
+		"description",
+		"email",
+		"endpoint",
+		"html",
+		"message",
+		"metadata",
+		"password",
+		"payload",
+		"privatekey",
+		"secret",
+		"signature",
+		"subject",
+		"text",
+		"token",
+	}
+
+	for _, part := range sensitiveParts {
+		if strings.Contains(normalized, part) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isSafeFieldName(name string, value reflect.Value) bool {
+	normalized := strings.ToLower(name)
+	if normalized == "id" || strings.HasSuffix(name, "ID") || strings.HasSuffix(name, "Id") {
+		return true
+	}
+
+	if strings.HasSuffix(name, "At") || strings.HasSuffix(name, "Date") {
+		return true
+	}
+
+	safeNames := map[string]struct{}{
+		"archived":  {},
+		"category":  {},
+		"count":     {},
+		"currency":  {},
+		"enabled":   {},
+		"interval":  {},
+		"kind":      {},
+		"limit":     {},
+		"mode":      {},
+		"offset":    {},
+		"page":      {},
+		"pagesize":  {},
+		"period":    {},
+		"provider":  {},
+		"published": {},
+		"role":      {},
+		"scope":     {},
+		"slug":      {},
+		"source":    {},
+		"state":     {},
+		"status":    {},
+		"type":      {},
+	}
+	if _, ok := safeNames[normalized]; ok {
+		return true
+	}
+
+	if strings.HasSuffix(normalized, "count") || strings.HasSuffix(normalized, "size") || strings.HasSuffix(normalized, "total") {
+		return true
+	}
+
+	value = indirectValue(value)
+	if value.IsValid() && value.Kind() == reflect.Bool {
+		return true
+	}
+
+	return strings.HasPrefix(normalized, "is") || strings.HasPrefix(normalized, "has") || strings.HasPrefix(normalized, "can")
+}
+
+func indirectValue(value reflect.Value) reflect.Value {
+	for value.IsValid() && (value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer) {
+		if value.IsNil() {
+			return reflect.Value{}
+		}
+		value = value.Elem()
+	}
+
+	return value
+}
+
+func formatTime(value reflect.Value) string {
+	if !value.CanInterface() {
+		return ""
+	}
+	t, ok := value.Interface().(time.Time)
+	if !ok || t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func shortTypeName(valueType reflect.Type) string {
+	valueType = indirectType(valueType)
+	if valueType.Name() == "" {
+		return valueType.String()
+	}
+
+	pkg := valueType.PkgPath()
+	if idx := strings.LastIndex(pkg, "/"); idx >= 0 {
+		pkg = pkg[idx+1:]
+	}
+	if pkg == "" {
+		return valueType.Name()
+	}
+
+	return pkg + "." + valueType.Name()
+}
+
+func typeSummary(value reflect.Value) map[string]any {
+	value = indirectValue(value)
+	if !value.IsValid() {
+		return nil
+	}
+
+	return map[string]any{
+		"type": value.Type().String(),
+	}
+}
+
+func indirectType(valueType reflect.Type) reflect.Type {
+	for valueType.Kind() == reflect.Pointer {
+		valueType = valueType.Elem()
+	}
+	return valueType
+}
+
+func fieldLogKey(name string) string {
+	runes := []rune(name)
+	result := make([]rune, 0, len(runes)+4)
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) {
+			prev := runes[i-1]
+			nextLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if unicode.IsLower(prev) || unicode.IsDigit(prev) || nextLower {
+				result = append(result, '-')
+			}
+		}
+		result = append(result, unicode.ToLower(r))
+	}
+
+	return string(result)
+}
+
+func truncateString(value string) string {
+	if len(value) <= maxSafeStringLength {
+		return value
+	}
+	return value[:maxSafeStringLength] + "...[truncated]"
+}

--- a/external/logger/safe.go
+++ b/external/logger/safe.go
@@ -29,6 +29,22 @@ func SafeValue(value any) any {
 	return safeValue(reflect.ValueOf(value), 0)
 }
 
+// EmailPresentForLog reports whether an email-like value is present without
+// exposing the address itself.
+func EmailPresentForLog(value string) bool {
+	return strings.TrimSpace(value) != ""
+}
+
+// EmailDomainForLog returns the lower-case domain for an email-like value.
+// The local part is intentionally omitted because it can identify a person.
+func EmailDomainForLog(value string) string {
+	parts := strings.Split(strings.TrimSpace(value), "@")
+	if len(parts) != 2 {
+		return ""
+	}
+	return strings.ToLower(parts[1])
+}
+
 func safeValue(value reflect.Value, depth int) any {
 	value = indirectValue(value)
 	if !value.IsValid() {

--- a/external/middleware/contenttype/contenttype.go
+++ b/external/middleware/contenttype/contenttype.go
@@ -5,11 +5,14 @@ import (
 	"strings"
 
 	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // NewContentType creates a middleware that sets the content-type header to application/json
 func NewContentType(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.AcquireOperationFrom(r.Context(), "external/middleware/contenttype", "content-type")
 
 		const contentTypeHeaderName string = "Content-Type"
 		const jsonContentType string = "application/json"
@@ -17,6 +20,7 @@ func NewContentType(h http.Handler) http.Handler {
 		if strings.Contains(r.Header.Get(contentTypeHeaderName), jsonContentType) ||
 			(strings.HasPrefix(r.URL.Path, common.ApiV1UriPrefix) && !strings.Contains(r.Header.Get(common.HtmxHttpRequestHeader), "true")) {
 			w.Header().Set(contentTypeHeaderName, jsonContentType)
+			logger.Debug("content-type-json-applied", zap.String("path", r.URL.Path))
 		}
 
 		h.ServeHTTP(w, r)

--- a/external/middleware/cors/cors.go
+++ b/external/middleware/cors/cors.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/gorilla/handlers"
 	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // NewCorsMiddleware creates a middleware that handles Cross-Origin Resource Sharing.
 func NewCorsMiddleware(allowedOrigins []string) func(handler http.Handler) http.Handler {
 
 	return func(handler http.Handler) http.Handler {
-		return handlers.CORS(
+		corsHandler := handlers.CORS(
 			handlers.AllowCredentials(),
 			handlers.AllowedHeaders([]string{common.CorrelationIdHttpHeader, "Content-Type", "Authorization", common.WebPlatformHttpRequestHeader, common.TimezoneHttpRequestHeader, common.SystemWideXApiToken, common.WebPartialHttpRequestHeader, common.CacheSkipHttpResponseHeader, common.HtmxHttpCurrentUrlHeader,
 				common.HtmxHttpRequestHeader,
@@ -20,6 +22,12 @@ func NewCorsMiddleware(allowedOrigins []string) func(handler http.Handler) http.
 			handlers.AllowedMethods([]string{"HEAD", "OPTIONS", "GET", "PATCH", "POST", "PUT", "DELETE"}),
 			handlers.AllowedOrigins(allowedOrigins),
 		)(handler)
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			logger.AcquireOperationFrom(r.Context(), "external/middleware/cors", "cors").
+				Debug("cors-request", zap.String("origin", r.Header.Get("Origin")), zap.Int("allowed-origin-count", len(allowedOrigins)))
+			corsHandler.ServeHTTP(w, r)
+		})
 	}
 
 }

--- a/external/notifier/logging.go
+++ b/external/notifier/logging.go
@@ -1,0 +1,7 @@
+package notifier
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/notifier/sender.go
+++ b/external/notifier/sender.go
@@ -147,6 +147,9 @@ func (s *WebPushSender) PublicKey() string {
 // The overall error returned to the caller is nil unless one or more
 // addresses experienced a transient failure OR the cleanup handler failed.
 func (s *WebPushSender) Send(ctx context.Context, subject, message string, addresses []NotificationAddress, data map[string]interface{}) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "send")
+	logger.Debug("handling-send-request")
+
 	_, err := s.SendWithReport(ctx, subject, message, addresses, data)
 	return err
 }
@@ -156,14 +159,13 @@ func (s *WebPushSender) Send(ctx context.Context, subject, message string, addre
 // call and is safe for the service to use when senders are shared.
 func (s *WebPushSender) SendWithReport(ctx context.Context, subject, message string, addresses []NotificationAddress, data map[string]interface{}) (channelSendReport, error) {
 	report := channelSendReport{}
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel)).With(
-		zap.String("component", "notifier"),
+	logger := logger.AcquirePackageFrom(ctx, "external/notifier").With(
 		zap.String("operation", "webpush-send"),
 		zap.String("channel", string(NotificationChannelWebPush)),
 	)
 
 	if !s.Enabled() {
-		log.Warn(
+		logger.Warn(
 			"webpush-sender-not-enabled",
 			zap.Bool("enabled", s != nil && s.config.Enabled),
 			zap.Bool("has-vapid-public-key", s != nil && s.config.VAPIDPublicKey != ""),
@@ -181,18 +183,18 @@ func (s *WebPushSender) SendWithReport(ctx context.Context, subject, message str
 		}
 	}
 	if len(valid) == 0 {
-		log.Warn("webpush-send-no-valid-addresses", zap.Int("attempted-addresses", len(addresses)), zap.Error(ErrNotificationNoActiveAddresses))
+		logger.Warn("webpush-send-no-valid-addresses", zap.Int("attempted-addresses", len(addresses)), zap.Error(ErrNotificationNoActiveAddresses))
 		return report, ErrNotificationNoActiveAddresses
 	}
 
-	log.Info("webpush-send-started", zap.Int("attempted-addresses", len(addresses)), zap.Int("valid-addresses", len(valid)), zap.Strings("data-keys", notificationDataKeysForLog(data)))
+	logger.Info("webpush-send-started", zap.Int("attempted-addresses", len(addresses)), zap.Int("valid-addresses", len(valid)), zap.Strings("data-keys", notificationDataKeysForLog(data)))
 
 	var sendErrs []error
 	for _, address := range valid {
 		err := s.sendOne(ctx, subject, message, address, data)
 		if err == nil {
 			report.Delivered++
-			log.Debug(
+			logger.Debug(
 				"webpush-address-send-completed",
 				zap.String("address-id", address.ID),
 				zap.String("address-hash", address.AddressHash),
@@ -200,7 +202,7 @@ func (s *WebPushSender) SendWithReport(ctx context.Context, subject, message str
 			continue
 		}
 		if isPermanentWebPushError(err) {
-			log.Warn(
+			logger.Warn(
 				"webpush-address-permanent-failure",
 				zap.String("address-id", address.ID),
 				zap.String("address-hash", address.AddressHash),
@@ -208,7 +210,7 @@ func (s *WebPushSender) SendWithReport(ctx context.Context, subject, message str
 			)
 			if s.invalidAddressHandler != nil {
 				if cleanupErr := s.invalidAddressHandler(ctx, address.AddressHash); cleanupErr != nil {
-					log.Error(
+					logger.Error(
 						"webpush-address-cleanup-failed",
 						zap.String("address-id", address.ID),
 						zap.String("address-hash", address.AddressHash),
@@ -218,7 +220,7 @@ func (s *WebPushSender) SendWithReport(ctx context.Context, subject, message str
 					continue
 				}
 				report.Cleaned++
-				log.Info(
+				logger.Info(
 					"webpush-address-disabled-after-permanent-failure",
 					zap.String("address-id", address.ID),
 					zap.String("address-hash", address.AddressHash),
@@ -226,7 +228,7 @@ func (s *WebPushSender) SendWithReport(ctx context.Context, subject, message str
 			}
 			continue
 		}
-		log.Error(
+		logger.Error(
 			"webpush-address-transient-failure",
 			zap.String("address-id", address.ID),
 			zap.String("address-hash", address.AddressHash),
@@ -237,7 +239,7 @@ func (s *WebPushSender) SendWithReport(ctx context.Context, subject, message str
 
 	if len(sendErrs) > 0 {
 		joinedErr := errors.Join(sendErrs...)
-		log.Error(
+		logger.Error(
 			"webpush-send-failed",
 			zap.Int("delivered", report.Delivered),
 			zap.Int("cleaned", report.Cleaned),
@@ -246,12 +248,15 @@ func (s *WebPushSender) SendWithReport(ctx context.Context, subject, message str
 		)
 		return report, joinedErr
 	}
-	log.Info("webpush-send-completed", zap.Int("delivered", report.Delivered), zap.Int("cleaned", report.Cleaned))
+	logger.Info("webpush-send-completed", zap.Int("delivered", report.Delivered), zap.Int("cleaned", report.Cleaned))
 	return report, nil
 }
 
 // sendOne delivers the message to a single Web Push address.
 func (s *WebPushSender) sendOne(ctx context.Context, subject, message string, address NotificationAddress, data map[string]interface{}) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "send-one")
+	logger.Debug("handling-send-one-request")
+
 	subscription := notifywebpush.Subscription{
 		Endpoint: address.WebPush.Endpoint,
 		Keys: webpush.Keys{
@@ -379,6 +384,9 @@ func (s *FCMSender) Enabled() bool {
 // nikoksr/notify's FCM service to ensure credentials are applied
 // during client construction, not after.
 func (s *FCMSender) Send(ctx context.Context, subject, message string, addresses []NotificationAddress, data map[string]interface{}) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "send")
+	logger.Debug("handling-send-request")
+
 	_, err := s.SendWithReport(ctx, subject, message, addresses, data)
 	return err
 }
@@ -391,14 +399,13 @@ func (s *FCMSender) Send(ctx context.Context, subject, message string, addresses
 // every token was rejected.
 func (s *FCMSender) SendWithReport(ctx context.Context, subject, message string, addresses []NotificationAddress, data map[string]interface{}) (channelSendReport, error) {
 	report := channelSendReport{}
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel)).With(
-		zap.String("component", "notifier"),
+	logger := logger.AcquirePackageFrom(ctx, "external/notifier").With(
 		zap.String("operation", "fcm-send"),
 		zap.String("channel", string(NotificationChannelFCM)),
 	)
 
 	if !s.Enabled() {
-		log.Warn(
+		logger.Warn(
 			"fcm-sender-not-enabled",
 			zap.Bool("enabled", s != nil && s.config.Enabled),
 			zap.Bool("has-credentials-file", s != nil && s.config.CredentialsFile != ""),
@@ -418,11 +425,11 @@ func (s *FCMSender) SendWithReport(ctx context.Context, subject, message string,
 	}
 
 	if len(tokens) == 0 {
-		log.Warn("fcm-send-no-valid-tokens", zap.Int("attempted-addresses", len(addresses)), zap.Error(ErrNotificationNoActiveAddresses))
+		logger.Warn("fcm-send-no-valid-tokens", zap.Int("attempted-addresses", len(addresses)), zap.Error(ErrNotificationNoActiveAddresses))
 		return report, ErrNotificationNoActiveAddresses
 	}
 
-	log.Info("fcm-send-started", zap.Int("attempted-addresses", len(addresses)), zap.Int("valid-tokens", len(tokens)), zap.Strings("data-keys", notificationDataKeysForLog(data)))
+	logger.Info("fcm-send-started", zap.Int("attempted-addresses", len(addresses)), zap.Int("valid-tokens", len(tokens)), zap.Strings("data-keys", notificationDataKeysForLog(data)))
 
 	var opts []fcm.Option
 	if s.config.CredentialsFile != "" {
@@ -434,7 +441,7 @@ func (s *FCMSender) SendWithReport(ctx context.Context, subject, message string,
 
 	fcmClient, err := fcm.NewClient(ctx, opts...)
 	if err != nil {
-		log.Error(
+		logger.Error(
 			"fcm-client-initialisation-failed",
 			zap.Bool("has-credentials-file", s.config.CredentialsFile != ""),
 			zap.Bool("has-project-id", s.config.ProjectID != ""),
@@ -454,7 +461,7 @@ func (s *FCMSender) SendWithReport(ctx context.Context, subject, message string,
 		}
 		batchResponse, err = fcmClient.Send(ctx, msg)
 		if err != nil {
-			log.Error("fcm-single-send-failed", zap.Int("valid-tokens", len(tokens)), zap.Error(err))
+			logger.Error("fcm-single-send-failed", zap.Int("valid-tokens", len(tokens)), zap.Error(err))
 			return report, err
 		}
 	} else {
@@ -467,20 +474,20 @@ func (s *FCMSender) SendWithReport(ctx context.Context, subject, message string,
 		}
 		batchResponse, err = fcmClient.SendMulticast(ctx, msg)
 		if err != nil {
-			log.Error("fcm-multicast-send-failed", zap.Int("valid-tokens", len(tokens)), zap.Error(err))
+			logger.Error("fcm-multicast-send-failed", zap.Int("valid-tokens", len(tokens)), zap.Error(err))
 			return report, err
 		}
 	}
 
 	if batchResponse == nil {
-		log.Error("fcm-send-nil-batch-response", zap.Int("valid-tokens", len(tokens)))
+		logger.Error("fcm-send-nil-batch-response", zap.Int("valid-tokens", len(tokens)))
 		return report, errors.New("fcm delivery failed: nil batch response")
 	}
 
 	report.Delivered = batchResponse.SuccessCount
 	if batchResponse.FailureCount > 0 {
 		err := fcmBatchResponseError(batchResponse)
-		log.Error(
+		logger.Error(
 			"fcm-send-partial-failure",
 			zap.Int("valid-tokens", len(tokens)),
 			zap.Int("delivered", report.Delivered),
@@ -490,7 +497,7 @@ func (s *FCMSender) SendWithReport(ctx context.Context, subject, message string,
 		return report, err
 	}
 
-	log.Info("fcm-send-completed", zap.Int("valid-tokens", len(tokens)), zap.Int("delivered", report.Delivered))
+	logger.Info("fcm-send-completed", zap.Int("valid-tokens", len(tokens)), zap.Int("delivered", report.Delivered))
 	return report, nil
 }
 

--- a/external/notifier/service.go
+++ b/external/notifier/service.go
@@ -614,13 +614,13 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 			"notification-send-failed",
 			zap.Int("channel-results", len(results)),
 			zap.Int("failed-channels", len(sendErrs)),
-			zap.Any("results", results),
+			zap.Any("results", safeLogValue(results)),
 			zap.Error(joinedErr),
 		)
 		return response, joinedErr
 	}
 
-	logger.Info("notification-send-completed", zap.Int("channel-results", len(results)), zap.Any("results", results))
+	logger.Info("notification-send-completed", zap.Int("channel-results", len(results)), zap.Any("results", safeLogValue(results)))
 	return response, nil
 }
 
@@ -701,7 +701,7 @@ func (s *Service) NotifyUsers(ctx context.Context, req *NotifyUsersRequest) (*No
 			}
 			continue
 		}
-		logger.Error("notification-dispatch-user-send-failed", zap.String("user-id", userID), zap.Any("results", result.Results), zap.Error(err))
+		logger.Error("notification-dispatch-user-send-failed", zap.String("user-id", userID), zap.Any("results", safeLogValue(result.Results)), zap.Error(err))
 		sendErrs = append(sendErrs, err)
 	}
 
@@ -711,13 +711,13 @@ func (s *Service) NotifyUsers(ctx context.Context, req *NotifyUsersRequest) (*No
 			"notification-dispatch-failed",
 			zap.Int("target-user-count", len(userIDs)),
 			zap.Int("failed-users", len(sendErrs)),
-			zap.Any("results", response.Results),
+			zap.Any("results", safeLogValue(response.Results)),
 			zap.Error(joinedErr),
 		)
 		return response, joinedErr
 	}
 
-	logger.Info("notification-dispatch-completed", zap.Int("target-user-count", len(userIDs)), zap.Any("results", response.Results))
+	logger.Info("notification-dispatch-completed", zap.Int("target-user-count", len(userIDs)), zap.Any("results", safeLogValue(response.Results)))
 	return response, nil
 }
 

--- a/external/notifier/service.go
+++ b/external/notifier/service.go
@@ -156,6 +156,9 @@ func (s *Service) WithSender(sender ChannelSender) *Service {
 //
 // The returned address is a sanitised summary with secrets stripped.
 func (s *Service) RegisterAddress(ctx context.Context, req *RegisterAddressRequest) (*RegisterAddressResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "register-address")
+	logger.Debug("handling-register-address-request")
+
 	if req == nil || strings.TrimSpace(req.UserID) == "" {
 		return nil, ErrNotificationUserIDRequired
 	}
@@ -205,6 +208,9 @@ func (s *Service) RegisterAddress(ctx context.Context, req *RegisterAddressReque
 // tokens) because the notifier itself needs those secrets to deliver
 // push messages.
 func (s *Service) GetActiveAddressesByUserID(ctx context.Context, req *GetActiveNotificationAddressesRequest) (*GetActiveNotificationAddressesResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "get-active-addresses-by-user-id")
+	logger.Debug("handling-get-active-addresses-by-user-id-request")
+
 	if req == nil || strings.TrimSpace(req.UserID) == "" {
 		return nil, ErrNotificationUserIDRequired
 	}
@@ -228,6 +234,9 @@ func (s *Service) GetActiveAddressesByUserID(ctx context.Context, req *GetActive
 // This is the method behind the GET /addresses endpoint. Users call it
 // to see which devices they have registered for push notifications.
 func (s *Service) ListUserAddresses(ctx context.Context, req *ListNotificationAddressesRequest) (*ListNotificationAddressesResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "list-user-addresses")
+	logger.Debug("handling-list-user-addresses-request")
+
 	if req == nil || strings.TrimSpace(req.UserID) == "" {
 		return nil, ErrNotificationUserIDRequired
 	}
@@ -244,6 +253,9 @@ func (s *Service) ListUserAddresses(ctx context.Context, req *ListNotificationAd
 // dashboards. Unlike ListUserAddresses, UserID is optional so callers can inspect
 // platform-wide registrations and narrow them with filters.
 func (s *Service) ListAddresses(ctx context.Context, req *ListNotificationAddressesRequest) (*ListNotificationAddressesResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "list-addresses")
+	logger.Debug("handling-list-addresses-request")
+
 	if req == nil {
 		req = &ListNotificationAddressesRequest{}
 	}
@@ -309,6 +321,9 @@ func normaliseAddressListPagination(page, perPage int) (int, int) {
 // deleting it. If the address does not exist or belongs to a different
 // user, the call returns ErrNotificationAddressNotFound.
 func (s *Service) DeleteAddress(ctx context.Context, req *DeleteNotificationAddressRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "delete-address")
+	logger.Debug("handling-delete-address-request")
+
 	if req == nil || strings.TrimSpace(req.UserID) == "" {
 		return ErrNotificationUserIDRequired
 	}
@@ -326,6 +341,9 @@ func (s *Service) DeleteAddress(ctx context.Context, req *DeleteNotificationAddr
 // means new users are opted in by default and can disable notifications
 // later if they want.
 func (s *Service) GetPreferences(ctx context.Context, req *GetNotificationPreferencesRequest) (*GetNotificationPreferencesResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "get-preferences")
+	logger.Debug("handling-get-preferences-request")
+
 	if req == nil || strings.TrimSpace(req.UserID) == "" {
 		return nil, ErrNotificationUserIDRequired
 	}
@@ -355,6 +373,9 @@ func (s *Service) GetPreferences(ctx context.Context, req *GetNotificationPrefer
 // global setting is not changed. Channels that are not mentioned in
 // the map are left as they were.
 func (s *Service) UpdatePreferences(ctx context.Context, req *UpdateNotificationPreferencesRequest) (*UpdateNotificationPreferencesResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "update-preferences")
+	logger.Debug("handling-update-preferences-request")
+
 	if req == nil || strings.TrimSpace(req.UserID) == "" {
 		return nil, ErrNotificationUserIDRequired
 	}
@@ -408,6 +429,9 @@ func (s *Service) UpdatePreferences(ctx context.Context, req *UpdateNotification
 // This method is safe to call without authentication – it doesn't expose
 // any user-specific data.
 func (s *Service) GetConfig(ctx context.Context, req *GetNotifierConfigRequest) (*GetNotifierConfigResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/notifier", "get-config")
+	logger.Debug("handling-get-config-request")
+
 	config := &NotifierConfig{
 		SupportedChannels: []NotificationChannel{},
 		WebPush:           WebPushClientConfig{},
@@ -463,13 +487,12 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 	}
 
 	userID := strings.TrimSpace(req.UserID)
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel)).With(
-		zap.String("component", "notifier"),
+	logger := logger.AcquirePackageFrom(ctx, "external/notifier").With(
 		zap.String("operation", "notify-user"),
 		zap.String("user-id", userID),
 	)
 
-	log.Info(
+	logger.Info(
 		"notification-send-started",
 		zap.Strings("requested-channels", notificationChannelsForLog(req.Channels)),
 		zap.Strings("data-keys", notificationDataKeysForLog(req.Data)),
@@ -477,36 +500,36 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 
 	preferencesResponse, err := s.GetPreferences(ctx, &GetNotificationPreferencesRequest{UserID: userID})
 	if err != nil {
-		log.Error("notification-preferences-lookup-failed", zap.Error(err))
+		logger.Error("notification-preferences-lookup-failed", zap.Error(err))
 		return nil, err
 	}
 	preferences := preferencesResponse.Preferences
 	if preferences != nil && !preferences.Enabled {
-		log.Info("notification-send-skipped-user-preferences-disabled")
+		logger.Info("notification-send-skipped-user-preferences-disabled")
 		return &NotifyUserResponse{Results: []NotificationSendResult{}}, nil
 	}
 
 	channels, err := normaliseChannels(req.Channels)
 	if err != nil {
-		log.Warn("notification-send-invalid-channels", zap.Strings("requested-channels", notificationChannelsForLog(req.Channels)), zap.Error(err))
+		logger.Warn("notification-send-invalid-channels", zap.Strings("requested-channels", notificationChannelsForLog(req.Channels)), zap.Error(err))
 		return nil, err
 	}
 	addresses, err := s.Repository.GetActiveAddressesByUserID(ctx, userID, channels...)
 	if err != nil {
-		log.Error("notification-active-address-lookup-failed", zap.Strings("channels", notificationChannelsForLog(channels)), zap.Error(err))
+		logger.Error("notification-active-address-lookup-failed", zap.Strings("channels", notificationChannelsForLog(channels)), zap.Error(err))
 		return nil, err
 	}
 	if len(addresses) == 0 {
-		log.Warn("notification-send-no-active-addresses", zap.Strings("channels", notificationChannelsForLog(channels)))
+		logger.Warn("notification-send-no-active-addresses", zap.Strings("channels", notificationChannelsForLog(channels)))
 		return nil, ErrNotificationNoActiveAddresses
 	}
-	log.Info("notification-active-addresses-found", zap.Int("address-count", len(addresses)), zap.Strings("channels", notificationChannelsForLog(channels)))
+	logger.Info("notification-active-addresses-found", zap.Int("address-count", len(addresses)), zap.Strings("channels", notificationChannelsForLog(channels)))
 
 	addressesByChannel := map[NotificationChannel][]NotificationAddress{}
 	for _, address := range addresses {
 		channel := address.Channel.Normalised()
 		if preferences != nil && preferences.Channels != nil && !preferences.Channels[string(channel)] {
-			log.Info(
+			logger.Info(
 				"notification-address-skipped-by-channel-preference",
 				zap.String("channel", string(channel)),
 				zap.String("address-id", address.ID),
@@ -517,7 +540,7 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 		addressesByChannel[channel] = append(addressesByChannel[channel], address)
 	}
 	if len(addressesByChannel) == 0 {
-		log.Info("notification-send-skipped-all-addresses-filtered-by-preferences")
+		logger.Info("notification-send-skipped-all-addresses-filtered-by-preferences")
 	}
 
 	results := []NotificationSendResult{}
@@ -528,7 +551,7 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 		if sender == nil || !sender.Enabled() {
 			result.Skipped = true
 			result.Error = ErrNotificationSenderNotEnabled.Error()
-			log.Warn(
+			logger.Warn(
 				"notification-channel-sender-not-enabled",
 				zap.String("channel", string(channel)),
 				zap.Int("attempted-addresses", len(channelAddresses)),
@@ -539,7 +562,7 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 			continue
 		}
 
-		log.Info(
+		logger.Info(
 			"notification-channel-send-started",
 			zap.String("channel", string(channel)),
 			zap.Int("attempted-addresses", len(channelAddresses)),
@@ -562,7 +585,7 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 		if sendErr != nil {
 			result.Error = sendErr.Error()
 			sendErrs = append(sendErrs, sendErr)
-			log.Error(
+			logger.Error(
 				"notification-channel-send-failed",
 				zap.String("channel", string(channel)),
 				zap.Int("attempted-addresses", result.Attempted),
@@ -572,7 +595,7 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 				zap.Error(sendErr),
 			)
 		} else {
-			log.Info(
+			logger.Info(
 				"notification-channel-send-completed",
 				zap.String("channel", string(channel)),
 				zap.Int("attempted-addresses", result.Attempted),
@@ -587,7 +610,7 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 	response := &NotifyUserResponse{Results: results}
 	if len(sendErrs) > 0 {
 		joinedErr := errors.Join(append([]error{ErrNotificationSendFailed}, sendErrs...)...)
-		log.Error(
+		logger.Error(
 			"notification-send-failed",
 			zap.Int("channel-results", len(results)),
 			zap.Int("failed-channels", len(sendErrs)),
@@ -597,7 +620,7 @@ func (s *Service) NotifyUser(ctx context.Context, req *NotifyUserRequest) (*Noti
 		return response, joinedErr
 	}
 
-	log.Info("notification-send-completed", zap.Int("channel-results", len(results)), zap.Any("results", results))
+	logger.Info("notification-send-completed", zap.Int("channel-results", len(results)), zap.Any("results", results))
 	return response, nil
 }
 
@@ -627,12 +650,11 @@ func (s *Service) NotifyUsers(ctx context.Context, req *NotifyUsersRequest) (*No
 		return nil, ErrInvalidNotificationAddressBody
 	}
 
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel)).With(
-		zap.String("component", "notifier"),
+	logger := logger.AcquirePackageFrom(ctx, "external/notifier").With(
 		zap.String("operation", "notify-users"),
 	)
 
-	log.Info(
+	logger.Info(
 		"notification-dispatch-started",
 		zap.Int("requested-user-count", len(req.UserIDs)),
 		zap.Bool("broadcast", len(req.UserIDs) == 0),
@@ -642,19 +664,19 @@ func (s *Service) NotifyUsers(ctx context.Context, req *NotifyUsersRequest) (*No
 
 	channels, err := normaliseChannels(req.Channels)
 	if err != nil {
-		log.Warn("notification-dispatch-invalid-channels", zap.Strings("requested-channels", notificationChannelsForLog(req.Channels)), zap.Error(err))
+		logger.Warn("notification-dispatch-invalid-channels", zap.Strings("requested-channels", notificationChannelsForLog(req.Channels)), zap.Error(err))
 		return nil, err
 	}
 
 	userIDs, err := s.resolveNotifyUsersTargetUserIDs(ctx, req.UserIDs, channels)
 	if err != nil {
-		log.Error("notification-dispatch-target-resolution-failed", zap.Strings("channels", notificationChannelsForLog(channels)), zap.Error(err))
+		logger.Error("notification-dispatch-target-resolution-failed", zap.Strings("channels", notificationChannelsForLog(channels)), zap.Error(err))
 		return nil, err
 	}
 	if len(userIDs) == 0 {
-		log.Warn("notification-dispatch-no-target-users", zap.Bool("broadcast", len(req.UserIDs) == 0), zap.Strings("channels", notificationChannelsForLog(channels)))
+		logger.Warn("notification-dispatch-no-target-users", zap.Bool("broadcast", len(req.UserIDs) == 0), zap.Strings("channels", notificationChannelsForLog(channels)))
 	}
-	log.Info("notification-dispatch-targets-resolved", zap.Int("target-user-count", len(userIDs)), zap.Bool("broadcast", len(req.UserIDs) == 0))
+	logger.Info("notification-dispatch-targets-resolved", zap.Int("target-user-count", len(userIDs)), zap.Bool("broadcast", len(req.UserIDs) == 0))
 
 	response := &NotifyUsersResponse{Results: make([]NotifyUsersResult, 0, len(userIDs))}
 	var sendErrs []error
@@ -675,17 +697,17 @@ func (s *Service) NotifyUsers(ctx context.Context, req *NotifyUsersRequest) (*No
 
 		if err == nil || errors.Is(err, ErrNotificationNoActiveAddresses) {
 			if errors.Is(err, ErrNotificationNoActiveAddresses) {
-				log.Warn("notification-dispatch-user-no-active-addresses", zap.String("user-id", userID), zap.Strings("channels", notificationChannelsForLog(channels)))
+				logger.Warn("notification-dispatch-user-no-active-addresses", zap.String("user-id", userID), zap.Strings("channels", notificationChannelsForLog(channels)))
 			}
 			continue
 		}
-		log.Error("notification-dispatch-user-send-failed", zap.String("user-id", userID), zap.Any("results", result.Results), zap.Error(err))
+		logger.Error("notification-dispatch-user-send-failed", zap.String("user-id", userID), zap.Any("results", result.Results), zap.Error(err))
 		sendErrs = append(sendErrs, err)
 	}
 
 	if len(sendErrs) > 0 {
 		joinedErr := errors.Join(sendErrs...)
-		log.Error(
+		logger.Error(
 			"notification-dispatch-failed",
 			zap.Int("target-user-count", len(userIDs)),
 			zap.Int("failed-users", len(sendErrs)),
@@ -695,13 +717,12 @@ func (s *Service) NotifyUsers(ctx context.Context, req *NotifyUsersRequest) (*No
 		return response, joinedErr
 	}
 
-	log.Info("notification-dispatch-completed", zap.Int("target-user-count", len(userIDs)), zap.Any("results", response.Results))
+	logger.Info("notification-dispatch-completed", zap.Int("target-user-count", len(userIDs)), zap.Any("results", response.Results))
 	return response, nil
 }
 
 func (s *Service) resolveNotifyUsersTargetUserIDs(ctx context.Context, userIDs []string, channels []NotificationChannel) ([]string, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel)).With(
-		zap.String("component", "notifier"),
+	logger := logger.AcquirePackageFrom(ctx, "external/notifier").With(
 		zap.String("operation", "resolve-notify-users-targets"),
 	)
 
@@ -716,16 +737,16 @@ func (s *Service) resolveNotifyUsersTargetUserIDs(ctx context.Context, userIDs [
 			seen[userID] = true
 			resolved = append(resolved, userID)
 		}
-		log.Info("notification-explicit-target-users-resolved", zap.Int("requested-user-count", len(userIDs)), zap.Int("target-user-count", len(resolved)))
+		logger.Info("notification-explicit-target-users-resolved", zap.Int("requested-user-count", len(userIDs)), zap.Int("target-user-count", len(resolved)))
 		return resolved, nil
 	}
 
 	addresses, err := s.Repository.GetAllActiveAddresses(ctx, channels...)
 	if err != nil {
-		log.Error("notification-broadcast-active-address-lookup-failed", zap.Strings("channels", notificationChannelsForLog(channels)), zap.Error(err))
+		logger.Error("notification-broadcast-active-address-lookup-failed", zap.Strings("channels", notificationChannelsForLog(channels)), zap.Error(err))
 		return nil, err
 	}
-	log.Info("notification-broadcast-active-addresses-found", zap.Int("address-count", len(addresses)), zap.Strings("channels", notificationChannelsForLog(channels)))
+	logger.Info("notification-broadcast-active-addresses-found", zap.Int("address-count", len(addresses)), zap.Strings("channels", notificationChannelsForLog(channels)))
 	for _, address := range addresses {
 		userID := strings.TrimSpace(address.UserID)
 		if userID == "" || seen[userID] {
@@ -735,7 +756,7 @@ func (s *Service) resolveNotifyUsersTargetUserIDs(ctx context.Context, userIDs [
 		resolved = append(resolved, userID)
 	}
 	sort.Strings(resolved)
-	log.Info("notification-broadcast-target-users-resolved", zap.Int("target-user-count", len(resolved)))
+	logger.Info("notification-broadcast-target-users-resolved", zap.Int("target-user-count", len(resolved)))
 	return resolved, nil
 }
 

--- a/external/oauth/oauth_google.go
+++ b/external/oauth/oauth_google.go
@@ -5,11 +5,11 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
@@ -73,24 +73,24 @@ func NewGoogleProvider(r *NewGoogleProviderRequest) *GoogleProvider {
 
 func (p *GoogleProvider) ProviderGetUserData(ctx context.Context, requestUriEntries url.Values) (OauthUserInfo, error) {
 
-	loggr := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/oauth")
 	var userInfo GoogleProviderOauthUserInfo
 	var providerOauthCode string = requestUriEntries["code"][0]
 
 	if providerOauthCode == "" {
-		loggr.Error("provider-oauth-code-not-detected")
+		logger.Error("provider-oauth-code-not-detected")
 		return nil, ErrProviderCodeNotDetected
 	}
 
 	providerToken, err := p.config.Exchange(ctx, providerOauthCode)
 	if err != nil {
-		loggr.Error(fmt.Sprintf("provider-oauth-code-exchange-incorrect: %s", err.Error()))
+		logger.Error("provider-oauth-code-exchange-incorrect", zap.Error(err))
 		return nil, ErrProviderCodeExchangeIncorrect
 	}
 
 	userInfoResponse, err := http.Get(p.providerUserInfoEndpoint + providerToken.AccessToken)
 	if err != nil {
-		loggr.Error(fmt.Sprintf("provider-failed-getting-user-info: %s", err.Error()))
+		logger.Error("provider-failed-getting-user-info", zap.Error(err))
 		return nil, ErrProviderFailedGettingUserInfo
 	}
 
@@ -98,7 +98,7 @@ func (p *GoogleProvider) ProviderGetUserData(ctx context.Context, requestUriEntr
 
 	err = json.NewDecoder(userInfoResponse.Body).Decode(&userInfo)
 	if err != nil {
-		loggr.Error(fmt.Sprintf("provider-failed-to-marshall-user-info: %s", err.Error()))
+		logger.Error("provider-failed-to-marshall-user-info", zap.Error(err))
 		return nil, ErrProviderFailedToMarshallUserInfo
 	}
 

--- a/external/paymentprovider/kofi.go
+++ b/external/paymentprovider/kofi.go
@@ -63,11 +63,11 @@ func (k *KofiProvider) GetProviderName() string {
 // The webhook secret should match the verification token configured in Ko-fi
 func (k *KofiProvider) VerifyWebhook(ctx context.Context, req *http.Request) error {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", k.name)).With(zap.String("method", "verify-webhook")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", k.name)).With(zap.String("operation", "verify-webhook"))
 
-	log.Debug("verifying-kofi-webhook")
+	logger.Debug("verifying-kofi-webhook")
 
-	dataField, err := k.getFormData(req, log)
+	dataField, err := k.getFormData(req, logger)
 	if err != nil {
 		return err
 	}
@@ -78,16 +78,16 @@ func (k *KofiProvider) VerifyWebhook(ctx context.Context, req *http.Request) err
 	}
 
 	if err := json.Unmarshal([]byte(dataField), &payload); err != nil {
-		log.Error("failed-to-parse-json-payload", zap.Error(err))
+		logger.Error("failed-to-parse-json-payload", zap.Error(err))
 		return ErrPaymentProviderInvalidPayload
 	}
 
 	if payload.VerificationToken != k.config.WebhookSecret {
-		log.Error("invalid-verification-token", zap.String("received", payload.VerificationToken))
+		logger.Error("invalid-verification-token", zap.Int("received-token-length", len(payload.VerificationToken)))
 		return ErrPaymentProviderInvalidWebhookSignature
 	}
 
-	log.Debug("kofi-webhook-verified-successfully")
+	logger.Debug("kofi-webhook-verified-successfully")
 
 	return nil
 }
@@ -103,11 +103,11 @@ func (k *KofiProvider) ParsePayload(ctx context.Context, req *http.Request) (*We
 		availableUntilDate string = ""
 	)
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", k.name)).With(zap.String("method", "parse-payload")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", k.name)).With(zap.String("operation", "parse-payload"))
 
-	log.Debug("parsing-kofi-webhook-payload")
+	logger.Debug("parsing-kofi-webhook-payload")
 
-	dataField, err := k.getFormData(req, log)
+	dataField, err := k.getFormData(req, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (k *KofiProvider) ParsePayload(ctx context.Context, req *http.Request) (*We
 	var payload KofiWebhookPayload
 
 	if err := json.Unmarshal([]byte(dataField), &payload); err != nil {
-		log.Warn("failed-to-parse-json-payload", zap.Error(err))
+		logger.Warn("failed-to-parse-json-payload", zap.Error(err))
 		return nil, ErrPaymentProviderPayloadParsing
 	}
 
@@ -149,7 +149,7 @@ func (k *KofiProvider) ParsePayload(ctx context.Context, req *http.Request) (*We
 		availableUntilDate = calculateAvailableUntilDate(ctx, payload.Timestamp)
 	}
 
-	log.Debug("parsed-kofi-webhook-payload",
+	logger.Debug("parsed-kofi-webhook-payload",
 		zap.String("event-type", eventType),
 		zap.String("payment-type", paymentType),
 		zap.String("email", payload.Email),
@@ -184,12 +184,12 @@ func (k *KofiProvider) ParsePayload(ctx context.Context, req *http.Request) (*We
 // Ko-fi does not provide this info, so we have to estimate it until their API improves
 // Their timestamp is in RFC3339 format, e.g., "2023-10-05T14:48:00Z"
 func calculateNextBillingDate(ctx context.Context, timestamp string) string {
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", "kofi")).With(zap.String("method", "calculate-next-billing-date")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", "kofi")).With(zap.String("operation", "calculate-next-billing-date"))
 
 	// convert to time.Time
 	providedTime, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
-		log.Warn("failed-to-parse-timestamp-defaulting-to-30-days-later", zap.Error(err))
+		logger.Warn("failed-to-parse-timestamp-defaulting-to-30-days-later", zap.Error(err))
 		return time.Now().Add(30 * 24 * time.Hour).Format(time.RFC3339)
 	}
 
@@ -202,14 +202,14 @@ func calculateNextBillingDate(ctx context.Context, timestamp string) string {
 // We will give users an extra 48 hours grace period after the billing date to minimise disruption.
 // Their timestamp is in RFC3339 format, e.g., "2023-10-05T14:48:00Z"
 func calculateAvailableUntilDate(ctx context.Context, timestamp string) string {
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", "kofi")).With(zap.String("method", "calculate-available-until-date")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", "kofi")).With(zap.String("operation", "calculate-available-until-date"))
 
 	gracePeriod := 48 * time.Hour
 
 	// convert to time.Time
 	providedTime, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
-		log.Warn("failed-to-parse-timestamp-defaulting-to-30-days-later", zap.Error(err))
+		logger.Warn("failed-to-parse-timestamp-defaulting-to-30-days-later", zap.Error(err))
 		return time.Now().Add(30 * 24 * time.Hour).Add(gracePeriod).Format(time.RFC3339)
 	}
 
@@ -247,25 +247,25 @@ func getPayloadPlanName(payload KofiWebhookPayload, planName string) string {
 // To get subscription info, we would need to track it in our own database.
 func (k *KofiProvider) GetSubscriptionInfo(ctx context.Context, subscriptionID string) (*SubscriptionInfo, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", k.name)).With(zap.String("method", "get-subscription-info")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", k.name)).With(zap.String("operation", "get-subscription-info"))
 
-	log.Warn("kofi-get-subscription-info-not-supported-there-is-no-subscription-api")
+	logger.Warn("kofi-get-subscription-info-not-supported-there-is-no-subscription-api")
 
 	return nil, ErrPaymentProviderKofiNoSubscriptionAPI
 }
 
 // getFormData extracts the 'data' field from the form-encoded request
-func (k *KofiProvider) getFormData(req *http.Request, log *zap.Logger) (string, error) {
+func (k *KofiProvider) getFormData(req *http.Request, logger *zap.Logger) (string, error) {
 
 	if err := req.ParseForm(); err != nil {
-		log.Warn("failed-to-parse-form", zap.Error(err))
+		logger.Warn("failed-to-parse-form", zap.Error(err))
 		return "", ErrPaymentProviderInvalidPayload
 	}
 
 	// Ko-fi sends data as form-encoded with a 'data' field containing JSON
 	dataField := req.FormValue("data")
 	if dataField == "" {
-		log.Warn("missing-data-field-in-form")
+		logger.Warn("missing-data-field-in-form")
 		return "", ErrPaymentProviderInvalidPayload
 	}
 

--- a/external/paymentprovider/kofi.go
+++ b/external/paymentprovider/kofi.go
@@ -152,7 +152,8 @@ func (k *KofiProvider) ParsePayload(ctx context.Context, req *http.Request) (*We
 	logger.Debug("parsed-kofi-webhook-payload",
 		zap.String("event-type", eventType),
 		zap.String("payment-type", paymentType),
-		zap.String("email", payload.Email),
+		zap.Bool("email-present", emailPresentForLog(payload.Email)),
+		zap.String("email-domain", emailDomainForLog(payload.Email)),
 		zap.Int64("amount", amount),
 		zap.String("currency", payload.Currency),
 		zap.Bool("is-one-off", isOneOff))

--- a/external/paymentprovider/lemonsqueezy.go
+++ b/external/paymentprovider/lemonsqueezy.go
@@ -40,11 +40,11 @@ func (l *LemonSqueezyProvider) GetProviderName() string {
 
 // VerifyWebhook verifies the Lemon Squeezy webhook signature
 func (l *LemonSqueezyProvider) VerifyWebhook(ctx context.Context, req *http.Request) error {
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", l.name)).With(zap.String("method", "verify-webhook")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", l.name)).With(zap.String("operation", "verify-webhook"))
 
-	log.Debug("verifying-lemonsqueezy-webhook")
+	logger.Debug("verifying-lemonsqueezy-webhook")
 
-	body, signature, err := l.getRequestBodyAndSignature(req, true, log)
+	body, signature, err := l.getRequestBodyAndSignature(req, true, logger)
 	if err != nil {
 		return err
 	}
@@ -55,22 +55,22 @@ func (l *LemonSqueezyProvider) VerifyWebhook(ctx context.Context, req *http.Requ
 
 	// Compare signatures
 	if !hmac.Equal([]byte(expectedSignature), []byte(signature)) {
-		log.Error("invalid-webhook-signature", zap.String("received", signature))
+		logger.Error("invalid-webhook-signature", zap.Int("received-signature-length", len(signature)))
 		return ErrPaymentProviderInvalidWebhookSignature
 	}
 
-	log.Debug("lemonsqueezy-webhook-verified-successfully")
+	logger.Debug("lemonsqueezy-webhook-verified-successfully")
 
 	return nil
 }
 
 // ParsePayload extracts and normalises Lemon Squeezy webhook data
 func (l *LemonSqueezyProvider) ParsePayload(ctx context.Context, req *http.Request) (*WebhookPayload, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", l.name)).With(zap.String("method", "parse-payload")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", l.name)).With(zap.String("operation", "parse-payload"))
 
-	log.Debug("parsing-lemonsqueezy-webhook-payload")
+	logger.Debug("parsing-lemonsqueezy-webhook-payload")
 
-	body, _, err := l.getRequestBodyAndSignature(req, false, log)
+	body, _, err := l.getRequestBodyAndSignature(req, false, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (l *LemonSqueezyProvider) ParsePayload(ctx context.Context, req *http.Reque
 	var webhook LemonSqueezyWebhookPayload
 
 	if err := json.Unmarshal(body, &webhook); err != nil {
-		log.Error("failed-to-parse-webhook-payload", zap.Error(err))
+		logger.Error("failed-to-parse-webhook-payload", zap.Error(err))
 		return nil, ErrPaymentProviderPayloadParsing
 	}
 
@@ -105,11 +105,11 @@ func (l *LemonSqueezyProvider) ParsePayload(ctx context.Context, req *http.Reque
 
 	priceInfo, err := l.getPriceByOrderItemID(ctx, attrs.OrderItemID)
 	if err != nil {
-		log.Error("failed-to-get-price-info", zap.Int64("order-item-id", attrs.OrderItemID), zap.String("event-type", eventType), zap.Error(err))
+		logger.Error("failed-to-get-price-info", zap.Int64("order-item-id", attrs.OrderItemID), zap.String("event-type", eventType), zap.Error(err))
 		return nil, ErrPaymentProviderAPIResponseInvalid
 	}
 
-	log.Debug("parsed-lemonsqueezy-webhook-payload", zap.String("event-type", eventType), zap.String("email", webhook.Data.Attributes.UserEmail))
+	logger.Debug("parsed-lemonsqueezy-webhook-payload", zap.String("event-type", eventType), zap.String("email", webhook.Data.Attributes.UserEmail))
 
 	return &WebhookPayload{
 		EventType:          eventType,
@@ -133,9 +133,9 @@ func (l *LemonSqueezyProvider) ParsePayload(ctx context.Context, req *http.Reque
 // GetSubscriptionInfo retrieves subscription information from Lemon Squeezy's API
 func (l *LemonSqueezyProvider) GetSubscriptionInfo(ctx context.Context, subscriptionID string) (*SubscriptionInfo, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", l.name)).With(zap.String("method", "get-subscription-info")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", l.name)).With(zap.String("operation", "get-subscription-info"))
 
-	log.Info("handle-request-to-get-subscription-information")
+	logger.Info("handle-request-to-get-subscription-information")
 
 	baseURL := l.config.APIBaseURL
 	if baseURL == "" {
@@ -143,7 +143,7 @@ func (l *LemonSqueezyProvider) GetSubscriptionInfo(ctx context.Context, subscrip
 	}
 
 	apiURL := baseURL + "/v1/subscriptions/" + subscriptionID
-	body, err := l.callLemonSqueezyEndpoint(log, "GET", apiURL, nil, []int{http.StatusOK})
+	body, err := l.callLemonSqueezyEndpoint(logger, "GET", apiURL, nil, []int{http.StatusOK})
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (l *LemonSqueezyProvider) GetSubscriptionInfo(ctx context.Context, subscrip
 	}
 
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		log.Error("failed-to-parse-api-response", zap.Error(err))
+		logger.Error("failed-to-parse-api-response", zap.Error(err))
 		return nil, ErrPaymentProviderAPIResponseInvalid
 	}
 
@@ -177,7 +177,7 @@ func (l *LemonSqueezyProvider) GetSubscriptionInfo(ctx context.Context, subscrip
 		planName = fmt.Sprintf("%s - %s", attrs.ProductName, attrs.VariantName)
 	}
 
-	log.Info("retrieved-subscription-info")
+	logger.Info("retrieved-subscription-info")
 
 	return &SubscriptionInfo{
 		SubscriptionID:  apiResp.Data.ID,
@@ -192,9 +192,9 @@ func (l *LemonSqueezyProvider) GetSubscriptionInfo(ctx context.Context, subscrip
 // getPriceByPriceID retrieves price details by price ID from Lemon Squeezy's API
 func (l *LemonSqueezyProvider) getPriceByPriceID(ctx context.Context, priceID string, quantity int64) (*PriceInfo, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", l.name)).With(zap.String("method", "get-price-by-id")).With(zap.String("price_id", priceID)).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", l.name)).With(zap.String("operation", "get-price-by-id")).With(zap.String("price_id", priceID))
 
-	log.Info("handle-request-to-get-price-information-by-id")
+	logger.Info("handle-request-to-get-price-information-by-id")
 
 	baseURL := l.config.APIBaseURL
 	if baseURL == "" {
@@ -202,7 +202,7 @@ func (l *LemonSqueezyProvider) getPriceByPriceID(ctx context.Context, priceID st
 	}
 
 	apiURL := baseURL + "/v1/prices/" + priceID
-	body, err := l.callLemonSqueezyEndpoint(log, "GET", apiURL, nil, []int{http.StatusOK})
+	body, err := l.callLemonSqueezyEndpoint(logger, "GET", apiURL, nil, []int{http.StatusOK})
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +210,12 @@ func (l *LemonSqueezyProvider) getPriceByPriceID(ctx context.Context, priceID st
 	var apiResp LemonSqueezyPricePayload
 
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		log.Error("failed-to-parse-api-response-for-price-info", zap.Error(err))
+		logger.Error("failed-to-parse-api-response-for-price-info", zap.Error(err))
 		return nil, ErrPaymentProviderAPIResponseInvalid
 	}
 
 	unitPrice := calculateLemonSqueezyUnitPrice(&apiResp, quantity)
-	log.Info("retrived-price-info-by-id", zap.Int64("unit_price", unitPrice), zap.String("scheme", apiResp.Data.Attributes.Scheme))
+	logger.Info("retrived-price-info-by-id", zap.Int64("unit_price", unitPrice), zap.String("scheme", apiResp.Data.Attributes.Scheme))
 
 	return &PriceInfo{
 		UnitPrice: unitPrice,
@@ -226,8 +226,8 @@ func (l *LemonSqueezyProvider) getPriceByPriceID(ctx context.Context, priceID st
 // getPriceByOrderItemID retrieves price details by order item ID from Lemon Squeezy's API
 func (l *LemonSqueezyProvider) getPriceByOrderItemID(ctx context.Context, orderItemID int64) (*PriceInfo, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", l.name)).With(zap.String("method", "get-price-by-order-item-id")).With(zap.Int64("order-item-id", orderItemID)).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Info("handle-request-to-get-price-information-by-order-item-id")
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", l.name)).With(zap.String("operation", "get-price-by-order-item-id")).With(zap.Int64("order-item-id", orderItemID))
+	logger.Info("handle-request-to-get-price-information-by-order-item-id")
 
 	baseURL := l.config.APIBaseURL
 	if baseURL == "" {
@@ -235,7 +235,7 @@ func (l *LemonSqueezyProvider) getPriceByOrderItemID(ctx context.Context, orderI
 	}
 
 	apiURL := baseURL + "/v1/order-items/" + fmt.Sprintf("%d", orderItemID)
-	body, err := l.callLemonSqueezyEndpoint(log, "GET", apiURL, nil, []int{http.StatusOK})
+	body, err := l.callLemonSqueezyEndpoint(logger, "GET", apiURL, nil, []int{http.StatusOK})
 	if err != nil {
 		return nil, err
 	}
@@ -259,10 +259,10 @@ func (l *LemonSqueezyProvider) getPriceByOrderItemID(ctx context.Context, orderI
 	}
 
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		log.Error("failed-to-parse-api-response-for-order-item-info", zap.Error(err))
+		logger.Error("failed-to-parse-api-response-for-order-item-info", zap.Error(err))
 		return nil, ErrPaymentProviderAPIResponseInvalid
 	}
-	log.Info("retrived-order-item-info", zap.Int64("price", apiResp.Data.Attributes.Price), zap.Int64("quantity", apiResp.Data.Attributes.Quantity))
+	logger.Info("retrived-order-item-info", zap.Int64("price", apiResp.Data.Attributes.Price), zap.Int64("quantity", apiResp.Data.Attributes.Quantity))
 	return &PriceInfo{
 		UnitPrice: apiResp.Data.Attributes.Price * apiResp.Data.Attributes.Quantity,
 		Currency:  "USD", // Lemon Squeezy uses USD by default
@@ -270,12 +270,12 @@ func (l *LemonSqueezyProvider) getPriceByOrderItemID(ctx context.Context, orderI
 }
 
 // callLemonSqueezyEndpoint is a helper to call Lemon Squeezy API endpoints
-func (l *LemonSqueezyProvider) callLemonSqueezyEndpoint(log *zap.Logger, method, endpoint string, body io.Reader, validHttpStatusCodes []int) ([]byte, error) {
-	log.Info("calling-lemon-squeezy-endpoint", zap.String("method", method), zap.String("endpoint", endpoint))
+func (l *LemonSqueezyProvider) callLemonSqueezyEndpoint(logger *zap.Logger, method, endpoint string, body io.Reader, validHttpStatusCodes []int) ([]byte, error) {
+	logger.Info("calling-lemon-squeezy-endpoint", zap.String("http-method", method), zap.String("endpoint-host", endpointHostForLog(endpoint)))
 
 	req, err := http.NewRequest(method, endpoint, body)
 	if err != nil {
-		log.Error("failed-to-create-http-request", zap.Error(err))
+		logger.Error("failed-to-create-http-request", zap.Error(err))
 		return nil, ErrPaymentProviderAPIRequestFailed
 	}
 
@@ -285,35 +285,35 @@ func (l *LemonSqueezyProvider) callLemonSqueezyEndpoint(log *zap.Logger, method,
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Error("http-request-failed", zap.Error(err))
+		logger.Error("http-request-failed", zap.Error(err))
 		return nil, ErrPaymentProviderAPIRequestFailed
 	}
 	defer resp.Body.Close()
 
 	if !slices.Contains(validHttpStatusCodes, resp.StatusCode) {
-		log.Error("http-request-returned-invalid-status", zap.Int("status-code", resp.StatusCode), zap.Ints("valid-status-codes", validHttpStatusCodes))
+		logger.Error("http-request-returned-invalid-status", zap.Int("status-code", resp.StatusCode), zap.Ints("valid-status-codes", validHttpStatusCodes))
 		return nil, ErrPaymentProviderSubscriptionNotFound
 	}
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Error("failed-to-read-http-response-body", zap.Error(err))
+		logger.Error("failed-to-read-http-response-body", zap.Error(err))
 		return nil, ErrPaymentProviderAPIResponseInvalid
 	}
 
-	log.Info("successfully-called-lemon-squeezy-endpoint")
+	logger.Info("successfully-called-lemon-squeezy-endpoint")
 	return responseBody, nil
 }
 
 // getRequestBodyAndSignature reads the request body and retrieves the signature header if needed
-func (l *LemonSqueezyProvider) getRequestBodyAndSignature(req *http.Request, getSignature bool, log *zap.Logger) ([]byte, string, error) {
+func (l *LemonSqueezyProvider) getRequestBodyAndSignature(req *http.Request, getSignature bool, logger *zap.Logger) ([]byte, string, error) {
 
 	var signature string
 
 	if getSignature {
 		signature = req.Header.Get("X-Signature")
 		if signature == "" {
-			log.Error("missing-signature-header")
+			logger.Error("missing-signature-header")
 			return nil, "", ErrPaymentProviderMissingSignature
 		}
 	}
@@ -321,7 +321,7 @@ func (l *LemonSqueezyProvider) getRequestBodyAndSignature(req *http.Request, get
 	// Read the body
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
-		log.Error("failed-to-read-request-body", zap.Error(err))
+		logger.Error("failed-to-read-request-body", zap.Error(err))
 		return nil, "", ErrPaymentProviderInvalidPayload
 	}
 

--- a/external/paymentprovider/lemonsqueezy.go
+++ b/external/paymentprovider/lemonsqueezy.go
@@ -196,7 +196,7 @@ func (l *LemonSqueezyProvider) GetSubscriptionInfo(ctx context.Context, subscrip
 // getPriceByPriceID retrieves price details by price ID from Lemon Squeezy's API
 func (l *LemonSqueezyProvider) getPriceByPriceID(ctx context.Context, priceID string, quantity int64) (*PriceInfo, error) {
 
-	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", l.name)).With(zap.String("operation", "get-price-by-id")).With(zap.String("price_id", priceID))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", l.name)).With(zap.String("operation", "get-price-by-id")).With(zap.String("price-id", priceID))
 
 	logger.Info("handle-request-to-get-price-information-by-id")
 
@@ -219,7 +219,7 @@ func (l *LemonSqueezyProvider) getPriceByPriceID(ctx context.Context, priceID st
 	}
 
 	unitPrice := calculateLemonSqueezyUnitPrice(&apiResp, quantity)
-	logger.Info("retrived-price-info-by-id", zap.Int64("unit_price", unitPrice), zap.String("scheme", apiResp.Data.Attributes.Scheme))
+	logger.Info("retrived-price-info-by-id", zap.Int64("unit-price", unitPrice), zap.String("scheme", apiResp.Data.Attributes.Scheme))
 
 	return &PriceInfo{
 		UnitPrice: unitPrice,

--- a/external/paymentprovider/lemonsqueezy.go
+++ b/external/paymentprovider/lemonsqueezy.go
@@ -109,7 +109,11 @@ func (l *LemonSqueezyProvider) ParsePayload(ctx context.Context, req *http.Reque
 		return nil, ErrPaymentProviderAPIResponseInvalid
 	}
 
-	logger.Debug("parsed-lemonsqueezy-webhook-payload", zap.String("event-type", eventType), zap.String("email", webhook.Data.Attributes.UserEmail))
+	logger.Debug("parsed-lemonsqueezy-webhook-payload",
+		zap.String("event-type", eventType),
+		zap.Bool("email-present", emailPresentForLog(webhook.Data.Attributes.UserEmail)),
+		zap.String("email-domain", emailDomainForLog(webhook.Data.Attributes.UserEmail)),
+	)
 
 	return &WebhookPayload{
 		EventType:          eventType,

--- a/external/paymentprovider/provider.go
+++ b/external/paymentprovider/provider.go
@@ -3,6 +3,7 @@ package paymentprovider
 import (
 	"context"
 	"net/http"
+	"net/url"
 )
 
 // Provider defines the interface that all payment providers must implement
@@ -25,4 +26,12 @@ type Provider interface {
 	// GetSubscriptionInfo retrieves current subscription details from the provider's API
 	// This is useful for syncing state or retrieving information not in webhooks
 	GetSubscriptionInfo(ctx context.Context, subscriptionID string) (*SubscriptionInfo, error)
+}
+
+func endpointHostForLog(endpoint string) string {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
 }

--- a/external/paymentprovider/provider.go
+++ b/external/paymentprovider/provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+
+	"github.com/ooaklee/ghatd/external/logger"
 )
 
 // Provider defines the interface that all payment providers must implement
@@ -34,4 +36,12 @@ func endpointHostForLog(endpoint string) string {
 		return ""
 	}
 	return parsed.Host
+}
+
+func emailPresentForLog(value string) bool {
+	return logger.EmailPresentForLog(value)
+}
+
+func emailDomainForLog(value string) string {
+	return logger.EmailDomainForLog(value)
 }

--- a/external/paymentprovider/registry.go
+++ b/external/paymentprovider/registry.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // ProviderRegistry manages multiple payment providers
@@ -50,18 +53,35 @@ func (r *ProviderRegistry) List() []string {
 // VerifyAndParseWebhookPayload is a convenience method that identifies the provider,
 // verifies the webhook, and parses the payload
 func (r *ProviderRegistry) VerifyAndParseWebhookPayload(ctx context.Context, providerName string, req *http.Request) (*WebhookPayload, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/paymentprovider", "verify-and-parse-webhook-payload", zap.String("provider", providerName))
+	logger.Info("payment-provider-webhook-processing-started")
+
 	provider, err := r.Get(providerName)
 	if err != nil {
+		logger.Warn("payment-provider-not-registered", zap.Error(err))
 		return nil, err
 	}
 
 	// Verify the webhook
 	if err := provider.VerifyWebhook(ctx, req); err != nil {
+		logger.Warn("payment-provider-webhook-verification-failed", zap.Error(err))
 		return nil, err
 	}
 
 	// Parse the payload
-	return provider.ParsePayload(ctx, req)
+	payload, err := provider.ParsePayload(ctx, req)
+	if err != nil {
+		logger.Warn("payment-provider-webhook-payload-parse-failed", zap.Error(err))
+		return nil, err
+	}
+
+	logger.Info("payment-provider-webhook-processing-completed",
+		zap.String("event-type", payload.EventType),
+		zap.String("event-id", payload.EventID),
+		zap.String("subscription-id", payload.SubscriptionID),
+		zap.Bool("is-subscription", payload.IsSubscription()),
+	)
+	return payload, nil
 }
 
 // CreateProviderFromConfig creates a provider instance from configuration

--- a/external/paymentprovider/stripe.go
+++ b/external/paymentprovider/stripe.go
@@ -189,7 +189,12 @@ func (s *StripeProvider) ParsePayload(ctx context.Context, req *http.Request) (*
 		nextBillingDate = time.Unix(int64(currentPeriodEnd), 0).Format(time.RFC3339)
 	}
 
-	logger.Debug("parsed-stripe-webhook-payload", zap.String("raw-event-type", event.Type), zap.String("event-type", stripeEventToStandard(event.Type)), zap.String("email", email))
+	logger.Debug("parsed-stripe-webhook-payload",
+		zap.String("raw-event-type", event.Type),
+		zap.String("event-type", stripeEventToStandard(event.Type)),
+		zap.Bool("email-present", emailPresentForLog(email)),
+		zap.String("email-domain", emailDomainForLog(email)),
+	)
 
 	return &WebhookPayload{
 		EventType:          stripeEventToStandard(event.Type),

--- a/external/paymentprovider/stripe.go
+++ b/external/paymentprovider/stripe.go
@@ -42,19 +42,19 @@ func (s *StripeProvider) GetProviderName() string {
 
 // VerifyWebhook verifies the Stripe webhook signature
 func (s *StripeProvider) VerifyWebhook(ctx context.Context, req *http.Request) error {
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", s.name)).With(zap.String("method", "verify-webhook")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", s.name)).With(zap.String("operation", "verify-webhook"))
 
-	log.Debug("verifying-stripe-webhook")
+	logger.Debug("verifying-stripe-webhook")
 
 	signature := req.Header.Get("Stripe-Signature")
 	if signature == "" {
-		log.Error("missing-signature-from-webhook")
+		logger.Error("missing-signature-from-webhook")
 		return ErrPaymentProviderMissingSignature
 	}
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
-		log.Error("failed-to-read-webhook-body", zap.Error(err))
+		logger.Error("failed-to-read-webhook-body", zap.Error(err))
 		return ErrPaymentProviderInvalidPayload
 	}
 
@@ -78,20 +78,20 @@ func (s *StripeProvider) VerifyWebhook(ctx context.Context, req *http.Request) e
 	}
 
 	if timestamp == "" || v1Signature == "" {
-		log.Error("missing-timestamp-or-signature-from-webhook")
+		logger.Error("missing-timestamp-or-signature-from-webhook")
 		return ErrPaymentProviderInvalidWebhookSignature
 	}
 
 	// Verify the timestamp is recent (within 5 minutes)
 	timestampInt, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
-		log.Error("invalid-timestamp-in-signature", zap.Error(err))
+		logger.Error("invalid-timestamp-in-signature", zap.Error(err))
 		return ErrPaymentProviderInvalidWebhookSignature
 	}
 
 	var maxAge int64 = 300 // 5 minutes
 	if time.Now().Unix()-timestampInt > maxAge {
-		log.Error("timestamp-too-old", zap.Int64("timestamp", timestampInt), zap.Int64("allowed-age-in-seconds", maxAge))
+		logger.Error("timestamp-too-old", zap.Int64("timestamp", timestampInt), zap.Int64("allowed-age-in-seconds", maxAge))
 		return ErrPaymentProviderWebhookTimestampTooOld
 	}
 
@@ -101,11 +101,11 @@ func (s *StripeProvider) VerifyWebhook(ctx context.Context, req *http.Request) e
 	expectedSignature := hex.EncodeToString(mac.Sum(nil))
 
 	if !hmac.Equal([]byte(expectedSignature), []byte(v1Signature)) {
-		log.Error("invalid-signature", zap.String("expected", expectedSignature), zap.String("received", v1Signature))
+		logger.Error("invalid-signature", zap.Int("received-signature-length", len(v1Signature)))
 		return ErrPaymentProviderInvalidWebhookSignature
 	}
 
-	log.Debug("stripe-webhook-verified-successfully")
+	logger.Debug("stripe-webhook-verified-successfully")
 
 	return nil
 }
@@ -113,13 +113,13 @@ func (s *StripeProvider) VerifyWebhook(ctx context.Context, req *http.Request) e
 // ParsePayload extracts and normalises Stripe webhook data
 func (s *StripeProvider) ParsePayload(ctx context.Context, req *http.Request) (*WebhookPayload, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", s.name)).With(zap.String("method", "parse-payload")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", s.name)).With(zap.String("operation", "parse-payload"))
 
-	log.Debug("parsing-stripe-webhook-payload")
+	logger.Debug("parsing-stripe-webhook-payload")
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
-		log.Error("failed-to-parse-webhook-payload", zap.Error(err))
+		logger.Error("failed-to-parse-webhook-payload", zap.Error(err))
 		return nil, ErrPaymentProviderInvalidPayload
 	}
 
@@ -134,7 +134,7 @@ func (s *StripeProvider) ParsePayload(ctx context.Context, req *http.Request) (*
 	}
 
 	if err := json.Unmarshal(body, &event); err != nil {
-		log.Error("failed-to-parse-webhook-payload", zap.Error(err))
+		logger.Error("failed-to-parse-webhook-payload", zap.Error(err))
 		return nil, ErrPaymentProviderPayloadParsing
 	}
 
@@ -189,7 +189,7 @@ func (s *StripeProvider) ParsePayload(ctx context.Context, req *http.Request) (*
 		nextBillingDate = time.Unix(int64(currentPeriodEnd), 0).Format(time.RFC3339)
 	}
 
-	log.Debug("parsed-stripe-webhook-payload", zap.String("raw-event-type", event.Type), zap.String("event-type", stripeEventToStandard(event.Type)), zap.String("email", email))
+	logger.Debug("parsed-stripe-webhook-payload", zap.String("raw-event-type", event.Type), zap.String("event-type", stripeEventToStandard(event.Type)), zap.String("email", email))
 
 	return &WebhookPayload{
 		EventType:          stripeEventToStandard(event.Type),
@@ -211,9 +211,9 @@ func (s *StripeProvider) ParsePayload(ctx context.Context, req *http.Request) (*
 // GetSubscriptionInfo retrieves subscription information from Stripe's API
 func (s *StripeProvider) GetSubscriptionInfo(ctx context.Context, subscriptionID string) (*SubscriptionInfo, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", s.name)).With(zap.String("method", "get-subscription-info")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", s.name)).With(zap.String("operation", "get-subscription-info"))
 
-	log.Info("handle-request-to-get-subscription-information")
+	logger.Info("handle-request-to-get-subscription-information")
 
 	baseURL := s.config.APIBaseURL
 	if baseURL == "" {
@@ -221,14 +221,14 @@ func (s *StripeProvider) GetSubscriptionInfo(ctx context.Context, subscriptionID
 	}
 
 	apiURL := baseURL + "/v1/subscriptions/" + subscriptionID
-	body, err := s.callStripeEndpoint(log, "GET", apiURL, nil, []int{http.StatusOK})
+	body, err := s.callStripeEndpoint(logger, "GET", apiURL, nil, []int{http.StatusOK})
 	if err != nil {
 		return nil, err
 	}
 
 	var obj map[string]interface{}
 	if err := json.Unmarshal(body, &obj); err != nil {
-		log.Error("failed-to-parse-api-response", zap.Error(err))
+		logger.Error("failed-to-parse-api-response", zap.Error(err))
 		return nil, ErrPaymentProviderAPIResponseInvalid
 	}
 
@@ -258,7 +258,7 @@ func (s *StripeProvider) GetSubscriptionInfo(ctx context.Context, subscriptionID
 		if info.PlanID != "" {
 			planName, err := s.getPlanDetailsByPlanID(ctx, info.PlanID)
 			if err != nil {
-				log.Warn("unable-to-get-plan-name", zap.Error(err))
+				logger.Warn("unable-to-get-plan-name", zap.Error(err))
 			} else {
 				info.PlanName = planName
 			}
@@ -267,7 +267,7 @@ func (s *StripeProvider) GetSubscriptionInfo(ctx context.Context, subscriptionID
 		}
 	}
 
-	log.Info("retrieved-subscription-info")
+	logger.Info("retrieved-subscription-info")
 
 	return info, nil
 }
@@ -275,9 +275,9 @@ func (s *StripeProvider) GetSubscriptionInfo(ctx context.Context, subscriptionID
 // getProductDetailsByProductID retrieves product details from Stripe's API
 func (s *StripeProvider) getProductDetailsByProductID(ctx context.Context, productID string) (string, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", s.name)).With(zap.String("method", "get-product-details-by-product-id")).With(zap.String("stripe-product-id", productID)).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", s.name)).With(zap.String("operation", "get-product-details-by-product-id")).With(zap.String("stripe-product-id", productID))
 
-	log.Info("handle-request-to-get-product-details-by-product-id")
+	logger.Info("handle-request-to-get-product-details-by-product-id")
 
 	baseURL := s.config.APIBaseURL
 	if baseURL == "" {
@@ -285,18 +285,18 @@ func (s *StripeProvider) getProductDetailsByProductID(ctx context.Context, produ
 	}
 
 	apiURL := baseURL + "/v1/products/" + productID
-	body, err := s.callStripeEndpoint(log, "GET", apiURL, nil, []int{http.StatusOK})
+	body, err := s.callStripeEndpoint(logger, "GET", apiURL, nil, []int{http.StatusOK})
 	if err != nil {
 		return "", err
 	}
 
 	var obj map[string]interface{}
 	if err := json.Unmarshal(body, &obj); err != nil {
-		log.Error("failed-to-parse-api-response", zap.Error(err))
+		logger.Error("failed-to-parse-api-response", zap.Error(err))
 		return "", ErrPaymentProviderAPIResponseInvalid
 	}
 
-	log.Info("successfully-retrieved-product-details")
+	logger.Info("successfully-retrieved-product-details")
 
 	return getStringField(obj, "name"), nil
 }
@@ -304,9 +304,9 @@ func (s *StripeProvider) getProductDetailsByProductID(ctx context.Context, produ
 // getPlanDetailsByPlanID retrieves plan details from Stripe's API
 func (s *StripeProvider) getPlanDetailsByPlanID(ctx context.Context, planID string) (string, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", s.name)).With(zap.String("method", "get-plan-details-by-plan-id")).With(zap.String("stripe-plan-id", planID)).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", s.name)).With(zap.String("operation", "get-plan-details-by-plan-id")).With(zap.String("stripe-plan-id", planID))
 
-	log.Info("handle-request-to-get-plan-details-by-plan-id")
+	logger.Info("handle-request-to-get-plan-details-by-plan-id")
 
 	baseURL := s.config.APIBaseURL
 	if baseURL == "" {
@@ -314,18 +314,18 @@ func (s *StripeProvider) getPlanDetailsByPlanID(ctx context.Context, planID stri
 	}
 
 	apiURL := baseURL + "/v1/plans/" + planID
-	body, err := s.callStripeEndpoint(log, "GET", apiURL, nil, []int{http.StatusOK})
+	body, err := s.callStripeEndpoint(logger, "GET", apiURL, nil, []int{http.StatusOK})
 	if err != nil {
 		return "", err
 	}
 
 	var obj map[string]interface{}
 	if err := json.Unmarshal(body, &obj); err != nil {
-		log.Error("failed-to-parse-api-response", zap.Error(err))
+		logger.Error("failed-to-parse-api-response", zap.Error(err))
 		return "", ErrPaymentProviderAPIResponseInvalid
 	}
 
-	log.Info("successfully-retrieved-plan-details")
+	logger.Info("successfully-retrieved-plan-details")
 
 	return getStringField(obj, "usage_type"), nil
 }
@@ -333,9 +333,9 @@ func (s *StripeProvider) getPlanDetailsByPlanID(ctx context.Context, planID stri
 // getCustomerDetailsByCustomerID retrieves customer details from Stripe's API
 func (s *StripeProvider) getCustomerDetailsByCustomerID(ctx context.Context, customerID string) (string, error) {
 
-	log := logger.AcquireFrom(ctx).With(zap.String("provider", s.name)).With(zap.String("method", "get-customer-details-by-customer-id")).With(zap.String("stripe-customer-id", customerID)).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/paymentprovider").With(zap.String("provider", s.name)).With(zap.String("operation", "get-customer-details-by-customer-id")).With(zap.String("stripe-customer-id", customerID))
 
-	log.Info("handle-request-to-get-customer-details-by-customer-id")
+	logger.Info("handle-request-to-get-customer-details-by-customer-id")
 
 	baseURL := s.config.APIBaseURL
 	if baseURL == "" {
@@ -343,18 +343,18 @@ func (s *StripeProvider) getCustomerDetailsByCustomerID(ctx context.Context, cus
 	}
 
 	apiURL := baseURL + "/v1/customers/" + customerID
-	body, err := s.callStripeEndpoint(log, "GET", apiURL, nil, []int{http.StatusOK})
+	body, err := s.callStripeEndpoint(logger, "GET", apiURL, nil, []int{http.StatusOK})
 	if err != nil {
 		return "", err
 	}
 
 	var obj map[string]interface{}
 	if err := json.Unmarshal(body, &obj); err != nil {
-		log.Error("failed-to-parse-api-response", zap.Error(err))
+		logger.Error("failed-to-parse-api-response", zap.Error(err))
 		return "", ErrPaymentProviderAPIResponseInvalid
 	}
 
-	log.Info("successfully-retrieved-customer-details")
+	logger.Info("successfully-retrieved-customer-details")
 
 	var customerEmail = getStringField(obj, "email")
 	if customerEmail == "" {
@@ -365,12 +365,12 @@ func (s *StripeProvider) getCustomerDetailsByCustomerID(ctx context.Context, cus
 }
 
 // callStripeEndpoint is a helper to call Stripe API endpoints
-func (s *StripeProvider) callStripeEndpoint(log *zap.Logger, method, endpoint string, body io.Reader, validHttpStatusCodes []int) ([]byte, error) {
-	log.Info("calling-stripe-endpoint", zap.String("method", method), zap.String("endpoint", endpoint))
+func (s *StripeProvider) callStripeEndpoint(logger *zap.Logger, method, endpoint string, body io.Reader, validHttpStatusCodes []int) ([]byte, error) {
+	logger.Info("calling-stripe-endpoint", zap.String("http-method", method), zap.String("endpoint-host", endpointHostForLog(endpoint)))
 
 	req, err := http.NewRequest(method, endpoint, body)
 	if err != nil {
-		log.Error("failed-to-create-http-request", zap.Error(err))
+		logger.Error("failed-to-create-http-request", zap.Error(err))
 		return nil, ErrPaymentProviderAPIRequestFailed
 	}
 
@@ -380,23 +380,23 @@ func (s *StripeProvider) callStripeEndpoint(log *zap.Logger, method, endpoint st
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Error("http-request-failed", zap.Error(err))
+		logger.Error("http-request-failed", zap.Error(err))
 		return nil, ErrPaymentProviderAPIRequestFailed
 	}
 	defer resp.Body.Close()
 
 	if !slices.Contains(validHttpStatusCodes, resp.StatusCode) {
-		log.Error("http-request-returned-invalid-status", zap.Int("status-code", resp.StatusCode), zap.Ints("valid-status-codes", validHttpStatusCodes))
+		logger.Error("http-request-returned-invalid-status", zap.Int("status-code", resp.StatusCode), zap.Ints("valid-status-codes", validHttpStatusCodes))
 		return nil, ErrPaymentProviderSubscriptionNotFound
 	}
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Error("failed-to-read-http-response-body", zap.Error(err))
+		logger.Error("failed-to-read-http-response-body", zap.Error(err))
 		return nil, ErrPaymentProviderAPIResponseInvalid
 	}
 
-	log.Info("successfully-called-lemon-squeezy-endpoint")
+	logger.Info("successfully-called-lemon-squeezy-endpoint")
 	return responseBody, nil
 }
 

--- a/external/policy/handler.go
+++ b/external/policy/handler.go
@@ -2,10 +2,12 @@ package policy
 
 import (
 	"context"
+	"github.com/ooaklee/ghatd/external/logger"
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/errormanifest"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // policyService manages business logic around policy request
@@ -37,9 +39,11 @@ func NewHandler(service policyService, validator policyValidator, errorMaps ...r
 
 // GetPolicies handles request for returning all policies
 func (h *Handler) GetPolicies(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/policy", "handle-get-policies")
 	request, err := MapRequestToGetPoliciesRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -47,6 +51,7 @@ func (h *Handler) GetPolicies(w http.ResponseWriter, r *http.Request) {
 	policies, err := h.service.GetPolicies(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -58,9 +63,11 @@ func (h *Handler) GetPolicies(w http.ResponseWriter, r *http.Request) {
 // GetPolicyByName handles request for returning a policy with a specific name
 // if found
 func (h *Handler) GetPolicyByName(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/policy", "handle-get-policy-by-name")
 	request, err := MapRequestToGetPolicyByNameRequest(r, h.validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -68,6 +75,7 @@ func (h *Handler) GetPolicyByName(w http.ResponseWriter, r *http.Request) {
 	policy, err := h.service.GetPolicyByName(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/policy/service.go
+++ b/external/policy/service.go
@@ -45,6 +45,9 @@ func NewService(store PolicyStore) *Service {
 
 // GetPolicies retrieves all policies from the store.
 func (s *Service) GetPolicies(ctx context.Context, r *GetPoliciesRequest) ([]WebAppPolicy, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/policy", "get-policies")
+	logger.Debug("handling-get-policies-request")
+
 	return s.Store.GetPolicies(), nil
 }
 
@@ -53,7 +56,7 @@ func (s *Service) GetPolicies(ctx context.Context, r *GetPoliciesRequest) ([]Web
 // Policy names are normalized to lowercase with spaces replaced by hyphens
 // for consistent matching. Returns an error if no matching policy is found.
 func (s *Service) GetPolicyByName(ctx context.Context, r *GetPolicyByNameRequest) (*WebAppPolicy, error) {
-	log := logger.Get(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/policy")
 
 	// Normalize requested policy name
 	standardizedName := standardisePolicyName(r.PolicyName)
@@ -61,7 +64,7 @@ func (s *Service) GetPolicyByName(ctx context.Context, r *GetPolicyByNameRequest
 	for _, policy := range s.Store.GetPolicies() {
 		policyName := standardisePolicyName(policy.Name)
 
-		log.Debug("comparing-policy-names",
+		logger.Debug("comparing-policy-names",
 			zap.String("policy", policyName),
 			zap.String("requested", standardizedName))
 

--- a/external/post/logging.go
+++ b/external/post/logging.go
@@ -1,0 +1,7 @@
+package post
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/post/service.go
+++ b/external/post/service.go
@@ -51,9 +51,7 @@ func NewService(contenterRepository contenterRepository, validChangelogTags []st
 func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*CreatePostResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 
 		newPost                 *Post
 		standardiseTitle        string
@@ -63,7 +61,7 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 		err                     error
 	)
 
-	logger.Debug("initiating-create-post-request", zap.Any("request", req))
+	logger.Debug("initiating-create-post-request", zap.Any("request", safeLogValue(req)))
 
 	if req.UserId == "" {
 		logger.Warn("a-user-id-must-be-given-to-create-a-post")
@@ -83,7 +81,7 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 	}
 
 	if standardiseTitle == "" {
-		logger.Warn("attempt-made-to-create-post-without-title", zap.Any("request", req))
+		logger.Warn("attempt-made-to-create-post-without-title", zap.Any("request", safeLogValue(req)))
 		return nil, ErrRequiredPostTitleIsMissing
 	}
 
@@ -92,7 +90,7 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 	}
 
 	if standardisedText == "" {
-		logger.Warn("attempt-made-to-create-post-without-text", zap.Any("request", req))
+		logger.Warn("attempt-made-to-create-post-without-text", zap.Any("request", safeLogValue(req)))
 		return nil, ErrRequiredPostTextIsMissing
 	}
 
@@ -133,7 +131,7 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 	// verify that  blog has header image and everything else does not
 	// if blog does not have one provided, bad request
 	if newPost.Type == PostTypeArticle && newPost.HeaderImage == "" {
-		logger.Warn("attempt-made-to-create-post-without-header-image", zap.Any("request", req))
+		logger.Warn("attempt-made-to-create-post-without-header-image", zap.Any("request", safeLogValue(req)))
 		return nil, ErrHeaderImageMissing
 	}
 
@@ -143,19 +141,19 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 
 	_, err = newPost.SetHeaderImageType()
 	if err != nil {
-		logger.Warn("attempt-made-to-create-post-with-invalid-header-image", zap.Any("request", req))
+		logger.Warn("attempt-made-to-create-post-with-invalid-header-image", zap.Any("request", safeLogValue(req)))
 		return nil, err
 	}
 	err = newPost.ValidateHeaderImageHasRequiredAltTextAlternativeElementsForInlineSvg()
 	if err != nil {
-		logger.Warn("attempt-made-to-create-post-with-invalid-svg-header-image", zap.Any("request", req))
+		logger.Warn("attempt-made-to-create-post-with-invalid-svg-header-image", zap.Any("request", safeLogValue(req)))
 		return nil, err
 	}
 
 	// Verify that changelog can only be tagged with valid tag i.e.
 	// announcement, bug-fix, product-news, exciting-news
 	if newPost.Type == PostTypeChangelog && len(s.validChangelogTags) > 0 && len(newPost.Tags) == 0 {
-		logger.Warn("attempt-made-to-create-changelog-post-without-tags", zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", req))
+		logger.Warn("attempt-made-to-create-changelog-post-without-tags", zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", safeLogValue(req)))
 		return nil, ErrChangelogPostMustHaveValidTagsSet
 	}
 
@@ -169,7 +167,7 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 		}
 
 		if len(invalidTags) > 0 {
-			logger.Warn("attempt-made-to-create-changelog-post-with-invalid-tags", zap.Strings("invalid-tags", invalidTags), zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", req))
+			logger.Warn("attempt-made-to-create-changelog-post-with-invalid-tags", zap.Strings("invalid-tags", invalidTags), zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", safeLogValue(req)))
 			return nil, ErrChangelogPostMustHaveValidTagsSet
 		}
 	}
@@ -180,17 +178,17 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 	// check to make sure url friendly is is not already being used
 	_, err = s.contenterRepository.GetPostByUrlFriendlyId(ctx, newPost.UrlFriendlyId)
 	if err == nil {
-		logger.Warn("attempt-made-to-create-post-with-existing-url-friendly-id", zap.Any("new-post", newPost))
+		logger.Warn("attempt-made-to-create-post-with-existing-url-friendly-id", zap.Any("new-post", safeLogValue(newPost)))
 		return nil, ErrPostAlreadyExistsWithGivenUrlFriendlyId
 	}
 
 	createdPost, err := s.contenterRepository.CreatePost(ctx, newPost)
 	if err != nil {
-		logger.Error("failed-to-create-post-error-creating-post", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-post-error-creating-post", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CreatePostResponse{}, err
 	}
 
-	logger.Debug("create-post-request-successful", zap.Any("request", req), zap.Any("created-post", createdPost))
+	logger.Debug("create-post-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("created-post", safeLogValue(createdPost)))
 
 	return &CreatePostResponse{
 		Post: createdPost,
@@ -201,9 +199,7 @@ func (s *Service) CreatePost(ctx context.Context, req *CreatePostRequest) (*Crea
 func (s *Service) GetPosts(ctx context.Context, req *GetPostsRequest) (*GetPostsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 	)
 
 	// default
@@ -270,16 +266,16 @@ func (s *Service) GetPosts(ctx context.Context, req *GetPostsRequest) (*GetPosts
 	}
 	totalPosts, err := s.contenterRepository.GetTotalPosts(ctx, getTotalPostsRequest)
 	if err != nil {
-		logger.Error("failed-to-get-posts-request-error-getting-total-posts", zap.Any("request", req), zap.Any("get-total-posts-request", getTotalPostsRequest), zap.Error(err))
+		logger.Error("failed-to-get-posts-request-error-getting-total-posts", zap.Any("request", safeLogValue(req)), zap.Any("get-total-posts-request", safeLogValue(getTotalPostsRequest)), zap.Error(err))
 		return &GetPostsResponse{}, err
 	}
 
 	req.TotalCount = int(totalPosts)
-	logger.Debug("handling-get-posts-request-total-posts-found", zap.Int64("total", totalPosts), zap.Any("request", req))
+	logger.Debug("handling-get-posts-request-total-posts-found", zap.Int64("total", totalPosts), zap.Any("request", safeLogValue(req)))
 
 	posts, err := s.contenterRepository.GetPosts(ctx, req)
 	if err != nil {
-		logger.Error("failed-to-get-posts-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-posts-request-error-getting-posts", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetPostsResponse{}, err
 	}
 
@@ -307,6 +303,9 @@ func (s *Service) GetPosts(ctx context.Context, req *GetPostsRequest) (*GetPosts
 // TODO: how should we handle when target post is soft deleted?
 // normal users should not see this
 func (s *Service) GetPostByUrlFriendlyId(ctx context.Context, urlFriendlyId string) (*Post, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/post", "get-post-by-url-friendly-id")
+	logger.Debug("handling-get-post-by-url-friendly-id-request")
+
 	return s.contenterRepository.GetPostByUrlFriendlyId(ctx, urlFriendlyId)
 }
 
@@ -314,18 +313,16 @@ func (s *Service) GetPostByUrlFriendlyId(ctx context.Context, urlFriendlyId stri
 func (s *Service) GetChangelogItems(ctx context.Context, req *GetChangelogItemsRequest) (*GetChangelogItemsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 	)
 
-	logger.Debug("handling-get-changelog-items-request", zap.Any("request", req))
+	logger.Debug("handling-get-changelog-items-request", zap.Any("request", safeLogValue(req)))
 
 	req.GetPostsRequest.WithTypes = string(PostTypeChangelog)
 
 	retrievedPosts, err := s.GetPosts(ctx, req.GetPostsRequest)
 	if err != nil {
-		logger.Error("failed-to-get-changelog-items-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-changelog-items-request-error-getting-posts", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
@@ -339,18 +336,16 @@ func (s *Service) GetChangelogItems(ctx context.Context, req *GetChangelogItemsR
 func (s *Service) GetGlossaryItems(ctx context.Context, req *GetGlossaryItemsRequest) (*GetGlossaryItemsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 	)
 
-	logger.Debug("handling-get-glossary-items-request", zap.Any("request", req))
+	logger.Debug("handling-get-glossary-items-request", zap.Any("request", safeLogValue(req)))
 
 	req.GetPostsRequest.WithTypes = string(PostTypeGlossary)
 
 	retrievedPosts, err := s.GetPosts(ctx, req.GetPostsRequest)
 	if err != nil {
-		logger.Error("failed-to-get-glossary-items-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-glossary-items-request-error-getting-posts", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
@@ -364,18 +359,16 @@ func (s *Service) GetGlossaryItems(ctx context.Context, req *GetGlossaryItemsReq
 func (s *Service) GetFaqItems(ctx context.Context, req *GetFaqItemsRequest) (*GetFaqItemsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 	)
 
-	logger.Debug("handling-get-faq-items-request", zap.Any("request", req))
+	logger.Debug("handling-get-faq-items-request", zap.Any("request", safeLogValue(req)))
 
 	req.GetPostsRequest.WithTypes = string(PostTypeFaq)
 
 	retrievedPosts, err := s.GetPosts(ctx, req.GetPostsRequest)
 	if err != nil {
-		logger.Error("failed-to-get-faq-items-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-faq-items-request-error-getting-posts", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
@@ -389,18 +382,16 @@ func (s *Service) GetFaqItems(ctx context.Context, req *GetFaqItemsRequest) (*Ge
 func (s *Service) GetArticles(ctx context.Context, req *GetArticlesRequest) (*GetArticlesResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 	)
 
-	logger.Debug("handling-get-articles-request", zap.Any("request", req))
+	logger.Debug("handling-get-articles-request", zap.Any("request", safeLogValue(req)))
 
 	req.GetPostsRequest.WithTypes = string(PostTypeArticle)
 
 	retrievedPosts, err := s.GetPosts(ctx, req.GetPostsRequest)
 	if err != nil {
-		logger.Error("failed-to-get-articles-request-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-articles-request-error-getting-posts", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
@@ -414,9 +405,7 @@ func (s *Service) GetArticles(ctx context.Context, req *GetArticlesRequest) (*Ge
 func (s *Service) UpdatePost(ctx context.Context, req *UpdatePostRequest) (*UpdatePostResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 
 		postToUpdate        *Post
 		err                 error
@@ -424,7 +413,7 @@ func (s *Service) UpdatePost(ctx context.Context, req *UpdatePostRequest) (*Upda
 		urlFriendlyIdChange bool
 	)
 
-	logger.Debug("initiating-update-post-request", zap.Any("request", req))
+	logger.Debug("initiating-update-post-request", zap.Any("request", safeLogValue(req)))
 
 	if req.UserId == "" {
 		logger.Warn("a-user-id-must-be-given-to-update-a-post")
@@ -528,19 +517,19 @@ func (s *Service) UpdatePost(ctx context.Context, req *UpdatePostRequest) (*Upda
 
 	// Validate title is not empty
 	if strings.TrimSpace(postToUpdate.Title) == "" {
-		logger.Warn("attempt-made-to-update-post-with-empty-title", zap.Any("request", req))
+		logger.Warn("attempt-made-to-update-post-with-empty-title", zap.Any("request", safeLogValue(req)))
 		return nil, ErrRequiredPostTitleIsMissing
 	}
 
 	// Validate text is not empty
 	if strings.TrimSpace(postToUpdate.Text) == "" {
-		logger.Warn("attempt-made-to-update-post-with-empty-text", zap.Any("request", req))
+		logger.Warn("attempt-made-to-update-post-with-empty-text", zap.Any("request", safeLogValue(req)))
 		return nil, ErrRequiredPostTextIsMissing
 	}
 
 	// Validate header image requirements for articles
 	if postToUpdate.Type == PostTypeArticle && postToUpdate.HeaderImage == "" {
-		logger.Warn("attempt-made-to-update-article-post-without-header-image", zap.Any("request", req))
+		logger.Warn("attempt-made-to-update-article-post-without-header-image", zap.Any("request", safeLogValue(req)))
 		return nil, ErrHeaderImageMissing
 	}
 
@@ -552,19 +541,19 @@ func (s *Service) UpdatePost(ctx context.Context, req *UpdatePostRequest) (*Upda
 	if postToUpdate.HeaderImage != "" {
 		_, err = postToUpdate.SetHeaderImageType()
 		if err != nil {
-			logger.Warn("attempt-made-to-update-post-with-invalid-header-image", zap.Any("request", req))
+			logger.Warn("attempt-made-to-update-post-with-invalid-header-image", zap.Any("request", safeLogValue(req)))
 			return nil, err
 		}
 		err = postToUpdate.ValidateHeaderImageHasRequiredAltTextAlternativeElementsForInlineSvg()
 		if err != nil {
-			logger.Warn("attempt-made-to-update-post-with-invalid-svg-header-image", zap.Any("request", req))
+			logger.Warn("attempt-made-to-update-post-with-invalid-svg-header-image", zap.Any("request", safeLogValue(req)))
 			return nil, err
 		}
 	}
 
 	// Verify changelog tags if applicable
 	if postToUpdate.Type == PostTypeChangelog && len(s.validChangelogTags) > 0 && len(postToUpdate.Tags) == 0 {
-		logger.Warn("attempt-made-to-update-changelog-post-without-tags", zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", req))
+		logger.Warn("attempt-made-to-update-changelog-post-without-tags", zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", safeLogValue(req)))
 		return nil, ErrChangelogPostMustHaveValidTagsSet
 	}
 
@@ -578,7 +567,7 @@ func (s *Service) UpdatePost(ctx context.Context, req *UpdatePostRequest) (*Upda
 		}
 
 		if len(invalidTags) > 0 {
-			logger.Warn("attempt-made-to-update-changelog-post-with-invalid-tags", zap.Strings("invalid-tags", invalidTags), zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", req))
+			logger.Warn("attempt-made-to-update-changelog-post-with-invalid-tags", zap.Strings("invalid-tags", invalidTags), zap.Strings("valid-tags", s.validChangelogTags), zap.Any("request", safeLogValue(req)))
 			return nil, ErrChangelogPostMustHaveValidTagsSet
 		}
 	}
@@ -604,11 +593,11 @@ func (s *Service) UpdatePost(ctx context.Context, req *UpdatePostRequest) (*Upda
 
 	updatedPost, err := s.contenterRepository.UpdatePost(ctx, postToUpdate)
 	if err != nil {
-		logger.Error("failed-to-update-post-error-updating-post", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-update-post-error-updating-post", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &UpdatePostResponse{}, err
 	}
 
-	logger.Debug("update-post-request-successful", zap.Any("request", req), zap.Any("updated-post", updatedPost))
+	logger.Debug("update-post-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("updated-post", safeLogValue(updatedPost)))
 
 	return &UpdatePostResponse{
 		Post: updatedPost,
@@ -641,12 +630,10 @@ func (s *Service) parsePostPublishTime(publishAtUtc string, logger *zap.Logger) 
 func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsByTypeRequest) (*GetLatestPostsByTypeResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 	)
 
-	logger.Debug("handling-get-latest-posts-by-type-request", zap.Any("request", req))
+	logger.Debug("handling-get-latest-posts-by-type-request", zap.Any("request", safeLogValue(req)))
 
 	// Default to article,changelog if no types specified
 	types := req.Types
@@ -681,7 +668,7 @@ func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsB
 	// Get posts with unique type enforcement
 	retrievedPosts, err := s.GetPosts(ctx, getPostsReq)
 	if err != nil {
-		logger.Error("failed-to-get-latest-posts-by-type-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-latest-posts-by-type-error-getting-posts", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
@@ -699,7 +686,7 @@ func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsB
 
 	logger.Debug("retrieved-posts-by-type", zap.Int("total-posts", len(retrievedPosts.Posts)), zap.Int("unique-types", len(postOverviews)))
 
-	logger.Debug("get-latest-posts-by-type-request-successful", zap.Any("request", req), zap.Int("types-count", len(postOverviews)))
+	logger.Debug("get-latest-posts-by-type-request-successful", zap.Any("request", safeLogValue(req)), zap.Int("types-count", len(postOverviews)))
 
 	return &GetLatestPostsByTypeResponse{
 		Overviews: postOverviews,
@@ -709,12 +696,10 @@ func (s *Service) GetLatestPostsByType(ctx context.Context, req *GetLatestPostsB
 // GetLatestNotificationOverviews returns the latest notification overviews for the given notification kinds
 func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *common.GetLatestNotificationOverviewsRequest) (*common.GetLatestNotificationOverviewsResponse, error) {
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 	)
 
-	logger.Debug("handling-get-latest-notification-overviews-request", zap.Any("request", req))
+	logger.Debug("handling-get-latest-notification-overviews-request", zap.Any("request", safeLogValue(req)))
 
 	limit := req.Limit
 	if limit <= 0 {
@@ -765,7 +750,7 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *commo
 		EnforceUniqueType: true,
 	})
 	if err != nil {
-		logger.Error("failed-to-get-latest-notification-overviews-error-getting-posts", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-latest-notification-overviews-error-getting-posts", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
@@ -786,12 +771,10 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, req *commo
 func (s *Service) DeletePostById(ctx context.Context, req *DeletePostByIdRequest) (*DeletePostByIdResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger   *zap.Logger             = logger.AcquirePackageFrom(ctx, "external/post")
 		response *DeletePostByIdResponse = &DeletePostByIdResponse{}
 	)
-	logger.Debug("handling-delete-post-by-id-request", zap.Any("request", req))
+	logger.Debug("handling-delete-post-by-id-request", zap.Any("request", safeLogValue(req)))
 
 	if req.Id == "" {
 		logger.Warn("attempt-made-to-delete-post-without-post-id")
@@ -814,7 +797,7 @@ func (s *Service) DeletePostById(ctx context.Context, req *DeletePostByIdRequest
 		// Perform hard delete
 		err := s.contenterRepository.DeletePost(ctx, postToDelete.Id)
 		if err != nil {
-			logger.Error("failed-to-delete-post-error-deleting-post", zap.Any("request", req), zap.Error(err))
+			logger.Error("failed-to-delete-post-error-deleting-post", zap.Any("request", safeLogValue(req)), zap.Error(err))
 			return nil, err
 		}
 		response.HardDelete = true
@@ -827,13 +810,13 @@ func (s *Service) DeletePostById(ctx context.Context, req *DeletePostByIdRequest
 
 		err = s.contenterRepository.SoftDeletePost(ctx, postToDelete, req.UserId)
 		if err != nil {
-			logger.Error("failed-to-soft-delete-post-error-soft-deleting-post", zap.Any("request", req), zap.Error(err))
+			logger.Error("failed-to-soft-delete-post-error-soft-deleting-post", zap.Any("request", safeLogValue(req)), zap.Error(err))
 			return nil, err
 		}
 		response.HardDelete = false
 	}
 
-	logger.Debug("delete-post-by-id-request-successful", zap.Any("request", req))
+	logger.Debug("delete-post-by-id-request-successful", zap.Any("request", safeLogValue(req)))
 
 	return response, nil
 }
@@ -841,12 +824,10 @@ func (s *Service) DeletePostById(ctx context.Context, req *DeletePostByIdRequest
 // RestorePostById restores a soft deleted post by its ID
 func (s *Service) RestorePostById(ctx context.Context, req *RestorePostByIdRequest) (*RestorePostByIdResponse, error) {
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/post")
 	)
 
-	logger.Debug("handling-restore-post-by-id-request", zap.Any("request", req))
+	logger.Debug("handling-restore-post-by-id-request", zap.Any("request", safeLogValue(req)))
 
 	if req.Id == "" {
 		logger.Warn("attempt-made-to-restore-post-without-post-id")
@@ -883,11 +864,11 @@ func (s *Service) RestorePostById(ctx context.Context, req *RestorePostByIdReque
 
 	restoredPost, err := s.contenterRepository.UpdatePost(ctx, postToRestore)
 	if err != nil {
-		logger.Error("failed-to-restore-post-error-restoring-post", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-restore-post-error-restoring-post", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
-	logger.Info("restore-post-by-id-request-successful", zap.Any("request", req), zap.Any("restored-post", restoredPost))
+	logger.Info("restore-post-by-id-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("restored-post", safeLogValue(restoredPost)))
 
 	return &RestorePostByIdResponse{
 		Post: restoredPost,

--- a/external/pricer/handler.go
+++ b/external/pricer/handler.go
@@ -2,10 +2,12 @@ package pricer
 
 import (
 	"context"
+	"github.com/ooaklee/ghatd/external/logger"
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/errormanifest"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // PriceService interface defines expected methods of a valid pricer service.
@@ -43,14 +45,17 @@ func NewHandler(service PriceService, validator PricerValidator, errorMaps ...re
 
 // CreatePricePlan handles price plan creation.
 func (h *Handler) CreatePricePlan(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-create-price-plan")
 	request, err := MapRequestToCreatePricePlanRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.CreatePricePlan(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -60,14 +65,17 @@ func (h *Handler) CreatePricePlan(w http.ResponseWriter, r *http.Request) {
 
 // UpdatePricePlan handles price plan updates.
 func (h *Handler) UpdatePricePlan(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-update-price-plan")
 	request, err := MapRequestToUpdatePricePlanRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdatePricePlan(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -77,14 +85,17 @@ func (h *Handler) UpdatePricePlan(w http.ResponseWriter, r *http.Request) {
 
 // GetPricePlanByID handles getting a price plan by ID.
 func (h *Handler) GetPricePlanByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-get-price-plan-by-id")
 	request, err := MapRequestToGetPricePlanByIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetPricePlanByID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -94,14 +105,17 @@ func (h *Handler) GetPricePlanByID(w http.ResponseWriter, r *http.Request) {
 
 // GetPricePlanBySlug handles getting a price plan by slug.
 func (h *Handler) GetPricePlanBySlug(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-get-price-plan-by-slug")
 	request, err := MapRequestToGetPricePlanBySlugRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetPricePlanBySlug(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -111,14 +125,17 @@ func (h *Handler) GetPricePlanBySlug(w http.ResponseWriter, r *http.Request) {
 
 // GetPricePlans handles getting price plans.
 func (h *Handler) GetPricePlans(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-get-price-plans")
 	request, err := MapRequestToGetPricePlansRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetPricePlans(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -133,14 +150,17 @@ func (h *Handler) GetPricePlans(w http.ResponseWriter, r *http.Request) {
 
 // ValidatePriceSlug handles pricing slug validation without persisting anything.
 func (h *Handler) ValidatePriceSlug(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-validate-price-slug")
 	request, err := MapRequestToValidatePriceSlugRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ValidatePriceSlug(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -150,14 +170,17 @@ func (h *Handler) ValidatePriceSlug(w http.ResponseWriter, r *http.Request) {
 
 // PublishPricePlan handles price plan publishing.
 func (h *Handler) PublishPricePlan(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-publish-price-plan")
 	request, err := MapRequestToPublishPricePlanRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.PublishPricePlan(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -167,14 +190,17 @@ func (h *Handler) PublishPricePlan(w http.ResponseWriter, r *http.Request) {
 
 // ArchivePricePlan handles price plan archiving.
 func (h *Handler) ArchivePricePlan(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-archive-price-plan")
 	request, err := MapRequestToArchivePricePlanRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ArchivePricePlan(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -184,14 +210,17 @@ func (h *Handler) ArchivePricePlan(w http.ResponseWriter, r *http.Request) {
 
 // DeletePricePlan handles price plan soft deletion.
 func (h *Handler) DeletePricePlan(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-delete-price-plan")
 	request, err := MapRequestToDeletePricePlanRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.DeletePricePlan(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -201,14 +230,17 @@ func (h *Handler) DeletePricePlan(w http.ResponseWriter, r *http.Request) {
 
 // CreateFeature handles feature creation.
 func (h *Handler) CreateFeature(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-create-feature")
 	request, err := MapRequestToCreateFeatureRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.CreateFeature(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -218,14 +250,17 @@ func (h *Handler) CreateFeature(w http.ResponseWriter, r *http.Request) {
 
 // UpdateFeature handles feature updates.
 func (h *Handler) UpdateFeature(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-update-feature")
 	request, err := MapRequestToUpdateFeatureRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateFeature(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -235,14 +270,17 @@ func (h *Handler) UpdateFeature(w http.ResponseWriter, r *http.Request) {
 
 // GetFeatures handles getting feature catalog items.
 func (h *Handler) GetFeatures(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-get-features")
 	request, err := MapRequestToGetFeaturesRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetFeatures(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -257,14 +295,17 @@ func (h *Handler) GetFeatures(w http.ResponseWriter, r *http.Request) {
 
 // DeleteFeature handles feature soft deletion.
 func (h *Handler) DeleteFeature(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/pricer", "handle-delete-feature")
 	request, err := MapRequestToDeleteFeatureRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.DeleteFeature(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/pricer/logging.go
+++ b/external/pricer/logging.go
@@ -1,0 +1,7 @@
+package pricer
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/pricer/service.go
+++ b/external/pricer/service.go
@@ -51,8 +51,8 @@ func NewService(pricerRepository PricerRepository) *Service {
 
 // CreatePricePlan creates a new price plan.
 func (s *Service) CreatePricePlan(ctx context.Context, req *CreatePricePlanRequest) (*CreatePricePlanResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("initiating-create-price-plan-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/pricer")
+	logger.Debug("initiating-create-price-plan-request", zap.Any("request", safeLogValue(req)))
 
 	if req == nil {
 		return nil, ErrInvalidPricePlanPayload
@@ -106,13 +106,13 @@ func (s *Service) CreatePricePlan(ctx context.Context, req *CreatePricePlanReque
 	}
 
 	if err := pricePlan.Validate(); err != nil {
-		log.Warn("attempt-made-to-create-invalid-price-plan", zap.Any("price_plan", pricePlan), zap.Error(err))
+		logger.Warn("attempt-made-to-create-invalid-price-plan", zap.Any("price_plan", safeLogValue(pricePlan)), zap.Error(err))
 		return nil, err
 	}
 
 	createdPricePlan, err := s.PricerRepository.CreatePricePlan(ctx, pricePlan)
 	if err != nil {
-		log.Error("failed-to-create-price-plan", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-price-plan", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CreatePricePlanResponse{}, err
 	}
 
@@ -121,8 +121,8 @@ func (s *Service) CreatePricePlan(ctx context.Context, req *CreatePricePlanReque
 
 // UpdatePricePlan updates an existing price plan.
 func (s *Service) UpdatePricePlan(ctx context.Context, req *UpdatePricePlanRequest) (*UpdatePricePlanResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("initiating-update-price-plan-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/pricer")
+	logger.Debug("initiating-update-price-plan-request", zap.Any("request", safeLogValue(req)))
 
 	if req == nil {
 		return nil, ErrInvalidPricePlanPayload
@@ -144,7 +144,7 @@ func (s *Service) UpdatePricePlan(ctx context.Context, req *UpdatePricePlanReque
 			IncludeProviders: true,
 		})
 		if err != nil {
-			log.Warn("attempt-made-to-update-missing-price-plan", zap.String("price_plan_id", req.ID), zap.Error(err))
+			logger.Warn("attempt-made-to-update-missing-price-plan", zap.String("price_plan_id", req.ID), zap.Error(err))
 			return nil, err
 		}
 
@@ -182,7 +182,7 @@ func (s *Service) UpdatePricePlan(ctx context.Context, req *UpdatePricePlanReque
 		return nil, ErrPricePlanIDRequired
 	} else {
 		if _, err := s.PricerRepository.GetPricePlanByID(ctx, pricePlanToUpdate.ID, &GetPricePlanByIDRequest{}); err != nil {
-			log.Warn("attempt-made-to-update-missing-price-plan", zap.String("price_plan_id", pricePlanToUpdate.ID), zap.Error(err))
+			logger.Warn("attempt-made-to-update-missing-price-plan", zap.String("price_plan_id", pricePlanToUpdate.ID), zap.Error(err))
 			return nil, err
 		}
 	}
@@ -200,13 +200,13 @@ func (s *Service) UpdatePricePlan(ctx context.Context, req *UpdatePricePlanReque
 	}
 
 	if err := pricePlanToUpdate.Validate(); err != nil {
-		log.Warn("attempt-made-to-update-invalid-price-plan", zap.Any("price_plan", pricePlanToUpdate), zap.Error(err))
+		logger.Warn("attempt-made-to-update-invalid-price-plan", zap.Any("price_plan", safeLogValue(pricePlanToUpdate)), zap.Error(err))
 		return nil, err
 	}
 
 	updatedPricePlan, err := s.PricerRepository.UpdatePricePlan(ctx, pricePlanToUpdate)
 	if err != nil {
-		log.Error("failed-to-update-price-plan", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-update-price-plan", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &UpdatePricePlanResponse{}, err
 	}
 
@@ -215,6 +215,9 @@ func (s *Service) UpdatePricePlan(ctx context.Context, req *UpdatePricePlanReque
 
 // GetPricePlanByID returns a price plan by ID.
 func (s *Service) GetPricePlanByID(ctx context.Context, req *GetPricePlanByIDRequest) (*GetPricePlanByIDResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/pricer", "get-price-plan-by-id")
+	logger.Debug("handling-get-price-plan-by-id-request")
+
 	if req == nil || strings.TrimSpace(req.ID) == "" {
 		return nil, ErrPricePlanIDRequired
 	}
@@ -231,6 +234,9 @@ func (s *Service) GetPricePlanByID(ctx context.Context, req *GetPricePlanByIDReq
 
 // GetPricePlanBySlug returns a price plan by slug.
 func (s *Service) GetPricePlanBySlug(ctx context.Context, req *GetPricePlanBySlugRequest) (*GetPricePlanBySlugResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/pricer", "get-price-plan-by-slug")
+	logger.Debug("handling-get-price-plan-by-slug-request")
+
 	if req == nil || strings.TrimSpace(req.Slug) == "" {
 		return nil, ErrInvalidPriceSlug
 	}
@@ -248,7 +254,7 @@ func (s *Service) GetPricePlanBySlug(ctx context.Context, req *GetPricePlanBySlu
 
 // GetPricePlans returns a list of price plans.
 func (s *Service) GetPricePlans(ctx context.Context, req *GetPricePlansRequest) (*GetPricePlansResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/pricer")
 
 	if req == nil {
 		req = &GetPricePlansRequest{}
@@ -263,14 +269,14 @@ func (s *Service) GetPricePlans(ctx context.Context, req *GetPricePlansRequest) 
 
 	total, err := s.PricerRepository.GetTotalPricePlans(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-price-plans-total", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-price-plans-total", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetPricePlansResponse{}, err
 	}
 	req.TotalCount = int(total)
 
 	pricePlans, err := s.PricerRepository.GetPricePlans(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-price-plans", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-price-plans", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetPricePlansResponse{}, err
 	}
 
@@ -293,6 +299,9 @@ func (s *Service) GetPricePlans(ctx context.Context, req *GetPricePlansRequest) 
 
 // ValidatePriceSlug returns the normalized slug and availability for a pricing resource.
 func (s *Service) ValidatePriceSlug(ctx context.Context, req *ValidatePriceSlugRequest) (*ValidatePriceSlugResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/pricer", "validate-price-slug")
+	logger.Debug("handling-validate-price-slug-request")
+
 	if req == nil {
 		return nil, ErrInvalidPriceQueryParam
 	}
@@ -386,7 +395,7 @@ func normalisePriceSlugResourceType(value string) (string, string, error) {
 
 // PublishPricePlan publishes a price plan.
 func (s *Service) PublishPricePlan(ctx context.Context, req *PublishPricePlanRequest) (*PublishPricePlanResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/pricer")
 
 	if req == nil || strings.TrimSpace(req.ID) == "" {
 		return nil, ErrPricePlanIDRequired
@@ -406,7 +415,7 @@ func (s *Service) PublishPricePlan(ctx context.Context, req *PublishPricePlanReq
 		IncludeProviders: true,
 	})
 	if err != nil {
-		log.Warn("attempt-made-to-publish-missing-price-plan", zap.String("price_plan_id", req.ID), zap.Error(err))
+		logger.Warn("attempt-made-to-publish-missing-price-plan", zap.String("price_plan_id", req.ID), zap.Error(err))
 		return nil, err
 	}
 
@@ -428,7 +437,7 @@ func (s *Service) PublishPricePlan(ctx context.Context, req *PublishPricePlanReq
 
 	err = s.PricerRepository.PublishPricePlan(ctx, req.ID, req.UserID, pricePlan.PublishedAt)
 	if err != nil {
-		log.Error("failed-to-publish-price-plan", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-publish-price-plan", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &PublishPricePlanResponse{}, err
 	}
 
@@ -446,6 +455,9 @@ func (s *Service) PublishPricePlan(ctx context.Context, req *PublishPricePlanReq
 
 // ArchivePricePlan archives a price plan.
 func (s *Service) ArchivePricePlan(ctx context.Context, req *ArchivePricePlanRequest) (*ArchivePricePlanResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/pricer", "archive-price-plan")
+	logger.Debug("handling-archive-price-plan-request")
+
 	if req == nil || strings.TrimSpace(req.ID) == "" {
 		return nil, ErrPricePlanIDRequired
 	}
@@ -472,6 +484,9 @@ func (s *Service) ArchivePricePlan(ctx context.Context, req *ArchivePricePlanReq
 
 // DeletePricePlan soft-deletes a price plan.
 func (s *Service) DeletePricePlan(ctx context.Context, req *DeletePricePlanRequest) (*DeletePricePlanResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/pricer", "delete-price-plan")
+	logger.Debug("handling-delete-price-plan-request")
+
 	if req == nil || strings.TrimSpace(req.ID) == "" {
 		return nil, ErrPricePlanIDRequired
 	}
@@ -498,7 +513,7 @@ func (s *Service) DeletePricePlan(ctx context.Context, req *DeletePricePlanReque
 
 // CreateFeature creates a feature catalog item.
 func (s *Service) CreateFeature(ctx context.Context, req *CreateFeatureRequest) (*CreateFeatureResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/pricer")
 
 	if req == nil {
 		return nil, ErrInvalidPriceFeaturePayload
@@ -538,13 +553,13 @@ func (s *Service) CreateFeature(ctx context.Context, req *CreateFeatureRequest) 
 	}
 
 	if err := feature.Validate(); err != nil {
-		log.Warn("attempt-made-to-create-invalid-price-feature", zap.Any("feature", feature), zap.Error(err))
+		logger.Warn("attempt-made-to-create-invalid-price-feature", zap.Any("feature", safeLogValue(feature)), zap.Error(err))
 		return nil, err
 	}
 
 	createdFeature, err := s.PricerRepository.CreateFeature(ctx, feature)
 	if err != nil {
-		log.Error("failed-to-create-price-feature", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-price-feature", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CreateFeatureResponse{}, err
 	}
 
@@ -553,7 +568,7 @@ func (s *Service) CreateFeature(ctx context.Context, req *CreateFeatureRequest) 
 
 // UpdateFeature updates a feature catalog item.
 func (s *Service) UpdateFeature(ctx context.Context, req *UpdateFeatureRequest) (*UpdateFeatureResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/pricer")
 
 	if req == nil {
 		return nil, ErrInvalidPriceFeaturePayload
@@ -571,7 +586,7 @@ func (s *Service) UpdateFeature(ctx context.Context, req *UpdateFeatureRequest) 
 		var err error
 		featureToUpdate, err = s.PricerRepository.GetFeatureByID(ctx, req.ID)
 		if err != nil {
-			log.Warn("attempt-made-to-update-missing-price-feature", zap.String("feature_id", req.ID), zap.Error(err))
+			logger.Warn("attempt-made-to-update-missing-price-feature", zap.String("feature_id", req.ID), zap.Error(err))
 			return nil, err
 		}
 
@@ -600,7 +615,7 @@ func (s *Service) UpdateFeature(ctx context.Context, req *UpdateFeatureRequest) 
 		return nil, ErrPriceFeatureIDRequired
 	} else {
 		if _, err := s.PricerRepository.GetFeatureByID(ctx, featureToUpdate.ID); err != nil {
-			log.Warn("attempt-made-to-update-missing-price-feature", zap.String("feature_id", featureToUpdate.ID), zap.Error(err))
+			logger.Warn("attempt-made-to-update-missing-price-feature", zap.String("feature_id", featureToUpdate.ID), zap.Error(err))
 			return nil, err
 		}
 	}
@@ -612,13 +627,13 @@ func (s *Service) UpdateFeature(ctx context.Context, req *UpdateFeatureRequest) 
 	featureToUpdate.UpdatedByID = req.UserID
 
 	if err := featureToUpdate.Validate(); err != nil {
-		log.Warn("attempt-made-to-update-invalid-price-feature", zap.Any("feature", featureToUpdate), zap.Error(err))
+		logger.Warn("attempt-made-to-update-invalid-price-feature", zap.Any("feature", safeLogValue(featureToUpdate)), zap.Error(err))
 		return nil, err
 	}
 
 	updatedFeature, err := s.PricerRepository.UpdateFeature(ctx, featureToUpdate)
 	if err != nil {
-		log.Error("failed-to-update-price-feature", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-update-price-feature", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &UpdateFeatureResponse{}, err
 	}
 
@@ -627,7 +642,7 @@ func (s *Service) UpdateFeature(ctx context.Context, req *UpdateFeatureRequest) 
 
 // GetFeatures returns feature catalog items.
 func (s *Service) GetFeatures(ctx context.Context, req *GetFeaturesRequest) (*GetFeaturesResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/pricer")
 
 	if req == nil {
 		req = &GetFeaturesRequest{}
@@ -642,14 +657,14 @@ func (s *Service) GetFeatures(ctx context.Context, req *GetFeaturesRequest) (*Ge
 
 	total, err := s.PricerRepository.GetTotalFeatures(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-features-total", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-features-total", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetFeaturesResponse{}, err
 	}
 	req.TotalCount = int(total)
 
 	features, err := s.PricerRepository.GetFeatures(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-features", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-features", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetFeaturesResponse{}, err
 	}
 
@@ -672,6 +687,9 @@ func (s *Service) GetFeatures(ctx context.Context, req *GetFeaturesRequest) (*Ge
 
 // DeleteFeature soft-deletes a feature catalog item.
 func (s *Service) DeleteFeature(ctx context.Context, req *DeleteFeatureRequest) (*DeleteFeatureResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/pricer", "delete-feature")
+	logger.Debug("handling-delete-feature-request")
+
 	if req == nil || strings.TrimSpace(req.ID) == "" {
 		return nil, ErrPriceFeatureIDRequired
 	}

--- a/external/pricer/service.go
+++ b/external/pricer/service.go
@@ -106,7 +106,7 @@ func (s *Service) CreatePricePlan(ctx context.Context, req *CreatePricePlanReque
 	}
 
 	if err := pricePlan.Validate(); err != nil {
-		logger.Warn("attempt-made-to-create-invalid-price-plan", zap.Any("price_plan", safeLogValue(pricePlan)), zap.Error(err))
+		logger.Warn("attempt-made-to-create-invalid-price-plan", zap.Any("price-plan", safeLogValue(pricePlan)), zap.Error(err))
 		return nil, err
 	}
 
@@ -144,7 +144,7 @@ func (s *Service) UpdatePricePlan(ctx context.Context, req *UpdatePricePlanReque
 			IncludeProviders: true,
 		})
 		if err != nil {
-			logger.Warn("attempt-made-to-update-missing-price-plan", zap.String("price_plan_id", req.ID), zap.Error(err))
+			logger.Warn("attempt-made-to-update-missing-price-plan", zap.String("price-plan-id", req.ID), zap.Error(err))
 			return nil, err
 		}
 
@@ -182,7 +182,7 @@ func (s *Service) UpdatePricePlan(ctx context.Context, req *UpdatePricePlanReque
 		return nil, ErrPricePlanIDRequired
 	} else {
 		if _, err := s.PricerRepository.GetPricePlanByID(ctx, pricePlanToUpdate.ID, &GetPricePlanByIDRequest{}); err != nil {
-			logger.Warn("attempt-made-to-update-missing-price-plan", zap.String("price_plan_id", pricePlanToUpdate.ID), zap.Error(err))
+			logger.Warn("attempt-made-to-update-missing-price-plan", zap.String("price-plan-id", pricePlanToUpdate.ID), zap.Error(err))
 			return nil, err
 		}
 	}
@@ -200,7 +200,7 @@ func (s *Service) UpdatePricePlan(ctx context.Context, req *UpdatePricePlanReque
 	}
 
 	if err := pricePlanToUpdate.Validate(); err != nil {
-		logger.Warn("attempt-made-to-update-invalid-price-plan", zap.Any("price_plan", safeLogValue(pricePlanToUpdate)), zap.Error(err))
+		logger.Warn("attempt-made-to-update-invalid-price-plan", zap.Any("price-plan", safeLogValue(pricePlanToUpdate)), zap.Error(err))
 		return nil, err
 	}
 
@@ -415,7 +415,7 @@ func (s *Service) PublishPricePlan(ctx context.Context, req *PublishPricePlanReq
 		IncludeProviders: true,
 	})
 	if err != nil {
-		logger.Warn("attempt-made-to-publish-missing-price-plan", zap.String("price_plan_id", req.ID), zap.Error(err))
+		logger.Warn("attempt-made-to-publish-missing-price-plan", zap.String("price-plan-id", req.ID), zap.Error(err))
 		return nil, err
 	}
 
@@ -586,7 +586,7 @@ func (s *Service) UpdateFeature(ctx context.Context, req *UpdateFeatureRequest) 
 		var err error
 		featureToUpdate, err = s.PricerRepository.GetFeatureByID(ctx, req.ID)
 		if err != nil {
-			logger.Warn("attempt-made-to-update-missing-price-feature", zap.String("feature_id", req.ID), zap.Error(err))
+			logger.Warn("attempt-made-to-update-missing-price-feature", zap.String("feature-id", req.ID), zap.Error(err))
 			return nil, err
 		}
 
@@ -615,7 +615,7 @@ func (s *Service) UpdateFeature(ctx context.Context, req *UpdateFeatureRequest) 
 		return nil, ErrPriceFeatureIDRequired
 	} else {
 		if _, err := s.PricerRepository.GetFeatureByID(ctx, featureToUpdate.ID); err != nil {
-			logger.Warn("attempt-made-to-update-missing-price-feature", zap.String("feature_id", featureToUpdate.ID), zap.Error(err))
+			logger.Warn("attempt-made-to-update-missing-price-feature", zap.String("feature-id", featureToUpdate.ID), zap.Error(err))
 			return nil, err
 		}
 	}

--- a/external/reminder/logging.go
+++ b/external/reminder/logging.go
@@ -1,0 +1,7 @@
+package reminder
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/reminder/service.go
+++ b/external/reminder/service.go
@@ -41,8 +41,8 @@ func NewService(reminderRepository ReminderRepository) *Service {
 
 // CreateReminder validates and creates a reminder declaration for a user.
 func (s *Service) CreateReminder(ctx context.Context, req *CreateReminderRequest) (*CreateReminderResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("initiating-create-reminder-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/reminder")
+	logger.Debug("initiating-create-reminder-request", zap.Any("request", safeLogValue(req)))
 
 	if req == nil {
 		return nil, ErrUserIDIsRequired
@@ -97,17 +97,17 @@ func (s *Service) CreateReminder(ctx context.Context, req *CreateReminderRequest
 
 	createdReminder, err := s.ReminderRepository.CreateReminder(ctx, reminder)
 	if err != nil {
-		log.Error("failed-to-create-reminder-error", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-reminder-error", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
-	log.Debug("create-reminder-request-successful", zap.Any("reminder-id", createdReminder.Id))
+	logger.Debug("create-reminder-request-successful", zap.Any("reminder-id", safeLogValue(createdReminder.Id)))
 	return &CreateReminderResponse{Reminder: createdReminder}, nil
 }
 
 // GetReminderByID retrieves one reminder declaration and enforces optional user ownership.
 func (s *Service) GetReminderByID(ctx context.Context, req *GetReminderByIDRequest) (*GetReminderByIDResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/reminder")
 
 	if req == nil || strings.TrimSpace(req.Id) == "" {
 		return nil, ErrIdIsRequired
@@ -118,7 +118,7 @@ func (s *Service) GetReminderByID(ctx context.Context, req *GetReminderByIDReque
 		if errors.Is(err, ErrResourceNotFound) {
 			return nil, ErrResourceNotFound
 		}
-		log.Error("failed-to-get-reminder-error", zap.String("reminder-id", req.Id), zap.Error(err))
+		logger.Error("failed-to-get-reminder-error", zap.String("reminder-id", req.Id), zap.Error(err))
 		return nil, err
 	}
 	if strings.TrimSpace(req.UserID) != "" && reminder.UserID != strings.TrimSpace(req.UserID) {
@@ -130,7 +130,7 @@ func (s *Service) GetReminderByID(ctx context.Context, req *GetReminderByIDReque
 
 // ListReminders returns reminder declarations matching the provided filters.
 func (s *Service) ListReminders(ctx context.Context, req *ListRemindersRequest) (*ListRemindersResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/reminder")
 
 	if req == nil {
 		req = &ListRemindersRequest{}
@@ -163,7 +163,7 @@ func (s *Service) ListReminders(ctx context.Context, req *ListRemindersRequest) 
 		perPage,
 	)
 	if err != nil {
-		log.Error("failed-to-list-reminders-error", zap.String("user-id", req.UserID), zap.Error(err))
+		logger.Error("failed-to-list-reminders-error", zap.String("user-id", req.UserID), zap.Error(err))
 		return nil, err
 	}
 
@@ -178,7 +178,7 @@ func (s *Service) ListReminders(ctx context.Context, req *ListRemindersRequest) 
 
 // UpdateReminderByID applies user-owned changes to one reminder declaration.
 func (s *Service) UpdateReminderByID(ctx context.Context, req *UpdateReminderByIDRequest) (*UpdateReminderByIDResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/reminder")
 
 	if req == nil || strings.TrimSpace(req.Id) == "" {
 		return nil, ErrIdIsRequired
@@ -192,7 +192,7 @@ func (s *Service) UpdateReminderByID(ctx context.Context, req *UpdateReminderByI
 		if errors.Is(err, ErrResourceNotFound) {
 			return nil, ErrResourceNotFound
 		}
-		log.Error("failed-to-update-reminder-error-fetching", zap.String("reminder-id", req.Id), zap.Error(err))
+		logger.Error("failed-to-update-reminder-error-fetching", zap.String("reminder-id", req.Id), zap.Error(err))
 		return nil, err
 	}
 
@@ -259,7 +259,7 @@ func (s *Service) UpdateReminderByID(ctx context.Context, req *UpdateReminderByI
 
 	updated, err := s.ReminderRepository.UpdateReminderByID(ctx, existing)
 	if err != nil {
-		log.Error("failed-to-update-reminder-error", zap.String("reminder-id", req.Id), zap.Error(err))
+		logger.Error("failed-to-update-reminder-error", zap.String("reminder-id", req.Id), zap.Error(err))
 		return nil, err
 	}
 
@@ -268,7 +268,7 @@ func (s *Service) UpdateReminderByID(ctx context.Context, req *UpdateReminderByI
 
 // DeleteReminderByID removes one reminder declaration after verifying ownership.
 func (s *Service) DeleteReminderByID(ctx context.Context, req *DeleteReminderByIDRequest) error {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/reminder")
 
 	if req == nil || strings.TrimSpace(req.Id) == "" {
 		return ErrIdIsRequired
@@ -282,7 +282,7 @@ func (s *Service) DeleteReminderByID(ctx context.Context, req *DeleteReminderByI
 		if errors.Is(err, ErrResourceNotFound) {
 			return ErrResourceNotFound
 		}
-		log.Error("failed-to-delete-reminder-error-fetching", zap.String("reminder-id", req.Id), zap.Error(err))
+		logger.Error("failed-to-delete-reminder-error-fetching", zap.String("reminder-id", req.Id), zap.Error(err))
 		return err
 	}
 
@@ -292,7 +292,7 @@ func (s *Service) DeleteReminderByID(ctx context.Context, req *DeleteReminderByI
 
 	err = s.ReminderRepository.DeleteReminderByID(ctx, req.Id)
 	if err != nil {
-		log.Error("failed-to-delete-reminder-error", zap.String("reminder-id", req.Id), zap.Error(err))
+		logger.Error("failed-to-delete-reminder-error", zap.String("reminder-id", req.Id), zap.Error(err))
 		return err
 	}
 
@@ -301,7 +301,7 @@ func (s *Service) DeleteReminderByID(ctx context.Context, req *DeleteReminderByI
 
 // DisableReminderByID marks a user-owned reminder as disabled.
 func (s *Service) DisableReminderByID(ctx context.Context, req *DisableReminderByIDRequest) (*UpdateReminderByIDResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/reminder")
 
 	if req == nil || strings.TrimSpace(req.Id) == "" {
 		return nil, ErrIdIsRequired
@@ -315,7 +315,7 @@ func (s *Service) DisableReminderByID(ctx context.Context, req *DisableReminderB
 		if errors.Is(err, ErrResourceNotFound) {
 			return nil, ErrResourceNotFound
 		}
-		log.Error("failed-to-disable-reminder-error-fetching", zap.String("reminder-id", req.Id), zap.Error(err))
+		logger.Error("failed-to-disable-reminder-error-fetching", zap.String("reminder-id", req.Id), zap.Error(err))
 		return nil, err
 	}
 
@@ -332,7 +332,7 @@ func (s *Service) DisableReminderByID(ctx context.Context, req *DisableReminderB
 
 	updated, err := s.ReminderRepository.UpdateReminderByID(ctx, existing)
 	if err != nil {
-		log.Error("failed-to-disable-reminder-error", zap.String("reminder-id", req.Id), zap.Error(err))
+		logger.Error("failed-to-disable-reminder-error", zap.String("reminder-id", req.Id), zap.Error(err))
 		return nil, err
 	}
 
@@ -341,7 +341,7 @@ func (s *Service) DisableReminderByID(ctx context.Context, req *DisableReminderB
 
 // GetReminderStats returns aggregate reminder counts for admin dashboards.
 func (s *Service) GetReminderStats(ctx context.Context, req *GetReminderStatsRequest) (*GetReminderStatsResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/reminder")
 
 	if req == nil {
 		req = &GetReminderStatsRequest{}
@@ -352,25 +352,25 @@ func (s *Service) GetReminderStats(ctx context.Context, req *GetReminderStatsReq
 
 	total, err := s.ReminderRepository.CountReminders(ctx, baseFilter)
 	if err != nil {
-		log.Error("failed-to-count-reminders-total", zap.Error(err))
+		logger.Error("failed-to-count-reminders-total", zap.Error(err))
 		return nil, err
 	}
 
 	active, err := s.ReminderRepository.CountReminders(ctx, &ReminderFilter{UserIDs: userIDs, Status: string(ReminderStatusActive)})
 	if err != nil {
-		log.Error("failed-to-count-reminders-active", zap.Error(err))
+		logger.Error("failed-to-count-reminders-active", zap.Error(err))
 		return nil, err
 	}
 
 	completed, err := s.ReminderRepository.CountReminders(ctx, &ReminderFilter{UserIDs: userIDs, Status: string(ReminderStatusCompleted)})
 	if err != nil {
-		log.Error("failed-to-count-reminders-completed", zap.Error(err))
+		logger.Error("failed-to-count-reminders-completed", zap.Error(err))
 		return nil, err
 	}
 
 	disabled, err := s.ReminderRepository.CountReminders(ctx, &ReminderFilter{UserIDs: userIDs, Status: string(ReminderStatusDisabled)})
 	if err != nil {
-		log.Error("failed-to-count-reminders-disabled", zap.Error(err))
+		logger.Error("failed-to-count-reminders-disabled", zap.Error(err))
 		return nil, err
 	}
 
@@ -380,7 +380,7 @@ func (s *Service) GetReminderStats(ctx context.Context, req *GetReminderStatsReq
 		DueBefore: toolbox.TimeNowUTC(),
 	}, 0)
 	if err != nil {
-		log.Error("failed-to-get-due-reminders-count", zap.Error(err))
+		logger.Error("failed-to-get-due-reminders-count", zap.Error(err))
 		return nil, err
 	}
 
@@ -397,7 +397,7 @@ func (s *Service) GetReminderStats(ctx context.Context, req *GetReminderStatsReq
 
 // GetDueReminders returns active reminders ready for scheduler dispatch.
 func (s *Service) GetDueReminders(ctx context.Context, req *GetDueRemindersRequest) (*GetDueRemindersResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/reminder")
 
 	if req == nil {
 		req = &GetDueRemindersRequest{}
@@ -430,7 +430,7 @@ func (s *Service) GetDueReminders(ctx context.Context, req *GetDueRemindersReque
 		UserIDs:   userIDs,
 	}, limit)
 	if err != nil {
-		log.Error("failed-to-get-due-reminders-error", zap.Error(err))
+		logger.Error("failed-to-get-due-reminders-error", zap.Error(err))
 		return nil, err
 	}
 
@@ -439,6 +439,9 @@ func (s *Service) GetDueReminders(ctx context.Context, req *GetDueRemindersReque
 
 // GetRemindersForTargetTypeByUserID returns a user's reminders for a target type and optional target ID.
 func (s *Service) GetRemindersForTargetTypeByUserID(ctx context.Context, req *GetRemindersForTargetTypeByUserIDRequest) (*ListRemindersResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/reminder", "get-reminders-for-target-type-by-user-id")
+	logger.Debug("handling-get-reminders-for-target-type-by-user-id-request")
+
 	if req == nil || strings.TrimSpace(req.UserID) == "" {
 		return nil, ErrUserIDIsRequired
 	}
@@ -460,6 +463,9 @@ func (s *Service) GetRemindersForTargetTypeByUserID(ctx context.Context, req *Ge
 
 // GetActiveRemindersForTargetTypeByUserID returns active reminders for a user's target type.
 func (s *Service) GetActiveRemindersForTargetTypeByUserID(ctx context.Context, req *GetActiveRemindersForTargetTypeByUserIDRequest) (*ListRemindersResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/reminder", "get-active-reminders-for-target-type-by-user-id")
+	logger.Debug("handling-get-active-reminders-for-target-type-by-user-id-request")
+
 	if req == nil || strings.TrimSpace(req.UserID) == "" {
 		return nil, ErrUserIDIsRequired
 	}
@@ -519,6 +525,9 @@ func reminderPaginationMeta(page, perPage int) map[string]interface{} {
 
 // RecordReminderExecution stores the result of one reminder scheduler or notification attempt.
 func (s *Service) RecordReminderExecution(ctx context.Context, req *RecordReminderExecutionRequest) (*RecordReminderExecutionResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/reminder", "record-reminder-execution")
+	logger.Debug("handling-record-reminder-execution-request")
+
 	if req == nil || strings.TrimSpace(req.ReminderId) == "" {
 		return nil, ErrIdIsRequired
 	}
@@ -577,6 +586,9 @@ func (s *Service) RecordReminderExecution(ctx context.Context, req *RecordRemind
 
 // ListReminderExecutions returns execution tracking records for operational review.
 func (s *Service) ListReminderExecutions(ctx context.Context, req *ListReminderExecutionsRequest) (*ListReminderExecutionsResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/reminder", "list-reminder-executions")
+	logger.Debug("handling-list-reminder-executions-request")
+
 	if req == nil {
 		req = &ListReminderExecutionsRequest{}
 	}

--- a/external/repository/helpers/mongo_handler.go
+++ b/external/repository/helpers/mongo_handler.go
@@ -6,7 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ooaklee/ghatd/external/logger"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.uber.org/zap"
 )
 
 // Handler implements MongoClientManager interface
@@ -45,23 +47,29 @@ func NewHandlerWithOptions(connectionString, database string, opts ...ConfigOpti
 
 // GetClient returns the MongoDB client, connecting if necessary
 func (h *Handler) GetClient(ctx context.Context) (*mongo.Client, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "get-client")
+
 	h.mu.RLock()
 	if h.connected && h.client != nil {
 		h.mu.RUnlock()
+		logger.Debug("mongo-client-cache-hit")
 		return h.client, nil
 	}
 	h.mu.RUnlock()
 
+	logger.Debug("mongo-client-cache-miss")
 	return h.connectWithLock(ctx)
 }
 
 // connectWithLock handles connection with proper locking
 func (h *Handler) connectWithLock(ctx context.Context) (*mongo.Client, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "connect-with-lock")
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	// Double-check pattern
 	if h.connected && h.client != nil {
+		logger.Debug("mongo-client-connected-while-waiting-for-lock")
 		return h.client, nil
 	}
 
@@ -70,6 +78,9 @@ func (h *Handler) connectWithLock(ctx context.Context) (*mongo.Client, error) {
 
 // connect establishes connection to MongoDB
 func (h *Handler) connect(ctx context.Context) (*mongo.Client, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "connect")
+	logger.Debug("mongo-connect-started", zap.Int("monitoring-hooks", len(h.config.MonitoringHooks)))
+
 	// Notify monitoring hooks
 	for _, hook := range h.config.MonitoringHooks {
 		ctx = hook.OnConnect(ctx, h.config.ConnectionString)
@@ -80,6 +91,7 @@ func (h *Handler) connect(ctx context.Context) (*mongo.Client, error) {
 	client, err := mongo.Connect(ctx, clientOptions)
 	if err != nil {
 		h.handleError(ctx, err, "connect")
+		logger.Error("mongo-connect-failed", zap.Error(err))
 		return nil, fmt.Errorf("failed-to-connect-to-mongodb: %w", err)
 	}
 
@@ -87,6 +99,7 @@ func (h *Handler) connect(ctx context.Context) (*mongo.Client, error) {
 	if err := client.Ping(ctx, nil); err != nil {
 		client.Disconnect(ctx) // Clean up
 		h.handleError(ctx, err, "ping")
+		logger.Error("mongo-ping-after-connect-failed", zap.Error(err))
 		return nil, fmt.Errorf("failed-to-ping-mongodb: %w", err)
 	}
 
@@ -97,13 +110,16 @@ func (h *Handler) connect(ctx context.Context) (*mongo.Client, error) {
 	h.stats.ConnectionsActive++
 	h.stats.LastConnected = time.Now()
 
+	logger.Info("mongo-connect-completed", zap.Int64("connections-created", h.stats.ConnectionsCreated), zap.Int64("connections-active", h.stats.ConnectionsActive))
 	return client, nil
 }
 
 // GetDatabase returns the specified database
 func (h *Handler) GetDatabase(ctx context.Context, name string) (*mongo.Database, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "get-database")
 	client, err := h.GetClient(ctx)
 	if err != nil {
+		logger.Error("mongo-database-client-unavailable", zap.Error(err))
 		return nil, err
 	}
 
@@ -111,25 +127,36 @@ func (h *Handler) GetDatabase(ctx context.Context, name string) (*mongo.Database
 		name = h.config.Database
 	}
 
+	logger.Debug("mongo-database-resolved", zap.String("database", name))
 	return client.Database(name), nil
 }
 
 // Ping tests the connection to MongoDB
 func (h *Handler) Ping(ctx context.Context) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "ping")
 	client, err := h.GetClient(ctx)
 	if err != nil {
+		logger.Error("mongo-ping-client-unavailable", zap.Error(err))
 		return err
 	}
 
-	return client.Ping(ctx, nil)
+	if err := client.Ping(ctx, nil); err != nil {
+		logger.Error("mongo-ping-failed", zap.Error(err))
+		return err
+	}
+
+	logger.Debug("mongo-ping-completed")
+	return nil
 }
 
 // Close closes the MongoDB connection
 func (h *Handler) Close(ctx context.Context) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "close")
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	if h.client != nil {
+		logger.Debug("mongo-close-started", zap.Int64("connections-active", h.stats.ConnectionsActive))
 		// Notify monitoring hooks
 		for _, hook := range h.config.MonitoringHooks {
 			hook.OnDisconnect(ctx, h.config.ConnectionString)
@@ -139,19 +166,34 @@ func (h *Handler) Close(ctx context.Context) error {
 		h.client = nil
 		h.connected = false
 		h.stats.ConnectionsActive--
+		if err != nil {
+			logger.Error("mongo-close-failed", zap.Error(err))
+			return err
+		}
+		logger.Info("mongo-close-completed", zap.Int64("connections-active", h.stats.ConnectionsActive))
 		return err
 	}
 
+	logger.Debug("mongo-close-skipped-no-client")
 	return nil
 }
 
 // Reconnect closes existing connection and establishes a new one
 func (h *Handler) Reconnect(ctx context.Context) error {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "reconnect")
+	logger.Info("mongo-reconnect-started")
+
 	if err := h.Close(ctx); err != nil {
+		logger.Error("mongo-reconnect-close-failed", zap.Error(err))
 		return fmt.Errorf("failed to close existing connection: %w", err)
 	}
 
 	_, err := h.connectWithLock(ctx)
+	if err != nil {
+		logger.Error("mongo-reconnect-failed", zap.Error(err))
+		return err
+	}
+	logger.Info("mongo-reconnect-completed")
 	return err
 }
 
@@ -171,6 +213,7 @@ func (h *Handler) Stats() ConnectionStats {
 
 // Health returns health information about the MongoDB connection
 func (h *Handler) Health(ctx context.Context) map[string]interface{} {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "health")
 	health := map[string]interface{}{
 		"connected":           h.connected,
 		"database":            h.config.Database,
@@ -189,11 +232,14 @@ func (h *Handler) Health(ctx context.Context) map[string]interface{} {
 		if err := h.Ping(ctx); err != nil {
 			health["ping_error"] = err.Error()
 			health["healthy"] = false
+			logger.Warn("mongo-health-ping-failed", zap.Error(err))
 		} else {
 			health["healthy"] = true
+			logger.Debug("mongo-health-ping-succeeded")
 		}
 	} else {
 		health["healthy"] = false
+		logger.Debug("mongo-health-not-connected")
 	}
 
 	return health
@@ -201,8 +247,10 @@ func (h *Handler) Health(ctx context.Context) map[string]interface{} {
 
 // handleError processes errors and updates stats
 func (h *Handler) handleError(ctx context.Context, err error, operation string) {
+	logger := logger.AcquireOperationFrom(ctx, "external/repository/helpers", "handle-error", zap.String("mongo-operation", operation))
 	h.lastError = err
 	h.stats.ErrorCount++
+	logger.Error("mongo-operation-error-recorded", zap.Int64("error-count", h.stats.ErrorCount), zap.Error(err))
 
 	for _, hook := range h.config.MonitoringHooks {
 		hook.OnError(ctx, err, operation)

--- a/external/repository/helpers/mongo_monitoring_hooks.go
+++ b/external/repository/helpers/mongo_monitoring_hooks.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"strings"
 	"time"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // LoggingHook provides basic logging for MongoDB operations
@@ -34,6 +37,7 @@ func (l *LoggingHook) OnConnect(ctx context.Context, addr string) context.Contex
 	}
 
 	l.logger.Printf("MongoDB: Connecting to %s", addr)
+	logger.AcquireOperationFrom(ctx, "external/repository/helpers", "monitoring-on-connect").Info("mongo-monitoring-connect", zap.String("masked-address", addr))
 	return ctx
 }
 
@@ -45,11 +49,13 @@ func (l *LoggingHook) OnDisconnect(ctx context.Context, addr string) {
 	}
 
 	l.logger.Printf("MongoDB: Disconnected from %s", addr)
+	logger.AcquireOperationFrom(ctx, "external/repository/helpers", "monitoring-on-disconnect").Info("mongo-monitoring-disconnect", zap.String("masked-address", addr))
 }
 
 // OnError logs error events
 func (l *LoggingHook) OnError(ctx context.Context, err error, operation string) {
 	l.logger.Printf("MongoDB Error during %s: %v", operation, err)
+	logger.AcquireOperationFrom(ctx, "external/repository/helpers", "monitoring-on-error", zap.String("mongo-operation", operation)).Error("mongo-monitoring-error", zap.Error(err))
 }
 
 // MetricsHook provides metrics collection for MongoDB operations

--- a/external/repository/repository_logger.go
+++ b/external/repository/repository_logger.go
@@ -20,65 +20,57 @@ func NewZapRepositoryLogger() *ZapRepositoryLogger {
 
 // Error logs error level messages
 func (l *ZapRepositoryLogger) Error(ctx context.Context, message string, err error, fields ...Field) {
-	zapLogger := logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	logger := logger.AcquirePackageFrom(ctx, "external/repository")
 
 	zapFields := l.convertFields(fields)
 	if err != nil {
 		zapFields = append(zapFields, zap.Error(err))
 	}
 
-	zapLogger.Error(message, zapFields...)
+	logger.Error(message, zapFields...)
 }
 
 // Warn logs warning level messages
 func (l *ZapRepositoryLogger) Warn(ctx context.Context, message string, err error, fields ...Field) {
-	zapLogger := logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	logger := logger.AcquirePackageFrom(ctx, "external/repository")
 
 	zapFields := l.convertFields(fields)
 	if err != nil {
 		zapFields = append(zapFields, zap.Error(err))
 	}
 
-	zapLogger.Warn(message, zapFields...)
+	logger.Warn(message, zapFields...)
 }
 
 // Info logs info level messages
 func (l *ZapRepositoryLogger) Info(ctx context.Context, message string, err error, fields ...Field) {
-	zapLogger := logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	logger := logger.AcquirePackageFrom(ctx, "external/repository")
 
 	zapFields := l.convertFields(fields)
 	if err != nil {
 		zapFields = append(zapFields, zap.Error(err))
 	}
 
-	zapLogger.Info(message, zapFields...)
+	logger.Info(message, zapFields...)
 }
 
 // Debug logs debug level messages
 func (l *ZapRepositoryLogger) Debug(ctx context.Context, message string, err error, fields ...Field) {
-	zapLogger := logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	logger := logger.AcquirePackageFrom(ctx, "external/repository")
 
 	zapFields := l.convertFields(fields)
 	if err != nil {
 		zapFields = append(zapFields, zap.Error(err))
 	}
 
-	zapLogger.Debug(message, zapFields...)
+	logger.Debug(message, zapFields...)
 }
 
 // convertFields converts Field slice to zap.Field slice
 func (l *ZapRepositoryLogger) convertFields(fields []Field) []zap.Field {
 	zapFields := make([]zap.Field, len(fields))
 	for i, field := range fields {
-		zapFields[i] = zap.Any(field.Key, field.Value)
+		zapFields[i] = zap.Any(field.Key, logger.SafeValue(field.Value))
 	}
 	return zapFields
 }

--- a/external/response/response.go
+++ b/external/response/response.go
@@ -4,7 +4,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 const (
@@ -18,13 +20,16 @@ var defaultErrorMap reply.ErrorManifest = reply.ErrorManifest{
 // GetResourceNotFoundError returns default 404 response
 func GetResourceNotFoundError(w http.ResponseWriter, r *http.Request) {
 	replier := reply.NewReplier(append([]reply.ErrorManifest{}, defaultErrorMap))
+	logger := logger.AcquireOperationFrom(r.Context(), "external/response", "resource-not-found")
 
 	if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		logger.Debug("resource-not-found-json-response", zap.String("path", r.URL.Path))
 		//nolint will set up default fallback later
 		replier.NewHTTPErrorResponse(w, ErrResourceNotFound)
 		return
 	}
 
+	logger.Debug("resource-not-found-text-response", zap.String("path", r.URL.Path))
 	http.Error(w, "Not Found", http.StatusNotFound)
 }
 
@@ -35,13 +40,16 @@ func GetResourceNotFoundError(w http.ResponseWriter, r *http.Request) {
 // a later date
 func GetDefault200Response(w http.ResponseWriter, r *http.Request) {
 	replier := reply.NewReplier([]reply.ErrorManifest{})
+	logger := logger.AcquireOperationFrom(r.Context(), "external/response", "default-200")
 
 	if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		logger.Debug("default-200-json-response", zap.String("path", r.URL.Path))
 		//nolint will set up default fallback later
 		replier.NewHTTPBlankResponse(w, 200)
 		return
 	}
 
+	logger.Debug("default-200-text-response", zap.String("path", r.URL.Path))
 	w.WriteHeader(200)
 	w.Write([]byte("OK"))
 }

--- a/external/router/handler.go
+++ b/external/router/handler.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/ooaklee/ghatd/external/common"
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // NewAuthVerifyHandler returns a function that handles authentication verification requests.
@@ -21,12 +23,14 @@ import (
 func NewAuthVerifyHandler(apiVerifyEndpoint, apiLoginEndpoint, frontendLoginUrl, frontendAppUrl string) func(http.ResponseWriter, *http.Request) {
 
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.AcquireOperationFrom(r.Context(), "external/router", "auth-verify-handler")
 
 		nextStepParam := fmt.Sprintf("&%s=", common.WebNextStepsHttpQueryParam)
 
 		authVerifyRequest := getAuthVerifyRequest(r.URL.RawQuery)
 
 		if authVerifyRequest.VerificationToken == "" || authVerifyRequest.VerificationEmailType == "" {
+			logger.Warn("auth-verify-request-missing-required-query", zap.Bool("has-token", authVerifyRequest.VerificationToken != ""), zap.Bool("has-type", authVerifyRequest.VerificationEmailType != ""))
 			http.Redirect(w, r, frontendLoginUrl, http.StatusTemporaryRedirect)
 			return
 		}
@@ -37,21 +41,32 @@ func NewAuthVerifyHandler(apiVerifyEndpoint, apiLoginEndpoint, frontendLoginUrl,
 		switch authVerifyRequest.VerificationEmailType {
 		// loginVerification
 		case "1":
+			logger.Debug("auth-verify-login-redirect", zap.String("next-step-host", hostForLog(nextStepParamValue)))
 			http.Redirect(w, r, fmt.Sprintf(apiLoginEndpoint, authVerifyRequest.VerificationToken)+nextStepParam+encodedNextStepParamValue, http.StatusTemporaryRedirect)
 			return
 
 		// emailVerification
 		case "2":
+			logger.Debug("auth-verify-email-redirect", zap.String("next-step-host", hostForLog(nextStepParamValue)))
 			http.Redirect(w, r, fmt.Sprintf(apiVerifyEndpoint, authVerifyRequest.VerificationToken)+nextStepParam+encodedNextStepParamValue, http.StatusTemporaryRedirect)
 			return
 
 		default:
 			// Fix: previously called WriteHeader before setting the Location
 			// header, causing the redirect target to be silently dropped.
+			logger.Warn("auth-verify-unknown-email-type", zap.String("email-type", authVerifyRequest.VerificationEmailType))
 			http.Redirect(w, r, frontendLoginUrl, http.StatusTemporaryRedirect)
 			return
 		}
 	}
+}
+
+func hostForLog(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
 }
 
 // resolveFrontendNextStep normalises the optional request_url carried by an auth

--- a/external/spa/cache_headers.go
+++ b/external/spa/cache_headers.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"path"
 	"strings"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 const (
@@ -21,6 +24,8 @@ func applyStaticAssetCachePolicy(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", serviceWorkerCacheControl)
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", expiredHTTPDate)
+	logger.AcquireOperationFrom(r.Context(), "external/spa", "static-asset-cache-policy").
+		Debug("spa-service-worker-cache-policy-applied", zap.String("path", r.URL.Path))
 }
 
 // isRootServiceWorkerRequest reports whether the request targets the root service-worker script.

--- a/external/spa/handler.go
+++ b/external/spa/handler.go
@@ -3,11 +3,12 @@ package spa
 import (
 	"fmt"
 	"io/fs"
-	"log"
 	"net/http"
 	"strings"
 
+	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // Handler manages request for spa
@@ -44,8 +45,10 @@ func NewSpaHandler(request *NewSpaHandlerRequest) *Handler {
 // while for other content types, it serves the root index page from the static assets.
 func (h *Handler) GetResourceNotFoundError(w http.ResponseWriter, r *http.Request) {
 	replier := reply.NewReplier(append([]reply.ErrorManifest{}, defaultErrorMap))
+	logger := logger.AcquireOperationFrom(r.Context(), "external/spa", "resource-not-found")
 
 	if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		logger.Debug("spa-resource-not-found-json-response", zap.String("path", r.URL.Path))
 		//nolint will set up default fallback later
 		replier.NewHTTPErrorResponse(w, ErrResourceNotFound)
 		return
@@ -54,7 +57,7 @@ func (h *Handler) GetResourceNotFoundError(w http.ResponseWriter, r *http.Reques
 	// Create filesystem only holding dist dir assets
 	distDirFS, err := fs.Sub(h.embeddedFileSystem, fmt.Sprintf("%sdist", h.embeddedContentFilePathPrefix))
 	if err != nil {
-		log.Default().Panicln("unable-to-create-file-system-for-static-assets", err)
+		logger.Panic("spa-static-file-system-create-failed", zap.Error(err))
 		return
 	}
 
@@ -62,6 +65,7 @@ func (h *Handler) GetResourceNotFoundError(w http.ResponseWriter, r *http.Reques
 	// serve the default index page for non-existent resources
 	r = h.spaUpdatePathToIndexFunc(r)
 
+	logger.Debug("spa-fallback-index-response", zap.String("path", r.URL.Path))
 	http.FileServer(http.FS(distDirFS)).ServeHTTP(w, r)
 }
 

--- a/external/spa/routes.go
+++ b/external/spa/routes.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/ghatd/external/router"
+	"go.uber.org/zap"
 )
 
 // SpaHandler expected methods for valid spa handler
@@ -66,7 +68,9 @@ func AttachRoutes(request *AttachRoutesRequest) error {
 	fileMatcher := regexp.MustCompile(`\/([^\/?\s#]*)(?:[\?#].*)?`)
 
 	httpRouter.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.AcquireOperationFrom(r.Context(), "external/spa", "serve-static-asset")
 		if !fileMatcher.MatchString(r.URL.Path) {
+			logger.Error("spa-static-route-invalid-path", zap.String("path", r.URL.Path))
 			w.WriteHeader(http.StatusInternalServerError)
 			// TODO: Update to include anchor to mailto email passed in appSettings
 			w.Write([]byte("<h1>Internal Server Error</h1><br>"))
@@ -79,6 +83,7 @@ func AttachRoutes(request *AttachRoutesRequest) error {
 			applyStaticAssetCachePolicy(w, r)
 			r = handleUpdatePathToIndexFunc(r)
 
+			logger.Debug("spa-static-route-serving", zap.String("path", r.URL.Path))
 			fileServer.ServeHTTP(w, r)
 		}
 	})

--- a/external/starter/v0/cleanup.go
+++ b/external/starter/v0/cleanup.go
@@ -3,6 +3,9 @@ package starter
 import (
 	"context"
 	"errors"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // CleanupGroup aggregates multiple Cleanup functions into a single Cleanup.
@@ -32,11 +35,25 @@ func (g *CleanupGroup) Run(ctx context.Context) error {
 	if g == nil {
 		return nil
 	}
+	logger := logger.AcquireOperationFrom(ctx, "external/starter/v0", "cleanup-run")
+	logger.Info("starter-cleanup-started", zap.Int("cleanup-count", len(g.cleanups)))
+
 	var errs []error
-	for _, fn := range g.cleanups {
+	for index, fn := range g.cleanups {
 		if err := fn(ctx); err != nil {
+			logger.Error("starter-cleanup-failed", zap.Int("cleanup-index", index), zap.Error(err))
 			errs = append(errs, err)
+			continue
 		}
+		logger.Debug("starter-cleanup-completed", zap.Int("cleanup-index", index))
 	}
-	return errors.Join(errs...)
+
+	joinedErr := errors.Join(errs...)
+	if joinedErr != nil {
+		logger.Error("starter-cleanup-completed-with-errors", zap.Int("error-count", len(errs)), zap.Error(joinedErr))
+		return joinedErr
+	}
+
+	logger.Info("starter-cleanup-completed")
+	return nil
 }

--- a/external/streaker/logging.go
+++ b/external/streaker/logging.go
@@ -1,0 +1,7 @@
+package streaker
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/streaker/service.go
+++ b/external/streaker/service.go
@@ -47,46 +47,46 @@ func NewService(streakRepository StreakRepository) *Service {
 // GetStreakByScopeAndPeriodOrCreate returns the streak entry for the resolved
 // scope and period, creating it when it does not already exist.
 func (s *Service) GetStreakByScopeAndPeriodOrCreate(ctx context.Context, req *RecordStreakRequest) (*RecordStreakResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("initiating-get-streak-by-scope-and-period-or-create-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/streaker")
+	logger.Debug("initiating-get-streak-by-scope-and-period-or-create-request", zap.Any("request", safeLogValue(req)))
 
-	resolvedReq, existingRes, err := s.getStreakByScopeAndPeriodFromRecordRequest(ctx, req, log)
+	resolvedReq, existingRes, err := s.getStreakByScopeAndPeriodFromRecordRequest(ctx, req, logger)
 	if err != nil || existingRes != nil {
 		return existingRes, err
 	}
 
-	createdRes, err := s.createResolvedStreak(ctx, req, resolvedReq, log)
+	createdRes, err := s.createResolvedStreak(ctx, req, resolvedReq, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Debug("get-streak-by-scope-and-period-or-create-request-successful", zap.Any("request", req), zap.Any("created-streak", createdRes.Streak))
+	logger.Debug("get-streak-by-scope-and-period-or-create-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("created-streak", safeLogValue(createdRes.Streak)))
 	return createdRes, nil
 }
 
 // RecordStreak records a completion and computes the streak count for its scope.
 func (s *Service) RecordStreak(ctx context.Context, req *RecordStreakRequest) (*RecordStreakResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
-	log.Debug("initiating-record-streak-request", zap.Any("request", req))
+	logger := logger.AcquirePackageFrom(ctx, "external/streaker")
+	logger.Debug("initiating-record-streak-request", zap.Any("request", safeLogValue(req)))
 
-	resolvedReq, existingRes, err := s.getStreakByScopeAndPeriodFromRecordRequest(ctx, req, log)
+	resolvedReq, existingRes, err := s.getStreakByScopeAndPeriodFromRecordRequest(ctx, req, logger)
 	if err != nil || existingRes != nil {
 		return existingRes, err
 	}
 
-	createdRes, err := s.createResolvedStreak(ctx, req, resolvedReq, log)
+	createdRes, err := s.createResolvedStreak(ctx, req, resolvedReq, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Debug("record-streak-request-successful", zap.Any("request", req), zap.Any("created-streak", createdRes.Streak))
+	logger.Debug("record-streak-request-successful", zap.Any("request", safeLogValue(req)), zap.Any("created-streak", safeLogValue(createdRes.Streak)))
 	return createdRes, nil
 }
 
 // getStreakByScopeAndPeriodFromRecordRequest validates and resolves a record
 // request, returning an existing streak response when the period was already
 // recorded.
-func (s *Service) getStreakByScopeAndPeriodFromRecordRequest(ctx context.Context, req *RecordStreakRequest, log *zap.Logger) (*resolvedRecordStreakRequest, *RecordStreakResponse, error) {
+func (s *Service) getStreakByScopeAndPeriodFromRecordRequest(ctx context.Context, req *RecordStreakRequest, logger *zap.Logger) (*resolvedRecordStreakRequest, *RecordStreakResponse, error) {
 	if req == nil {
 		return nil, nil, ErrStreakTypeIsRequired
 	}
@@ -156,7 +156,7 @@ func (s *Service) getStreakByScopeAndPeriodFromRecordRequest(ctx context.Context
 		return resolvedReq, &RecordStreakResponse{Streak: existing}, nil
 	}
 	if err != nil && !errors.Is(err, ErrResourceNotFound) {
-		log.Error("failed-to-resolve-streak-error-checking-period", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-resolve-streak-error-checking-period", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, nil, err
 	}
 
@@ -166,13 +166,13 @@ func (s *Service) getStreakByScopeAndPeriodFromRecordRequest(ctx context.Context
 // createResolvedStreak creates a streak from a previously validated and
 // resolved record request, carrying forward consecutive count and previous
 // streak metadata when available.
-func (s *Service) createResolvedStreak(ctx context.Context, req *RecordStreakRequest, resolvedReq *resolvedRecordStreakRequest, log *zap.Logger) (*RecordStreakResponse, error) {
+func (s *Service) createResolvedStreak(ctx context.Context, req *RecordStreakRequest, resolvedReq *resolvedRecordStreakRequest, logger *zap.Logger) (*RecordStreakResponse, error) {
 	var previous *Streak
 	previous, err := s.StreakRepository.GetLatestStreak(ctx, &GetLatestStreakRequest{
 		StreakStatsRequest: resolvedReq.statsReq,
 	})
 	if err != nil && !errors.Is(err, ErrResourceNotFound) {
-		log.Error("failed-to-create-streak-error-getting-latest-streak", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-streak-error-getting-latest-streak", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return nil, err
 	}
 
@@ -202,7 +202,7 @@ func (s *Service) createResolvedStreak(ctx context.Context, req *RecordStreakReq
 
 	createdStreak, err := s.StreakRepository.CreateStreak(ctx, newStreak)
 	if err != nil {
-		log.Error("failed-to-create-streak-error-creating-streak", zap.Any("request", req), zap.Any("new-streak", newStreak), zap.Error(err))
+		logger.Error("failed-to-create-streak-error-creating-streak", zap.Any("request", safeLogValue(req)), zap.Any("new-streak", safeLogValue(newStreak)), zap.Error(err))
 		return nil, err
 	}
 
@@ -211,6 +211,9 @@ func (s *Service) createResolvedStreak(ctx context.Context, req *RecordStreakReq
 
 // CreateRawStreak creates a precomputed streak entry.
 func (s *Service) CreateRawStreak(ctx context.Context, req *CreateRawStreakRequest) (*RecordStreakResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/streaker", "create-raw-streak")
+	logger.Debug("handling-create-raw-streak-request")
+
 	if req == nil || req.Streak == nil {
 		return nil, ErrStreakTypeIsRequired
 	}
@@ -239,6 +242,9 @@ func (s *Service) CreateRawStreak(ctx context.Context, req *CreateRawStreakReque
 
 // GetLongestStreak gets the longest streak matching the request filters.
 func (s *Service) GetLongestStreak(ctx context.Context, req *GetLongestStreakRequest) (*GetLongestStreakResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/streaker", "get-longest-streak")
+	logger.Debug("handling-get-longest-streak-request")
+
 	var sourceReq *StreakStatsRequest
 	if req != nil {
 		sourceReq = &req.StreakStatsRequest
@@ -265,11 +271,17 @@ func (s *Service) GetLongestStreak(ctx context.Context, req *GetLongestStreakReq
 
 // GetLongestStreakByStreakTypeAndUserID gets the longest streak for a user and type.
 func (s *Service) GetLongestStreakByStreakTypeAndUserID(ctx context.Context, req *GetLongestStreakRequest) (*GetLongestStreakResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/streaker", "get-longest-streak-by-streak-type-and-user-id")
+	logger.Debug("handling-get-longest-streak-by-streak-type-and-user-id-request")
+
 	return s.GetLongestStreak(ctx, req)
 }
 
 // GetCurrentCount gets the latest current count matching the request filters.
 func (s *Service) GetCurrentCount(ctx context.Context, req *GetCurrentCountRequest) (*GetCurrentCountResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/streaker", "get-current-count")
+	logger.Debug("handling-get-current-count-request")
+
 	var sourceReq *StreakStatsRequest
 	if req != nil {
 		sourceReq = &req.StreakStatsRequest
@@ -296,11 +308,17 @@ func (s *Service) GetCurrentCount(ctx context.Context, req *GetCurrentCountReque
 
 // GetCurrentCountByStreakTypeAndUserID gets the current count for a user and type.
 func (s *Service) GetCurrentCountByStreakTypeAndUserID(ctx context.Context, req *GetCurrentCountRequest) (*GetCurrentCountResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/streaker", "get-current-count-by-streak-type-and-user-id")
+	logger.Debug("handling-get-current-count-by-streak-type-and-user-id-request")
+
 	return s.GetCurrentCount(ctx, req)
 }
 
 // GetNumberOfStreaks gets the number of streak entries matching the request filters.
 func (s *Service) GetNumberOfStreaks(ctx context.Context, req *GetNumberOfStreaksRequest) (*GetNumberOfStreaksResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/streaker", "get-number-of-streaks")
+	logger.Debug("handling-get-number-of-streaks-request")
+
 	var sourceReq *StreakStatsRequest
 	if req != nil {
 		sourceReq = &req.StreakStatsRequest
@@ -321,11 +339,17 @@ func (s *Service) GetNumberOfStreaks(ctx context.Context, req *GetNumberOfStreak
 
 // GetNumberOfStreaksByStreakTypeAndUserID gets the number of streak entries for a user and type.
 func (s *Service) GetNumberOfStreaksByStreakTypeAndUserID(ctx context.Context, req *GetNumberOfStreaksRequest) (*GetNumberOfStreaksResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/streaker", "get-number-of-streaks-by-streak-type-and-user-id")
+	logger.Debug("handling-get-number-of-streaks-by-streak-type-and-user-id-request")
+
 	return s.GetNumberOfStreaks(ctx, req)
 }
 
 // ListStreaks lists streak entries matching the provided filters.
 func (s *Service) ListStreaks(ctx context.Context, req *ListStreaksRequest) (*ListStreaksResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/streaker", "list-streaks")
+	logger.Debug("handling-list-streaks-request")
+
 	listReq, err := normaliseListStreaksRequest(req)
 	if err != nil {
 		return nil, err

--- a/external/toolbox/paginator.go
+++ b/external/toolbox/paginator.go
@@ -61,9 +61,7 @@ func Paginate[T any](
 	resources []T,
 	totalCount int,
 ) (*PaginationResponse[T], error) {
-	logger := logger.AcquireFrom(ctx).WithOptions(
-		zap.AddStacktrace(zap.DPanicLevel),
-	)
+	logger := logger.AcquirePackageFrom(ctx, "external/toolbox")
 
 	// Set default values if needed
 	perPage := req.PerPage

--- a/external/user/handler.go
+++ b/external/user/handler.go
@@ -2,10 +2,12 @@ package user
 
 import (
 	"context"
+	"github.com/ooaklee/ghatd/external/logger"
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/errormanifest"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 type UserService interface {
@@ -41,10 +43,12 @@ func NewHandler(service UserService, validator UserValidator, errorMaps ...reply
 
 // GetProfile returns a user profile of the user that matches id
 func (h *Handler) GetProfile(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user", "handle-get-profile")
 
 	request, err := MapRequestToGetProfileRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -52,6 +56,7 @@ func (h *Handler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetProfile(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -63,10 +68,12 @@ func (h *Handler) GetProfile(w http.ResponseWriter, r *http.Request) {
 
 // GetMicroProfile returns a user micro profile of the user that matches id
 func (h *Handler) GetMicroProfile(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user", "handle-get-micro-profile")
 
 	request, err := MapRequestToGetMicroProfileRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -74,6 +81,7 @@ func (h *Handler) GetMicroProfile(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetMicroProfile(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -85,10 +93,12 @@ func (h *Handler) GetMicroProfile(w http.ResponseWriter, r *http.Request) {
 
 // CreateUser returns reponse from user creation
 func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user", "handle-create-user")
 
 	request, err := MapRequestToCreateUserRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -96,6 +106,7 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.CreateUser(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -106,10 +117,12 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // GetUsers returns all the users
 func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user", "handle-get-users")
 
 	request, err := MapRequestToGetUsersRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -117,6 +130,7 @@ func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
 	users, err := h.Service.GetUsers(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -134,10 +148,12 @@ func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
 
 // GetUserByID returns an user if it matches id
 func (h *Handler) GetUserByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user", "handle-get-user-by-id")
 
 	request, err := MapRequestToGetUserByIdRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -145,6 +161,7 @@ func (h *Handler) GetUserByID(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetUserByID(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -156,10 +173,12 @@ func (h *Handler) GetUserByID(w http.ResponseWriter, r *http.Request) {
 
 // UpdateUser returns reponse from user update request
 func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user", "handle-update-user")
 
 	request, err := MapRequestToUpdateUserRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -167,6 +186,7 @@ func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.UpdateUser(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -177,10 +197,12 @@ func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 
 // DeleteUser returns reponse after user delete request
 func (h *Handler) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user", "handle-delete-user")
 
 	request, err := MapRequestToDeleteUserRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -188,6 +210,7 @@ func (h *Handler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	err = h.Service.DeleteUser(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/user/logging.go
+++ b/external/user/logging.go
@@ -1,0 +1,7 @@
+package user
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/user/service.go
+++ b/external/user/service.go
@@ -47,6 +47,8 @@ func NewService(userRespository UserRespository, auditService AuditService, auto
 
 // GetMicroProfile returns user with matching ID's micro profile
 func (s *Service) GetMicroProfile(ctx context.Context, r *GetMicroProfileRequest) (*GetMicroProfileResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/user", "get-micro-profile")
+	logger.Debug("handling-get-micro-profile-request")
 
 	userResponse, err := s.GetUserByID(ctx, &GetUserByIdRequest{
 		Id: r.Id,
@@ -62,6 +64,8 @@ func (s *Service) GetMicroProfile(ctx context.Context, r *GetMicroProfileRequest
 
 // GetProfile returns user with matching ID's profile
 func (s *Service) GetProfile(ctx context.Context, r *GetProfileRequest) (*GetProfileResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/user", "get-profile")
+	logger.Debug("handling-get-profile-request")
 
 	userResponse, err := s.GetUserByID(ctx, &GetUserByIdRequest{
 		Id: r.Id,
@@ -77,6 +81,8 @@ func (s *Service) GetProfile(ctx context.Context, r *GetProfileRequest) (*GetPro
 
 // GetUserByEmail returns an user if it matches email
 func (s *Service) GetUserByEmail(ctx context.Context, r *GetUserByEmailRequest) (*GetUserByEmailResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/user", "get-user-by-email")
+	logger.Debug("handling-get-user-by-email-request")
 
 	user, err := s.UserRespository.GetUserByEmail(ctx, normaliseUserEmail(r.Email), true)
 	if err != nil {
@@ -91,7 +97,7 @@ func (s *Service) GetUserByEmail(ctx context.Context, r *GetUserByEmailRequest) 
 // DeleteUser attempts to delete the user with matching ID in repository
 func (s *Service) DeleteUser(ctx context.Context, r *DeleteUserRequest) error {
 
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/user")
 
 	userToDelete, err := s.UserRespository.GetUserByID(ctx, r.Id)
 	if err != nil {
@@ -116,7 +122,7 @@ func (s *Service) DeleteUser(ctx context.Context, r *DeleteUserRequest) error {
 		})
 
 		if auditErr != nil {
-			log.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", r.Id), zap.String("event-type", string(auditEvent)))
+			logger.Warn("failed-to-log-event", zap.String("actor-id", audit.AuditActorIdSystem), zap.String("user-id", r.Id), zap.String("event-type", string(auditEvent)))
 		}
 	}
 
@@ -125,6 +131,8 @@ func (s *Service) DeleteUser(ctx context.Context, r *DeleteUserRequest) error {
 
 // UpdateUser attempts to update the user with matching ID in repository
 func (s *Service) UpdateUser(ctx context.Context, r *UpdateUserRequest) (*UpdateUserResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/user", "update-user")
+	logger.Debug("handling-update-user-request")
 
 	var (
 		persistentUser *User
@@ -165,6 +173,8 @@ func (s *Service) UpdateUser(ctx context.Context, r *UpdateUserRequest) (*Update
 
 // GetUserByNanoId is returning a user if they have matching nano id
 func (s *Service) GetUserByNanoId(ctx context.Context, id string) (*GetUserByIDResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/user", "get-user-by-nano-id")
+	logger.Debug("handling-get-user-by-nano-id-request")
 
 	user, err := s.UserRespository.GetUserByNanoId(ctx, id)
 	if err != nil {
@@ -178,6 +188,8 @@ func (s *Service) GetUserByNanoId(ctx context.Context, id string) (*GetUserByIDR
 
 // GetUserByID returns an user if it matches id
 func (s *Service) GetUserByID(ctx context.Context, r *GetUserByIdRequest) (*GetUserByIDResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/user", "get-user-by-id")
+	logger.Debug("handling-get-user-by-id-request")
 
 	user, err := s.UserRespository.GetUserByID(ctx, r.Id)
 	if err != nil {
@@ -193,7 +205,7 @@ func (s *Service) GetUserByID(ctx context.Context, r *GetUserByIdRequest) (*GetU
 func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*CreateUserResponse, error) {
 
 	var isAutoAdminEmail bool
-	log := logger.AcquireFrom(ctx)
+	logger := logger.AcquirePackageFrom(ctx, "external/user")
 
 	user := User{
 		FirstName: normaliseUserNames(r.FirstName),
@@ -209,7 +221,7 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 		boasiEmailRegex := regexp.MustCompile(s.autoAdminEmailAddressRegex)
 		isAutoAdminEmail = boasiEmailRegex.Match([]byte(user.Email))
 		if isAutoAdminEmail {
-			log.Info("assigning-admin-role-to-user-role", zap.String("team-member-email", user.Email))
+			logger.Info("assigning-admin-role-to-user-role", zap.String("team-member-email", user.Email))
 			user.Roles = append(user.Roles, UserRoleAdmin)
 		}
 	}
@@ -220,7 +232,7 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 	}
 
 	if s.autoAdminEmailAddressRegex != "" && isAutoAdminEmail {
-		log.Warn("user-created-with-admin-role", zap.String("team-member-email", user.Email), zap.String("user-id", user.ID))
+		logger.Warn("user-created-with-admin-role", zap.String("team-member-email", user.Email), zap.String("user-id", user.ID))
 	}
 
 	return &CreateUserResponse{
@@ -233,9 +245,7 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 func (s *Service) GetUsers(ctx context.Context, r *GetUsersRequest) (*GetUsersResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/user")
 	)
 
 	// default
@@ -254,16 +264,16 @@ func (s *Service) GetUsers(ctx context.Context, r *GetUsersRequest) (*GetUsersRe
 	// get count of all users
 	totalUsers, err := s.UserRespository.GetTotalUsers(ctx, r.FirstName, r.LastName, r.Email, r.Status, r.IsAdmin)
 	if err != nil {
-		logger.Error("failed-get-users-request--error-getting-total-users", zap.Any("request", r), zap.Error(err))
+		logger.Error("failed-get-users-request--error-getting-total-users", zap.Any("request", safeLogValue(r)), zap.Error(err))
 		return nil, err
 	}
 
 	r.TotalCount = int(totalUsers)
-	logger.Debug("handling-get-users-request--total-users-found", zap.Int64("total", totalUsers), zap.Any("request", r))
+	logger.Debug("handling-get-users-request--total-users-found", zap.Int64("total", totalUsers), zap.Any("request", safeLogValue(r)))
 
 	users, err := s.UserRespository.GetUsers(ctx, r)
 	if err != nil {
-		logger.Error("failed-get-users-request--error-getting-users", zap.Any("request", r), zap.Error(err))
+		logger.Error("failed-get-users-request--error-getting-users", zap.Any("request", safeLogValue(r)), zap.Error(err))
 		return nil, err
 	}
 

--- a/external/user/service.go
+++ b/external/user/service.go
@@ -221,7 +221,7 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 		boasiEmailRegex := regexp.MustCompile(s.autoAdminEmailAddressRegex)
 		isAutoAdminEmail = boasiEmailRegex.Match([]byte(user.Email))
 		if isAutoAdminEmail {
-			logger.Info("assigning-admin-role-to-user-role", zap.String("team-member-email", user.Email))
+			logger.Info("assigning-admin-role-to-user-role", emailLogFields("team-member-email", user.Email)...)
 			user.Roles = append(user.Roles, UserRoleAdmin)
 		}
 	}
@@ -232,7 +232,7 @@ func (s *Service) CreateUser(ctx context.Context, r *CreateUserRequest) (*Create
 	}
 
 	if s.autoAdminEmailAddressRegex != "" && isAutoAdminEmail {
-		logger.Warn("user-created-with-admin-role", zap.String("team-member-email", user.Email), zap.String("user-id", user.ID))
+		logger.Warn("user-created-with-admin-role", append(emailLogFields("team-member-email", user.Email), zap.String("user-id", user.ID))...)
 	}
 
 	return &CreateUserResponse{

--- a/external/user/v2/handler.go
+++ b/external/user/v2/handler.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // UserService interface defines expected methods of a valid user service
@@ -58,14 +60,17 @@ func NewHandler(service UserService, validator UserValidator, errorMaps ...reply
 
 // CreateUser handles user creation
 func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-create-user")
 	request, err := MapRequestToCreateUserRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.CreateUser(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -75,14 +80,17 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // GetUserByID handles retrieval of a user by ID
 func (h *Handler) GetUserByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-user-by-id")
 	request, err := MapRequestToGetUserByIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserByID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -92,14 +100,17 @@ func (h *Handler) GetUserByID(w http.ResponseWriter, r *http.Request) {
 
 // GetUserByNanoID handles retrieval of a user by nano ID
 func (h *Handler) GetUserByNanoID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-user-by-nano-id")
 	request, err := MapRequestToGetUserByNanoIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserByNanoID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -109,14 +120,17 @@ func (h *Handler) GetUserByNanoID(w http.ResponseWriter, r *http.Request) {
 
 // GetUserByEmail handles retrieval of a user by email
 func (h *Handler) GetUserByEmail(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-user-by-email")
 	request, err := MapRequestToGetUserByEmailRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserByEmail(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -126,14 +140,17 @@ func (h *Handler) GetUserByEmail(w http.ResponseWriter, r *http.Request) {
 
 // UpdateUser handles user updates
 func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-update-user")
 	request, err := MapRequestToUpdateUserRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateUser(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -143,14 +160,17 @@ func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 
 // DeleteUser handles user deletion
 func (h *Handler) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-delete-user")
 	request, err := MapRequestToDeleteUserRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	err = h.Service.DeleteUser(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -160,14 +180,17 @@ func (h *Handler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 
 // GetUsers handles retrieval of multiple users with filters and pagination
 func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-users")
 	request, err := MapRequestToGetUsersRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUsers(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -183,14 +206,17 @@ func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
 
 // UpdateUserStatus handles user status updates
 func (h *Handler) UpdateUserStatus(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-update-user-status")
 	request, err := MapRequestToUpdateUserStatusRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateUserStatus(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -200,14 +226,17 @@ func (h *Handler) UpdateUserStatus(w http.ResponseWriter, r *http.Request) {
 
 // AddUserRole handles adding a role to a user
 func (h *Handler) AddUserRole(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-add-user-role")
 	request, err := MapRequestToAddUserRoleRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.AddUserRole(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -217,14 +246,17 @@ func (h *Handler) AddUserRole(w http.ResponseWriter, r *http.Request) {
 
 // RemoveUserRole handles removing a role from a user
 func (h *Handler) RemoveUserRole(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-remove-user-role")
 	request, err := MapRequestToRemoveUserRoleRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RemoveUserRole(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -234,14 +266,17 @@ func (h *Handler) RemoveUserRole(w http.ResponseWriter, r *http.Request) {
 
 // VerifyUserEmail handles marking a user's email as verified
 func (h *Handler) VerifyUserEmail(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-verify-user-email")
 	request, err := MapRequestToVerifyUserEmailRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.VerifyUserEmail(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -251,14 +286,17 @@ func (h *Handler) VerifyUserEmail(w http.ResponseWriter, r *http.Request) {
 
 // UnverifyUserEmail handles marking a user's email as unverified
 func (h *Handler) UnverifyUserEmail(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-unverify-user-email")
 	request, err := MapRequestToUnverifyUserEmailRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UnverifyUserEmail(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -268,14 +306,17 @@ func (h *Handler) UnverifyUserEmail(w http.ResponseWriter, r *http.Request) {
 
 // VerifyUserPhone handles marking a user's phone as verified
 func (h *Handler) VerifyUserPhone(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-verify-user-phone")
 	request, err := MapRequestToVerifyUserPhoneRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.VerifyUserPhone(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -285,14 +326,17 @@ func (h *Handler) VerifyUserPhone(w http.ResponseWriter, r *http.Request) {
 
 // RecordUserLogin handles recording a user login event
 func (h *Handler) RecordUserLogin(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-record-user-login")
 	request, err := MapRequestToRecordUserLoginRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RecordUserLogin(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -302,14 +346,17 @@ func (h *Handler) RecordUserLogin(w http.ResponseWriter, r *http.Request) {
 
 // GetUserProfile handles retrieval of a user's full profile
 func (h *Handler) GetUserProfile(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-user-profile")
 	request, err := MapRequestToGetUserProfileRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserProfile(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -319,14 +366,17 @@ func (h *Handler) GetUserProfile(w http.ResponseWriter, r *http.Request) {
 
 // GetUserMicroProfile handles retrieval of a user's micro profile
 func (h *Handler) GetUserMicroProfile(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-user-micro-profile")
 	request, err := MapRequestToGetUserMicroProfileRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserMicroProfile(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -336,14 +386,17 @@ func (h *Handler) GetUserMicroProfile(w http.ResponseWriter, r *http.Request) {
 
 // SetUserExtension handles setting an extension field value
 func (h *Handler) SetUserExtension(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-set-user-extension")
 	request, err := MapRequestToSetUserExtensionRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.SetUserExtension(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -353,14 +406,17 @@ func (h *Handler) SetUserExtension(w http.ResponseWriter, r *http.Request) {
 
 // GetUserExtension handles retrieving an extension field value
 func (h *Handler) GetUserExtension(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-user-extension")
 	request, err := MapRequestToGetUserExtensionRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserExtension(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -370,14 +426,17 @@ func (h *Handler) GetUserExtension(w http.ResponseWriter, r *http.Request) {
 
 // UpdateUserPersonalInfo handles updating a user's personal information
 func (h *Handler) UpdateUserPersonalInfo(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-update-user-personal-info")
 	request, err := MapRequestToUpdateUserPersonalInfoRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateUserPersonalInfo(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -387,14 +446,17 @@ func (h *Handler) UpdateUserPersonalInfo(w http.ResponseWriter, r *http.Request)
 
 // ValidateUser handles validating a user
 func (h *Handler) ValidateUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-validate-user")
 	request, err := MapRequestToValidateUserRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ValidateUser(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -404,14 +466,17 @@ func (h *Handler) ValidateUser(w http.ResponseWriter, r *http.Request) {
 
 // BulkUpdateUsersStatus handles bulk updating user statuses
 func (h *Handler) BulkUpdateUsersStatus(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-bulk-update-users-status")
 	request, err := MapRequestToBulkUpdateUsersStatusRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.BulkUpdateUsersStatus(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -421,14 +486,17 @@ func (h *Handler) BulkUpdateUsersStatus(w http.ResponseWriter, r *http.Request) 
 
 // GetUserStats handles retrieving aggregated stats about platform users
 func (h *Handler) GetUserStats(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-user-stats")
 	request, err := MapRequestToGetUserStatsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserStats(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -438,14 +506,17 @@ func (h *Handler) GetUserStats(w http.ResponseWriter, r *http.Request) {
 
 // GetUserConfigs handles retrieving supported user config presets
 func (h *Handler) GetUserConfigs(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/user/v2", "handle-get-user-configs")
 	request, err := MapRequestToGetUserConfigsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserConfigs(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/user/v2/logging.go
+++ b/external/user/v2/logging.go
@@ -5,10 +5,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func safeLogValue(value any) any {
-	return logger.SafeValue(value)
-}
-
 func emailLogFields(prefix, value string) []zap.Field {
 	return []zap.Field{
 		zap.Bool(prefix+"-present", logger.EmailPresentForLog(value)),

--- a/external/user/v2/service.go
+++ b/external/user/v2/service.go
@@ -77,17 +77,17 @@ func (s *Service) WithConfigs(configs ...*UserConfig) *Service {
 
 // CreateUser creates a new user
 func (s *Service) CreateUser(ctx context.Context, req *CreateUserRequest) (*CreateUserResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "create-user")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "create-user"))
 	config, err := s.resolveRequestedConfig(req.Type)
 	if err != nil {
-		log.Error("invalid-user-config-type", zap.String("config-type", req.Type), zap.Error(err))
+		logger.Error("invalid-user-config-type", zap.String("config-type", req.Type), zap.Error(err))
 		return nil, err
 	}
 
 	// Check if user already exists
 	existingUser, _ := s.UserRepository.GetUserByEmail(ctx, req.Email, false)
 	if existingUser != nil {
-		log.Error("user-with-email-already-exists", zap.String("email", req.Email))
+		logger.Error("user-with-email-already-exists", zap.String("email", req.Email))
 		return nil, ErrEmailAlreadyExists
 	}
 
@@ -157,14 +157,14 @@ func (s *Service) CreateUser(ctx context.Context, req *CreateUserRequest) (*Crea
 
 	// Validate user
 	if err := user.Validate(); err != nil {
-		log.Error("user-validation-failed", zap.Error(err))
+		logger.Error("user-validation-failed", zap.Error(err))
 		return nil, ErrValidationFailed
 	}
 
 	// Create user in repository
 	createdUser, err := s.UserRepository.CreateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-create-user", zap.Error(err))
+		logger.Error("failed-to-create-user", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -178,14 +178,14 @@ func (s *Service) CreateUser(ctx context.Context, req *CreateUserRequest) (*Crea
 		})
 	}
 
-	log.Info("user-created-successfully", zap.String("user-id", createdUser.ID))
+	logger.Info("user-created-successfully", zap.String("user-id", createdUser.ID))
 
 	return &CreateUserResponse{User: createdUser}, nil
 }
 
 // GetUserByID retrieves a user by ID
 func (s *Service) GetUserByID(ctx context.Context, req *GetUserByIDRequest) (*GetUserByIDResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "create-user")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "create-user"))
 
 	if req.ID == "" {
 		return nil, ErrInvalidUserID
@@ -193,7 +193,7 @@ func (s *Service) GetUserByID(ctx context.Context, req *GetUserByIDRequest) (*Ge
 
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed to get user by ID", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed to get user by ID", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -205,7 +205,7 @@ func (s *Service) GetUserByID(ctx context.Context, req *GetUserByIDRequest) (*Ge
 
 // GetUserByNanoID retrieves a user by nano ID
 func (s *Service) GetUserByNanoID(ctx context.Context, req *GetUserByNanoIDRequest) (*GetUserByNanoIDResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "create-user")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "create-user"))
 
 	if req.NanoID == "" {
 		return nil, ErrInvalidNanoID
@@ -213,7 +213,7 @@ func (s *Service) GetUserByNanoID(ctx context.Context, req *GetUserByNanoIDReque
 
 	user, err := s.UserRepository.GetUserByNanoID(ctx, req.NanoID)
 	if err != nil {
-		log.Error("failed to get user by nano ID", zap.Error(err), zap.String("nano_id", req.NanoID))
+		logger.Error("failed to get user by nano ID", zap.Error(err), zap.String("nano_id", req.NanoID))
 		return nil, ErrUserNotFound
 	}
 
@@ -225,7 +225,7 @@ func (s *Service) GetUserByNanoID(ctx context.Context, req *GetUserByNanoIDReque
 
 // GetUserByEmail retrieves a user by email
 func (s *Service) GetUserByEmail(ctx context.Context, req *GetUserByEmailRequest) (*GetUserByEmailResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-user-by-email")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "get-user-by-email"))
 
 	if req.Email == "" {
 		return nil, ErrInvalidEmail
@@ -233,7 +233,7 @@ func (s *Service) GetUserByEmail(ctx context.Context, req *GetUserByEmailRequest
 
 	user, err := s.UserRepository.GetUserByEmail(ctx, normaliseUserEmail(req.Email), true)
 	if err != nil {
-		log.Error("failed to get user by email", zap.Error(err), zap.String("email", req.Email))
+		logger.Error("failed to get user by email", zap.Error(err), zap.String("email", req.Email))
 		return nil, ErrUserNotFound
 	}
 
@@ -245,7 +245,7 @@ func (s *Service) GetUserByEmail(ctx context.Context, req *GetUserByEmailRequest
 
 // UpdateUser updates an existing user
 func (s *Service) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*UpdateUserResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-user")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "update-user"))
 
 	targetUserId := req.ID
 	if req.User != nil && req.User.ID != "" {
@@ -255,7 +255,7 @@ func (s *Service) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*Upda
 	// Get existing user
 	user, err := s.UserRepository.GetUserByID(ctx, targetUserId)
 	if err != nil {
-		log.Error("failed-to-get-user-for-update", zap.Error(err), zap.String("id", targetUserId))
+		logger.Error("failed-to-get-user-for-update", zap.Error(err), zap.String("id", targetUserId))
 		return nil, ErrUserNotFound
 	}
 
@@ -268,7 +268,7 @@ func (s *Service) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*Upda
 
 		config, err := s.resolveRequestedConfig(requestedType)
 		if err != nil {
-			log.Error("invalid-user-config-type", zap.String("config-type", requestedType), zap.Error(err))
+			logger.Error("invalid-user-config-type", zap.String("config-type", requestedType), zap.Error(err))
 			return nil, err
 		}
 
@@ -299,7 +299,7 @@ func (s *Service) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*Upda
 		if req.Type != "" && req.Type != user.Type {
 			config, err := s.resolveRequestedConfig(req.Type)
 			if err != nil {
-				log.Error("invalid-user-config-type", zap.String("config-type", req.Type), zap.Error(err))
+				logger.Error("invalid-user-config-type", zap.String("config-type", req.Type), zap.Error(err))
 				return nil, err
 			}
 
@@ -350,7 +350,7 @@ func (s *Service) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*Upda
 		if req.Status != "" && req.Status != user.Status {
 			_, err := user.UpdateStatus(req.Status)
 			if err != nil {
-				log.Error("failed-to-update-user-status", zap.Error(err))
+				logger.Error("failed-to-update-user-status", zap.Error(err))
 				return nil, err
 			}
 			hasChanges = true
@@ -373,7 +373,7 @@ func (s *Service) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*Upda
 
 	// Validate user
 	if err := user.Validate(); err != nil {
-		log.Error("user-validation-failed", zap.Error(err))
+		logger.Error("user-validation-failed", zap.Error(err))
 		return nil, ErrValidationFailed
 	}
 
@@ -385,7 +385,7 @@ func (s *Service) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*Upda
 	// Update in repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-update-user", zap.Error(err))
+		logger.Error("failed-to-update-user", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -399,26 +399,26 @@ func (s *Service) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*Upda
 		})
 	}
 
-	log.Info("user-updated-successfully", zap.String("user-id", updatedUser.ID))
+	logger.Info("user-updated-successfully", zap.String("user-id", updatedUser.ID))
 
 	return &UpdateUserResponse{User: updatedUser}, nil
 }
 
 // DeleteUser deletes a user
 func (s *Service) DeleteUser(ctx context.Context, req *DeleteUserRequest) error {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "delete-user")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "delete-user"))
 
 	// Verify user exists
 	_, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("user-not-found", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("user-not-found", zap.Error(err), zap.String("id", req.ID))
 		return ErrUserNotFound
 	}
 
 	// Delete user
 	err = s.UserRepository.DeleteUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-delete-user", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-delete-user", zap.Error(err), zap.String("id", req.ID))
 		return ErrDatabaseError
 	}
 
@@ -432,14 +432,14 @@ func (s *Service) DeleteUser(ctx context.Context, req *DeleteUserRequest) error 
 		})
 	}
 
-	log.Info("user-deleted-successfully", zap.String("user-id", req.ID))
+	logger.Info("user-deleted-successfully", zap.String("user-id", req.ID))
 
 	return nil
 }
 
 // GetUsers retrieves users with filters and pagination
 func (s *Service) GetUsers(ctx context.Context, req *GetUsersRequest) (*GetUsersResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-users")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "get-users"))
 
 	// Validate pagination
 	if req.Page < 1 {
@@ -467,14 +467,14 @@ func (s *Service) GetUsers(ctx context.Context, req *GetUsersRequest) (*GetUsers
 
 	totalMatchingUsers, err := s.UserRepository.GetTotalUsers(ctx, totalReq)
 	if err != nil {
-		log.Error("failed-to-get-total-users", zap.Error(err))
+		logger.Error("failed-to-get-total-users", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
 	// Get users
 	users, err := s.UserRepository.GetUsers(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-users", zap.Error(err))
+		logger.Error("failed-to-get-users", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -502,11 +502,11 @@ func (s *Service) GetUsers(ctx context.Context, req *GetUsersRequest) (*GetUsers
 
 // GetTotalUsers retrieves the total count of users matching filters
 func (s *Service) GetTotalUsers(ctx context.Context, req *GetTotalUsersRequest) (*GetTotalUsersResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-total-users")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "get-total-users"))
 
 	total, err := s.UserRepository.GetTotalUsers(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-total-users", zap.Error(err))
+		logger.Error("failed-to-get-total-users", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -515,12 +515,12 @@ func (s *Service) GetTotalUsers(ctx context.Context, req *GetTotalUsersRequest) 
 
 // UpdateUserStatus updates a user's status
 func (s *Service) UpdateUserStatus(ctx context.Context, req *UpdateUserStatusRequest) (*UpdateUserStatusResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-user-status")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "update-user-status"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-status-update", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-status-update", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -530,14 +530,14 @@ func (s *Service) UpdateUserStatus(ctx context.Context, req *UpdateUserStatusReq
 	// Update status
 	updatedUser, err := user.UpdateStatus(req.DesiredStatus)
 	if err != nil {
-		log.Error("failed-to-update-user-status", zap.Error(err))
+		logger.Error("failed-to-update-user-status", zap.Error(err))
 		return nil, err
 	}
 
 	// Save to repository
 	updatedUser, err = s.UserRepository.UpdateUser(ctx, updatedUser)
 	if err != nil {
-		log.Error("failed-to-save-user-after-status-update", zap.Error(err))
+		logger.Error("failed-to-save-user-after-status-update", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -551,19 +551,19 @@ func (s *Service) UpdateUserStatus(ctx context.Context, req *UpdateUserStatusReq
 		})
 	}
 
-	log.Info("user-status-updated-successfully", zap.String("user-id", updatedUser.ID), zap.String("status", req.DesiredStatus))
+	logger.Info("user-status-updated-successfully", zap.String("user-id", updatedUser.ID), zap.String("status", req.DesiredStatus))
 
 	return &UpdateUserStatusResponse{User: updatedUser}, nil
 }
 
 // AddUserRole adds a role to a user
 func (s *Service) AddUserRole(ctx context.Context, req *AddUserRoleRequest) (*AddUserRoleResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "add-user-role")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "add-user-role"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-adding-role", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-adding-role", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -576,7 +576,7 @@ func (s *Service) AddUserRole(ctx context.Context, req *AddUserRoleRequest) (*Ad
 	// Save to repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-save-user-after-adding-role", zap.Error(err))
+		logger.Error("failed-to-save-user-after-adding-role", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -590,19 +590,19 @@ func (s *Service) AddUserRole(ctx context.Context, req *AddUserRoleRequest) (*Ad
 		})
 	}
 
-	log.Info("user-role-added-successfully", zap.String("user-id", updatedUser.ID), zap.String("role", req.Role))
+	logger.Info("user-role-added-successfully", zap.String("user-id", updatedUser.ID), zap.String("role", req.Role))
 
 	return &AddUserRoleResponse{User: updatedUser}, nil
 }
 
 // RemoveUserRole removes a role from a user
 func (s *Service) RemoveUserRole(ctx context.Context, req *RemoveUserRoleRequest) (*RemoveUserRoleResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "remove-user-role")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "remove-user-role"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-removing-role", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-removing-role", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -615,7 +615,7 @@ func (s *Service) RemoveUserRole(ctx context.Context, req *RemoveUserRoleRequest
 	// Save to repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-save-user-after-removing-role", zap.Error(err))
+		logger.Error("failed-to-save-user-after-removing-role", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -629,19 +629,19 @@ func (s *Service) RemoveUserRole(ctx context.Context, req *RemoveUserRoleRequest
 		})
 	}
 
-	log.Info("user-role-removed-successfully", zap.String("user-id", updatedUser.ID), zap.String("role", req.Role))
+	logger.Info("user-role-removed-successfully", zap.String("user-id", updatedUser.ID), zap.String("role", req.Role))
 
 	return &RemoveUserRoleResponse{User: updatedUser}, nil
 }
 
 // VerifyUserEmail marks a user's email as verified
 func (s *Service) VerifyUserEmail(ctx context.Context, req *VerifyUserEmailRequest) (*VerifyUserEmailResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "verify-user-email")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "verify-user-email"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-email-verification", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-email-verification", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -654,7 +654,7 @@ func (s *Service) VerifyUserEmail(ctx context.Context, req *VerifyUserEmailReque
 	// Save to repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-save-user-after-email-verification", zap.Error(err))
+		logger.Error("failed-to-save-user-after-email-verification", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -668,19 +668,19 @@ func (s *Service) VerifyUserEmail(ctx context.Context, req *VerifyUserEmailReque
 		})
 	}
 
-	log.Info("user-email-verified-successfully", zap.String("user-id", updatedUser.ID))
+	logger.Info("user-email-verified-successfully", zap.String("user-id", updatedUser.ID))
 
 	return &VerifyUserEmailResponse{User: updatedUser}, nil
 }
 
 // UnverifyUserEmail marks a user's email as unverified
 func (s *Service) UnverifyUserEmail(ctx context.Context, req *UnverifyUserEmailRequest) (*UnverifyUserEmailResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "unverify-user-email")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "unverify-user-email"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-email-unverification", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-email-unverification", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -693,7 +693,7 @@ func (s *Service) UnverifyUserEmail(ctx context.Context, req *UnverifyUserEmailR
 	// Save to repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-save-user-after-email-unverification", zap.Error(err))
+		logger.Error("failed-to-save-user-after-email-unverification", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -707,19 +707,19 @@ func (s *Service) UnverifyUserEmail(ctx context.Context, req *UnverifyUserEmailR
 		})
 	}
 
-	log.Info("user-email-unverified-successfully", zap.String("user-id", updatedUser.ID))
+	logger.Info("user-email-unverified-successfully", zap.String("user-id", updatedUser.ID))
 
 	return &UnverifyUserEmailResponse{User: updatedUser}, nil
 }
 
 // VerifyUserPhone marks a user's phone as verified
 func (s *Service) VerifyUserPhone(ctx context.Context, req *VerifyUserPhoneRequest) (*VerifyUserPhoneResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "veify-user-phone")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "veify-user-phone"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-phone-verification", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-phone-verification", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -732,7 +732,7 @@ func (s *Service) VerifyUserPhone(ctx context.Context, req *VerifyUserPhoneReque
 	// Save to repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-save-user-after-phone-verification", zap.Error(err))
+		logger.Error("failed-to-save-user-after-phone-verification", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -746,19 +746,19 @@ func (s *Service) VerifyUserPhone(ctx context.Context, req *VerifyUserPhoneReque
 		})
 	}
 
-	log.Info("user-phone-verified-successfully", zap.String("user-id", updatedUser.ID))
+	logger.Info("user-phone-verified-successfully", zap.String("user-id", updatedUser.ID))
 
 	return &VerifyUserPhoneResponse{User: updatedUser}, nil
 }
 
 // RecordUserLogin records a user login event
 func (s *Service) RecordUserLogin(ctx context.Context, req *RecordUserLoginRequest) (*RecordUserLoginResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "record-user-login")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "record-user-login"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-login-recording", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-login-recording", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -772,22 +772,22 @@ func (s *Service) RecordUserLogin(ctx context.Context, req *RecordUserLoginReque
 	// Save to repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-save-user-after-login-recording", zap.Error(err))
+		logger.Error("failed-to-save-user-after-login-recording", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
-	log.Info("user-login-recorded-successfully", zap.String("user-id", updatedUser.ID))
+	logger.Info("user-login-recorded-successfully", zap.String("user-id", updatedUser.ID))
 
 	return &RecordUserLoginResponse{User: updatedUser}, nil
 }
 
 // GetUserProfile retrieves a user's profile
 func (s *Service) GetUserProfile(ctx context.Context, req *GetUserProfileRequest) (*GetUserProfileResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-user-profile")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "get-user-profile"))
 
 	userResp, err := s.GetUserByID(ctx, &GetUserByIDRequest{ID: req.ID})
 	if err != nil {
-		log.Error("failed-to-get-user-for-profile-retrieval", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-profile-retrieval", zap.Error(err), zap.String("id", req.ID))
 		return nil, err
 	}
 
@@ -798,11 +798,11 @@ func (s *Service) GetUserProfile(ctx context.Context, req *GetUserProfileRequest
 
 // GetUserMicroProfile retrieves a user's micro profile
 func (s *Service) GetUserMicroProfile(ctx context.Context, req *GetUserMicroProfileRequest) (*GetUserMicroProfileResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-user-micro-profile")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "get-user-micro-profile"))
 
 	userResp, err := s.GetUserByID(ctx, &GetUserByIDRequest{ID: req.ID})
 	if err != nil {
-		log.Error("failed-to-get-user-for-micro-profile-retrieval", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-micro-profile-retrieval", zap.Error(err), zap.String("id", req.ID))
 		return nil, err
 	}
 
@@ -813,12 +813,12 @@ func (s *Service) GetUserMicroProfile(ctx context.Context, req *GetUserMicroProf
 
 // SetUserExtension sets an extension field value
 func (s *Service) SetUserExtension(ctx context.Context, req *SetUserExtensionRequest) (*SetUserExtensionResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "set-user-extension")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "set-user-extension"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-setting-extension", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-setting-extension", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -835,23 +835,23 @@ func (s *Service) SetUserExtension(ctx context.Context, req *SetUserExtensionReq
 	// Save to repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-save-user-after-setting-extension", zap.Error(err))
+		logger.Error("failed-to-save-user-after-setting-extension", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
-	log.Info("user-extension-set-successfully", zap.String("user-id", updatedUser.ID), zap.String("key", req.Key))
+	logger.Info("user-extension-set-successfully", zap.String("user-id", updatedUser.ID), zap.String("key", req.Key))
 
 	return &SetUserExtensionResponse{User: updatedUser}, nil
 }
 
 // GetUserExtension retrieves an extension field value
 func (s *Service) GetUserExtension(ctx context.Context, req *GetUserExtensionRequest) (*GetUserExtensionResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-user-extension")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "get-user-extension"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-getting-extension", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-getting-extension", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -866,12 +866,12 @@ func (s *Service) GetUserExtension(ctx context.Context, req *GetUserExtensionReq
 
 // UpdateUserPersonalInfo updates a user's personal information
 func (s *Service) UpdateUserPersonalInfo(ctx context.Context, req *UpdateUserPersonalInfoRequest) (*UpdateUserPersonalInfoResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "update-user-personal-info")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "update-user-personal-info"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-updating-personal-info", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-updating-personal-info", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -918,7 +918,7 @@ func (s *Service) UpdateUserPersonalInfo(ctx context.Context, req *UpdateUserPer
 	// Save to repository
 	updatedUser, err := s.UserRepository.UpdateUser(ctx, user)
 	if err != nil {
-		log.Error("failed-to-save-user-after-updating-personal-info", zap.Error(err))
+		logger.Error("failed-to-save-user-after-updating-personal-info", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 
@@ -932,19 +932,19 @@ func (s *Service) UpdateUserPersonalInfo(ctx context.Context, req *UpdateUserPer
 		})
 	}
 
-	log.Info("user-personal-info-updated-successfully", zap.String("user-id", updatedUser.ID))
+	logger.Info("user-personal-info-updated-successfully", zap.String("user-id", updatedUser.ID))
 
 	return &UpdateUserPersonalInfoResponse{User: updatedUser}, nil
 }
 
 // ValidateUser validates a user
 func (s *Service) ValidateUser(ctx context.Context, req *ValidateUserRequest) (*ValidateUserResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "validate-user")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "validate-user"))
 
 	// Get user
 	user, err := s.UserRepository.GetUserByID(ctx, req.ID)
 	if err != nil {
-		log.Error("failed-to-get-user-for-validation", zap.Error(err), zap.String("id", req.ID))
+		logger.Error("failed-to-get-user-for-validation", zap.Error(err), zap.String("id", req.ID))
 		return nil, ErrUserNotFound
 	}
 
@@ -955,7 +955,7 @@ func (s *Service) ValidateUser(ctx context.Context, req *ValidateUserRequest) (*
 	validationErr := user.Validate()
 
 	if validationErr != nil {
-		log.Error("user-validation-failed", zap.Error(validationErr))
+		logger.Error("user-validation-failed", zap.Error(validationErr))
 		errorStr := validationErr.Error()
 		return &ValidateUserResponse{
 			Valid:  false,
@@ -968,7 +968,7 @@ func (s *Service) ValidateUser(ctx context.Context, req *ValidateUserRequest) (*
 
 // BulkUpdateUsersStatus updates status for multiple users
 func (s *Service) BulkUpdateUsersStatus(ctx context.Context, req *BulkUpdateUsersStatusRequest) (*BulkUpdateUsersStatusResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "bulk-update-users-status")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "bulk-update-users-status"))
 
 	var successCount, failureCount int
 	var failedIDs []string
@@ -983,13 +983,13 @@ func (s *Service) BulkUpdateUsersStatus(ctx context.Context, req *BulkUpdateUser
 		if err != nil {
 			failureCount++
 			failedIDs = append(failedIDs, userID)
-			log.Warn("failed-to-update-user-status-in-bulk-operation", zap.String("user-id", userID), zap.Error(err))
+			logger.Warn("failed-to-update-user-status-in-bulk-operation", zap.String("user-id", userID), zap.Error(err))
 		} else {
 			successCount++
 		}
 	}
 
-	log.Info("bulk-status-update-completed", zap.Int("success", successCount), zap.Int("failures", failureCount))
+	logger.Info("bulk-status-update-completed", zap.Int("success", successCount), zap.Int("failures", failureCount))
 
 	return &BulkUpdateUsersStatusResponse{
 		UpdatedCount: successCount,
@@ -999,11 +999,11 @@ func (s *Service) BulkUpdateUsersStatus(ctx context.Context, req *BulkUpdateUser
 
 // GetUserStats retrieves aggregated stats about platform users
 func (s *Service) GetUserStats(ctx context.Context, req *GetUserStatsRequest) (*GetUserStatsResponse, error) {
-	log := logger.AcquireFrom(ctx).With(zap.String("method", "get-user-stats")).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/user/v2").With(zap.String("operation", "get-user-stats"))
 
 	stats, err := s.UserRepository.GetUserStatsCounts(ctx, req)
 	if err != nil {
-		log.Error("failed-to-get-user-stats-counts", zap.Error(err))
+		logger.Error("failed-to-get-user-stats-counts", zap.Error(err))
 		return nil, ErrDatabaseError
 	}
 

--- a/external/user/v2/service.go
+++ b/external/user/v2/service.go
@@ -213,7 +213,7 @@ func (s *Service) GetUserByNanoID(ctx context.Context, req *GetUserByNanoIDReque
 
 	user, err := s.UserRepository.GetUserByNanoID(ctx, req.NanoID)
 	if err != nil {
-		logger.Error("failed to get user by nano ID", zap.Error(err), zap.String("nano_id", req.NanoID))
+		logger.Error("failed to get user by nano ID", zap.Error(err), zap.String("nano-id", req.NanoID))
 		return nil, ErrUserNotFound
 	}
 

--- a/external/user/v2/service.go
+++ b/external/user/v2/service.go
@@ -87,7 +87,7 @@ func (s *Service) CreateUser(ctx context.Context, req *CreateUserRequest) (*Crea
 	// Check if user already exists
 	existingUser, _ := s.UserRepository.GetUserByEmail(ctx, req.Email, false)
 	if existingUser != nil {
-		logger.Error("user-with-email-already-exists", zap.String("email", req.Email))
+		logger.Error("user-with-email-already-exists", emailLogFields("email", req.Email)...)
 		return nil, ErrEmailAlreadyExists
 	}
 
@@ -233,7 +233,7 @@ func (s *Service) GetUserByEmail(ctx context.Context, req *GetUserByEmailRequest
 
 	user, err := s.UserRepository.GetUserByEmail(ctx, normaliseUserEmail(req.Email), true)
 	if err != nil {
-		logger.Error("failed to get user by email", zap.Error(err), zap.String("email", req.Email))
+		logger.Error("failed to get user by email", append(emailLogFields("email", req.Email), zap.Error(err))...)
 		return nil, ErrUserNotFound
 	}
 

--- a/external/usermanager/fender.go
+++ b/external/usermanager/fender.go
@@ -25,11 +25,11 @@ func MapRequestToUpdateUserProfileRequest(r *http.Request, validator Usermanager
 	var parsedRequest = UpdateUserProfileRequest{
 		UpdateUserRequest: &userv2.UpdateUserRequest{},
 	}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -51,10 +51,10 @@ func MapRequestToUpdateUserProfileRequest(r *http.Request, validator Usermanager
 func MapRequestToGetUserMicroProfileRequest(r *http.Request, validator UsermanagerValidator) (*GetUserMicroProfileRequest, error) {
 	var parsedRequest GetUserMicroProfileRequest
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -64,17 +64,17 @@ func MapRequestToGetUserMicroProfileRequest(r *http.Request, validator Usermanag
 // MapRequestToGetGroupsByUserIDRequest maps incoming GetGroupsByUserID request to correct struct
 func MapRequestToGetGroupsByUserIDRequest(r *http.Request, validator UsermanagerValidator) (*GetGroupsByUserIDRequest, error) {
 	var parsedRequest GetGroupsByUserIDRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.ID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.ID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	targetUserId, err := toolbox.GetVariableValueFromUri(r, "userId")
 	if err != nil {
-		log.Error("unable-get-user-id-from-uri")
+		logger.Error("unable-get-user-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -92,7 +92,7 @@ func MapRequestToGetGroupsByUserIDRequest(r *http.Request, validator Usermanager
 	parsedRequest.GetGroupsByUserIDRequest = &baseRequest
 
 	if err := validateParsedRequest(&parsedRequest, validator); err != nil {
-		log.Error("get-groups-by-user-id-request-validation-failed", zap.Error(err))
+		logger.Error("get-groups-by-user-id-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -103,19 +103,19 @@ func MapRequestToGetGroupsByUserIDRequest(r *http.Request, validator Usermanager
 func MapRequestToGetUserByIDRequest(r *http.Request, validator UsermanagerValidator) (*GetUserByIDRequest, error) {
 	var parsedRequest GetUserByIDRequest
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	baseRequest := userv2.GetUserByIDRequest{}
 
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	// Extract target user ID from URL path
 	targetUserId, err := toolbox.GetVariableValueFromUri(r, "userId")
 	if err != nil {
-		log.Error("unable-get-user-id-from-uri")
+		logger.Error("unable-get-user-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -123,7 +123,7 @@ func MapRequestToGetUserByIDRequest(r *http.Request, validator UsermanagerValida
 	parsedRequest.GetUserByIDRequest = &baseRequest
 
 	if err := validateParsedRequest(&parsedRequest, validator); err != nil {
-		log.Error("get-user-by-id-request-validation-failed", zap.Error(err))
+		logger.Error("get-user-by-id-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -135,11 +135,11 @@ func MapRequestToGetUsersRequest(r *http.Request, validator UsermanagerValidator
 	var parsedRequest GetUsersRequest = GetUsersRequest{
 		GetUsersRequest: &userv2.GetUsersRequest{},
 	}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -151,7 +151,7 @@ func MapRequestToGetUsersRequest(r *http.Request, validator UsermanagerValidator
 	}
 
 	if err := validateParsedRequest(&parsedRequest, validator); err != nil {
-		log.Error("get-users-request-validation-failed", zap.Error(err))
+		logger.Error("get-users-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -160,7 +160,7 @@ func MapRequestToGetUsersRequest(r *http.Request, validator UsermanagerValidator
 
 // MapRequestToGetGroupLineageRequest maps incoming GetGroupLineage request to correct struct.
 func MapRequestToGetGroupLineageRequest(r *http.Request, validator UsermanagerValidator) (*GetGroupLineageRequest, error) {
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	baseRequest := group.GetGroupLineageRequest{}
 	parsedRequest := GetGroupLineageRequest{
@@ -169,13 +169,13 @@ func MapRequestToGetGroupLineageRequest(r *http.Request, validator UsermanagerVa
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -192,7 +192,7 @@ func MapRequestToGetGroupLineageRequest(r *http.Request, validator UsermanagerVa
 // MapRequestToGetGroupsConfigRequest maps incoming GetGroupsConfig request to correct struct.
 // MapRequestToGetGroupDescendantsRequest maps incoming GetGroupDescendants request to correct struct.
 func MapRequestToGetGroupDescendantsRequest(r *http.Request, validator UsermanagerValidator) (*GetGroupDescendantsRequest, error) {
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	baseRequest := group.GetGroupDescendantsRequest{}
 	parsedRequest := GetGroupDescendantsRequest{
@@ -201,13 +201,13 @@ func MapRequestToGetGroupDescendantsRequest(r *http.Request, validator Usermanag
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -224,11 +224,11 @@ func MapRequestToGetGroupDescendantsRequest(r *http.Request, validator Usermanag
 // MapRequestToGetGroupsConfigRequest maps incoming GetGroupsConfig request to correct struct.
 func MapRequestToGetGroupsConfigRequest(r *http.Request, validator UsermanagerValidator) (*GetGroupsConfigRequest, error) {
 	var parsedRequest GetGroupsConfigRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -239,7 +239,7 @@ func MapRequestToGetGroupsConfigRequest(r *http.Request, validator UsermanagerVa
 // struct.
 func MapRequestToGetUserProfileRequest(r *http.Request, validator UsermanagerValidator) (*GetUserProfileRequest, error) {
 
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 	parsedRequest := GetUserProfileRequest{
 		GetUserProfileRequest: &userv2.GetUserProfileRequest{},
 	}
@@ -258,7 +258,7 @@ func MapRequestToGetUserProfileRequest(r *http.Request, validator UsermanagerVal
 	parsedRequest.GetUserProfileRequest = &baseRequest
 
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -270,10 +270,10 @@ func MapRequestToGetUserProfileRequest(r *http.Request, validator UsermanagerVal
 func MapRequestToDeleteUserPermanentlyRequest(r *http.Request, validator UsermanagerValidator) (*DeleteUserPermanentlyRequest, error) {
 	var parsedRequest DeleteUserPermanentlyRequest
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -281,12 +281,12 @@ func MapRequestToDeleteUserPermanentlyRequest(r *http.Request, validator Userman
 
 	err := toolbox.DecodeRequestBody(r, &parsedRequest)
 	if err != nil {
-		log.Error("unable-decode-request-body", zap.Error(err))
+		logger.Error("unable-decode-request-body", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
 	if err := validateParsedRequest(&parsedRequest, validator); err != nil {
-		log.Error("delete-user-permanently-request-validation-failed", zap.Error(err))
+		logger.Error("delete-user-permanently-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -296,7 +296,7 @@ func MapRequestToDeleteUserPermanentlyRequest(r *http.Request, validator Userman
 // MapRequestToCreateCommsRequest maps the request to a CreateCommsRequest
 func MapRequestToCreateCommsRequest(r *http.Request, validator UsermanagerValidator) (*CreateCommsRequest, error) {
 
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest := &CreateCommsRequest{
 		CreateCommsRequest: &contacter.CreateCommsRequest{},
@@ -314,7 +314,7 @@ func MapRequestToCreateCommsRequest(r *http.Request, validator UsermanagerValida
 	parsedRequest.CreateCommsRequest = &baseRequest
 
 	if err := validateParsedRequest(&baseRequest, validator); err != nil {
-		log.Error("create-comms-request-validation-failed", zap.Error(err))
+		logger.Error("create-comms-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -382,12 +382,12 @@ func validateParsedRequest(request interface{}, validator UsermanagerValidator) 
 func MapRequestToUpdateCommsRequest(r *http.Request, validator UsermanagerValidator) (*UpdateCommsRequest, error) {
 
 	var parsedRequest UpdateCommsRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	// Extract comms ID from URL path
 	commsId, err := toolbox.GetVariableValueFromUri(r, "id")
 	if err != nil {
-		log.Error("unable-get-comms-id-from-uri")
+		logger.Error("unable-get-comms-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -403,7 +403,7 @@ func MapRequestToUpdateCommsRequest(r *http.Request, validator UsermanagerValida
 	parsedRequest.UpdateCommsRequest = &baseRequest
 
 	if err := validateParsedRequest(&baseRequest, validator); err != nil {
-		log.Error("update-comms-request-validation-failed", zap.Error(err))
+		logger.Error("update-comms-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -413,11 +413,11 @@ func MapRequestToUpdateCommsRequest(r *http.Request, validator UsermanagerValida
 // MapRequestToGetEnrichedUserProfileRequest maps incoming GetEnrichedUserProfile request to correct struct
 func MapRequestToGetEnrichedUserProfileRequest(r *http.Request, validator UsermanagerValidator) (*GetEnrichedUserProfileRequest, error) {
 	var parsedRequest GetEnrichedUserProfileRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -437,11 +437,11 @@ func MapRequestToGetEnrichedUserProfileRequest(r *http.Request, validator Userma
 // MapRequestToGetUserGroupsRequest maps incoming GetUserGroups request to correct struct
 func MapRequestToGetUserGroupsRequest(r *http.Request, validator UsermanagerValidator) (*GetUserGroupsRequest, error) {
 	var parsedRequest GetUserGroupsRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -452,7 +452,7 @@ func MapRequestToGetUserGroupsRequest(r *http.Request, validator UsermanagerVali
 	}
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("get-user-groups-request-validation-failed", zap.Error(err))
+		logger.Error("get-user-groups-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -462,11 +462,11 @@ func MapRequestToGetUserGroupsRequest(r *http.Request, validator UsermanagerVali
 // MapRequestToGetLatestNotificationOverviewsRequest maps incoming latest notifications request to the correct struct.
 func MapRequestToGetLatestNotificationOverviewsRequest(r *http.Request, validator UsermanagerValidator) (*GetLatestNotificationOverviewsRequest, error) {
 	var parsedRequest GetLatestNotificationOverviewsRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	requesterUserID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if requesterUserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -489,7 +489,7 @@ func MapRequestToGetLatestNotificationOverviewsRequest(r *http.Request, validato
 	parsedRequest.GetLatestNotificationOverviewsRequest = &baseRequest
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("get-latest-notification-overviews-request-validation-failed", zap.Error(err))
+		logger.Error("get-latest-notification-overviews-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -499,11 +499,11 @@ func MapRequestToGetLatestNotificationOverviewsRequest(r *http.Request, validato
 // MapRequestToGetNotifierConfigRequest maps incoming notifier config request to the correct struct.
 func MapRequestToGetNotifierConfigRequest(r *http.Request, validator UsermanagerValidator) (*GetNotifierConfigRequest, error) {
 	var parsedRequest GetNotifierConfigRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 	parsedRequest.GetNotifierConfigRequest = &notifier.GetNotifierConfigRequest{}
@@ -514,11 +514,11 @@ func MapRequestToGetNotifierConfigRequest(r *http.Request, validator Usermanager
 // MapRequestToRegisterNotificationAddressRequest maps incoming notification address registration to the correct struct.
 func MapRequestToRegisterNotificationAddressRequest(r *http.Request, validator UsermanagerValidator) (*RegisterNotificationAddressRequest, error) {
 	var parsedRequest RegisterNotificationAddressRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	requesterUserID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if requesterUserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -537,7 +537,7 @@ func MapRequestToRegisterNotificationAddressRequest(r *http.Request, validator U
 	parsedRequest.UserId = requesterUserID
 	parsedRequest.RegisterAddressRequest = &baseRequest
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("register-notification-address-request-validation-failed", zap.Error(err))
+		logger.Error("register-notification-address-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -547,11 +547,11 @@ func MapRequestToRegisterNotificationAddressRequest(r *http.Request, validator U
 // MapRequestToListNotificationAddressesRequest maps incoming notification address list request to the correct struct.
 func MapRequestToListNotificationAddressesRequest(r *http.Request, validator UsermanagerValidator) (*ListNotificationAddressesRequest, error) {
 	var parsedRequest ListNotificationAddressesRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	requesterUserID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if requesterUserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -580,17 +580,17 @@ func MapRequestToListNotificationAddressesRequest(r *http.Request, validator Use
 // MapRequestToDeleteNotificationAddressRequest maps incoming notification address delete request to the correct struct.
 func MapRequestToDeleteNotificationAddressRequest(r *http.Request, validator UsermanagerValidator) (*DeleteNotificationAddressRequest, error) {
 	var parsedRequest DeleteNotificationAddressRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	requesterUserID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if requesterUserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	addressID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableAddressID)
 	if err != nil {
-		log.Error("unable-get-notification-address-id-from-uri")
+		logger.Error("unable-get-notification-address-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -610,11 +610,11 @@ func MapRequestToDeleteNotificationAddressRequest(r *http.Request, validator Use
 // MapRequestToGetNotificationPreferencesRequest maps incoming notification preferences request to the correct struct.
 func MapRequestToGetNotificationPreferencesRequest(r *http.Request, validator UsermanagerValidator) (*GetNotificationPreferencesRequest, error) {
 	var parsedRequest GetNotificationPreferencesRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	requesterUserID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if requesterUserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -632,11 +632,11 @@ func MapRequestToGetNotificationPreferencesRequest(r *http.Request, validator Us
 // MapRequestToUpdateNotificationPreferencesRequest maps incoming notification preferences update to the correct struct.
 func MapRequestToUpdateNotificationPreferencesRequest(r *http.Request, validator UsermanagerValidator) (*UpdateNotificationPreferencesRequest, error) {
 	var parsedRequest UpdateNotificationPreferencesRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	requesterUserID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if requesterUserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -659,17 +659,17 @@ func MapRequestToUpdateNotificationPreferencesRequest(r *http.Request, validator
 // MapRequestToNotifyUserRequest maps incoming admin/service notification send request to the correct struct.
 func MapRequestToNotifyUserRequest(r *http.Request, validator UsermanagerValidator) (*NotifyUserRequest, error) {
 	var parsedRequest NotifyUserRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	targetUserID, err := toolbox.GetVariableValueFromUri(r, "userId")
 	if err != nil {
-		log.Error("unable-get-target-user-id-from-uri")
+		logger.Error("unable-get-target-user-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -681,7 +681,7 @@ func MapRequestToNotifyUserRequest(r *http.Request, validator UsermanagerValidat
 
 	parsedRequest.NotifyUserRequest = &baseRequest
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("notify-user-request-validation-failed", zap.Error(err))
+		logger.Error("notify-user-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -691,11 +691,11 @@ func MapRequestToNotifyUserRequest(r *http.Request, validator UsermanagerValidat
 // MapRequestToNotifyUsersRequest maps incoming admin notification dispatch request to the correct struct.
 func MapRequestToNotifyUsersRequest(r *http.Request, validator UsermanagerValidator) (*NotifyUsersRequest, error) {
 	var parsedRequest NotifyUsersRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -706,7 +706,7 @@ func MapRequestToNotifyUsersRequest(r *http.Request, validator UsermanagerValida
 
 	parsedRequest.NotifyUsersRequest = &baseRequest
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("notify-users-request-validation-failed", zap.Error(err))
+		logger.Error("notify-users-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -716,11 +716,11 @@ func MapRequestToNotifyUsersRequest(r *http.Request, validator UsermanagerValida
 // MapRequestToGetMyGroupInvitationsRequest maps incoming my-group-invitations request to the correct struct.
 func MapRequestToGetMyGroupInvitationsRequest(r *http.Request, validator UsermanagerValidator) (*GetMyGroupInvitationsRequest, error) {
 	var parsedRequest GetMyGroupInvitationsRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -729,7 +729,7 @@ func MapRequestToGetMyGroupInvitationsRequest(r *http.Request, validator Userman
 	}
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("get-my-group-invitations-request-validation-failed", zap.Error(err))
+		logger.Error("get-my-group-invitations-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -739,11 +739,11 @@ func MapRequestToGetMyGroupInvitationsRequest(r *http.Request, validator Userman
 // MapRequestToAcceptMyGroupInvitationRequest maps incoming accept-my-group-invitation request to the correct struct.
 func MapRequestToAcceptMyGroupInvitationRequest(r *http.Request, validator UsermanagerValidator) (*AcceptMyGroupInvitationRequest, error) {
 	var parsedRequest AcceptMyGroupInvitationRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -754,7 +754,7 @@ func MapRequestToAcceptMyGroupInvitationRequest(r *http.Request, validator Userm
 	parsedRequest.GroupID = groupID
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("accept-my-group-invitation-request-validation-failed", zap.Error(err))
+		logger.Error("accept-my-group-invitation-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -764,11 +764,11 @@ func MapRequestToAcceptMyGroupInvitationRequest(r *http.Request, validator Userm
 // MapRequestToRejectMyGroupInvitationRequest maps incoming reject-my-group-invitation request to the correct struct.
 func MapRequestToRejectMyGroupInvitationRequest(r *http.Request, validator UsermanagerValidator) (*RejectMyGroupInvitationRequest, error) {
 	var parsedRequest RejectMyGroupInvitationRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -779,7 +779,7 @@ func MapRequestToRejectMyGroupInvitationRequest(r *http.Request, validator Userm
 	parsedRequest.GroupID = groupID
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("reject-my-group-invitation-request-validation-failed", zap.Error(err))
+		logger.Error("reject-my-group-invitation-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -792,11 +792,11 @@ func MapRequestToGetUserGroupMembershipsRequestRequest(r *http.Request, validato
 		GroupType:          "",
 		IncludeDescendants: true,
 	}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -807,7 +807,7 @@ func MapRequestToGetUserGroupMembershipsRequestRequest(r *http.Request, validato
 	}
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("get-user-team-memberships-request-validation-failed", zap.Error(err))
+		logger.Error("get-user-team-memberships-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -817,17 +817,17 @@ func MapRequestToGetUserGroupMembershipsRequestRequest(r *http.Request, validato
 // MapRequestToGetGroupDetailRequest maps incoming GetGroupDetail request to correct struct
 func MapRequestToGetGroupDetailRequest(r *http.Request, validator UsermanagerValidator) (*GetGroupDetailRequest, error) {
 	var parsedRequest GetGroupDetailRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -849,17 +849,17 @@ func MapRequestToGetGroupDetailRequest(r *http.Request, validator UsermanagerVal
 // MapRequestToGetGroupStatsRequest maps incoming GetGroupStats request to correct struct
 func MapRequestToGetGroupStatsRequest(r *http.Request, validator UsermanagerValidator) (*GetGroupStatsRequest, error) {
 	var parsedRequest GetGroupStatsRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -881,13 +881,13 @@ func MapRequestToGetGroupStatsRequest(r *http.Request, validator UsermanagerVali
 // MapRequestToCreateGroupRequest maps incoming CreateGroup request to correct struct
 func MapRequestToCreateGroupRequest(r *http.Request, validator UsermanagerValidator) (*CreateGroupRequest, error) {
 	var parsedRequest CreateGroupRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	baseRequest := group.CreateGroupRequest{}
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -910,17 +910,17 @@ func MapRequestToUpdateGroupRequest(r *http.Request, validator UsermanagerValida
 	var parsedRequest UpdateGroupRequest = UpdateGroupRequest{
 		UpdateGroupRequest: &group.UpdateGroupRequest{},
 	}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserId = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserId == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 	parsedRequest.UpdateGroupRequest.ID = groupID
@@ -939,19 +939,19 @@ func MapRequestToUpdateGroupRequest(r *http.Request, validator UsermanagerValida
 // MapRequestToDeleteGroupRequest  maps incoming DeleteGroup request to correct struct
 func MapRequestToDeleteGroupRequest(r *http.Request, validator UsermanagerValidator) (*DeleteGroupRequest, error) {
 	var parsedRequest DeleteGroupRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	baseRequest := group.DeleteGroupRequest{}
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 	baseRequest.ID = groupID
@@ -976,17 +976,17 @@ func MapRequestToAddGroupMemberRequest(r *http.Request, validator UsermanagerVal
 	var parsedRequest AddGroupMemberRequest = AddGroupMemberRequest{
 		AddMemberRequest: &group.AddMemberRequest{},
 	}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 	parsedRequest.GroupID = groupID
@@ -996,7 +996,7 @@ func MapRequestToAddGroupMemberRequest(r *http.Request, validator UsermanagerVal
 	}
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("add-group-member-request-validation-failed", zap.Error(err))
+		logger.Error("add-group-member-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -1006,11 +1006,11 @@ func MapRequestToAddGroupMemberRequest(r *http.Request, validator UsermanagerVal
 // MapRequestToRemoveGroupMemberRequest maps a remove-member request to the correct struct
 func MapRequestToRemoveGroupMemberRequest(r *http.Request, validator UsermanagerValidator) (*RemoveGroupMemberRequest, error) {
 	var parsedRequest RemoveGroupMemberRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1025,14 +1025,14 @@ func MapRequestToRemoveGroupMemberRequest(r *http.Request, validator Usermanager
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 	baseRequest.GroupID = groupID
 
 	memberID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableMemberID)
 	if err != nil {
-		log.Error("unable-get-member-id-from-uri")
+		logger.Error("unable-get-member-id-from-uri")
 		return nil, ErrInvalidMemberID
 	}
 	baseRequest.MemberID = memberID
@@ -1047,24 +1047,24 @@ func MapRequestToUpdateGroupMemberRequest(r *http.Request, validator Usermanager
 	var parsedRequest UpdateGroupMemberRequest = UpdateGroupMemberRequest{
 		UpdateMemberRoleRequest: &group.UpdateMemberRoleRequest{},
 	}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 	parsedRequest.GroupID = groupID
 
 	memberID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableMemberID)
 	if err != nil {
-		log.Error("unable-get-member-id-from-uri")
+		logger.Error("unable-get-member-id-from-uri")
 		return nil, ErrInvalidMemberID
 	}
 	parsedRequest.MemberID = memberID
@@ -1074,7 +1074,7 @@ func MapRequestToUpdateGroupMemberRequest(r *http.Request, validator Usermanager
 	}
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("update-group-member-request-validation-failed", zap.Error(err))
+		logger.Error("update-group-member-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -1086,17 +1086,17 @@ func MapRequestToUpdateGroupOwnerRequest(r *http.Request, validator UsermanagerV
 	var parsedRequest UpdateGroupOwnerRequest = UpdateGroupOwnerRequest{
 		UpdateOwnerRequest: &group.UpdateOwnerRequest{},
 	}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	groupID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableGroupID)
 	if err != nil {
-		log.Error("unable-get-group-id-from-uri")
+		logger.Error("unable-get-group-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 	parsedRequest.GroupID = groupID
@@ -1111,11 +1111,11 @@ func MapRequestToUpdateGroupOwnerRequest(r *http.Request, validator UsermanagerV
 // MapRequestToValidateGroupNameRequest maps incoming ValidateGroupName request to correct struct
 func MapRequestToValidateGroupNameRequest(r *http.Request, validator UsermanagerValidator) (*ValidateGroupNameRequest, error) {
 	var parsedRequest ValidateGroupNameRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1131,7 +1131,7 @@ func MapRequestToValidateGroupNameRequest(r *http.Request, validator Usermanager
 	parsedRequest.ValidateGroupNameRequest = &baseRequest
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
-		log.Error("validate-group-name-request-validation-failed", zap.Error(err))
+		logger.Error("validate-group-name-request-validation-failed", zap.Error(err))
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -1141,11 +1141,11 @@ func MapRequestToValidateGroupNameRequest(r *http.Request, validator Usermanager
 // MapRequestToCreateReminderRequest maps incoming create reminder request to the correct struct.
 func MapRequestToCreateReminderRequest(r *http.Request, validator UsermanagerValidator) (*CreateReminderRequest, error) {
 	var parsedRequest CreateReminderRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	userID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if userID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1164,17 +1164,17 @@ func MapRequestToCreateReminderRequest(r *http.Request, validator UsermanagerVal
 // MapRequestToGetReminderByIDRequest maps incoming get-reminder-by-ID request to the correct struct.
 func MapRequestToGetReminderByIDRequest(r *http.Request, validator UsermanagerValidator) (*GetReminderByIDRequest, error) {
 	var parsedRequest GetReminderByIDRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	userID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if userID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	reminderID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableReminderID)
 	if err != nil {
-		log.Error("unable-get-reminder-id-from-uri")
+		logger.Error("unable-get-reminder-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -1187,11 +1187,11 @@ func MapRequestToGetReminderByIDRequest(r *http.Request, validator UsermanagerVa
 // MapRequestToListRemindersRequest maps incoming reminder list request to the correct struct.
 func MapRequestToListRemindersRequest(r *http.Request, validator UsermanagerValidator) (*ListRemindersRequest, error) {
 	var parsedRequest ListRemindersRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	userID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if userID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1207,17 +1207,17 @@ func MapRequestToListRemindersRequest(r *http.Request, validator UsermanagerVali
 // MapRequestToUpdateReminderByIDRequest maps incoming update-reminder-by-ID request to the correct struct.
 func MapRequestToUpdateReminderByIDRequest(r *http.Request, validator UsermanagerValidator) (*UpdateReminderByIDRequest, error) {
 	var parsedRequest UpdateReminderByIDRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	userID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if userID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	reminderID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableReminderID)
 	if err != nil {
-		log.Error("unable-get-reminder-id-from-uri")
+		logger.Error("unable-get-reminder-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -1238,17 +1238,17 @@ func MapRequestToUpdateReminderByIDRequest(r *http.Request, validator Usermanage
 // MapRequestToDeleteReminderByIDRequest maps incoming delete-reminder-by-ID request to the correct struct.
 func MapRequestToDeleteReminderByIDRequest(r *http.Request, validator UsermanagerValidator) (*DeleteReminderByIDRequest, error) {
 	var parsedRequest DeleteReminderByIDRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	userID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if userID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	reminderID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableReminderID)
 	if err != nil {
-		log.Error("unable-get-reminder-id-from-uri")
+		logger.Error("unable-get-reminder-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -1261,17 +1261,17 @@ func MapRequestToDeleteReminderByIDRequest(r *http.Request, validator Usermanage
 // MapRequestToDisableReminderByIDRequest maps incoming disable-reminder-by-ID request to the correct struct.
 func MapRequestToDisableReminderByIDRequest(r *http.Request, validator UsermanagerValidator) (*DisableReminderByIDRequest, error) {
 	var parsedRequest DisableReminderByIDRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	userID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if userID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
 	reminderID, err := toolbox.GetVariableValueFromUri(r, UserManagerURIVariableReminderID)
 	if err != nil {
-		log.Error("unable-get-reminder-id-from-uri")
+		logger.Error("unable-get-reminder-id-from-uri")
 		return nil, ErrRequestFailedValidation
 	}
 
@@ -1284,11 +1284,11 @@ func MapRequestToDisableReminderByIDRequest(r *http.Request, validator Usermanag
 // MapRequestToGetReminderStatsRequest maps incoming reminder stats request to the correct struct.
 func MapRequestToGetReminderStatsRequest(r *http.Request, validator UsermanagerValidator) (*GetReminderStatsRequest, error) {
 	var parsedRequest GetReminderStatsRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1302,11 +1302,11 @@ func MapRequestToGetReminderStatsRequest(r *http.Request, validator UsermanagerV
 // MapRequestToGetDueRemindersRequest maps incoming due reminders request to the correct struct.
 func MapRequestToGetDueRemindersRequest(r *http.Request, validator UsermanagerValidator) (*GetDueRemindersRequest, error) {
 	var parsedRequest GetDueRemindersRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1324,11 +1324,11 @@ func MapRequestToGetDueRemindersRequest(r *http.Request, validator UsermanagerVa
 // MapRequestToRecordStreakRequest maps incoming record-streak request to the correct struct.
 func MapRequestToRecordStreakRequest(r *http.Request, validator UsermanagerValidator) (*RecordStreakRequest, error) {
 	var parsedRequest RecordStreakRequest
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	userID := accessmanagerhelpers.AcquireFrom(r.Context())
 	if userID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1348,11 +1348,11 @@ func MapRequestToRecordStreakRequest(r *http.Request, validator UsermanagerValid
 // MapRequestToListStreaksRequest maps incoming list-streaks request to the correct struct.
 func MapRequestToListStreaksRequest(r *http.Request, validator UsermanagerValidator) (*ListStreaksRequest, error) {
 	parsedRequest := ListStreaksRequest{ListStreaksRequest: &streaker.ListStreaksRequest{}}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1372,11 +1372,11 @@ func MapRequestToListStreaksRequest(r *http.Request, validator UsermanagerValida
 // MapRequestToGetCurrentStreakRequest maps incoming current-streak request to the correct struct.
 func MapRequestToGetCurrentStreakRequest(r *http.Request, validator UsermanagerValidator) (*GetCurrentStreakRequest, error) {
 	parsedRequest := GetCurrentStreakRequest{GetCurrentCountRequest: &streaker.GetCurrentCountRequest{}}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1396,11 +1396,11 @@ func MapRequestToGetCurrentStreakRequest(r *http.Request, validator UsermanagerV
 // MapRequestToGetLongestStreakRequest maps incoming longest-streak request to the correct struct.
 func MapRequestToGetLongestStreakRequest(r *http.Request, validator UsermanagerValidator) (*GetLongestStreakRequest, error) {
 	parsedRequest := GetLongestStreakRequest{GetLongestStreakRequest: &streaker.GetLongestStreakRequest{}}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 
@@ -1420,11 +1420,11 @@ func MapRequestToGetLongestStreakRequest(r *http.Request, validator UsermanagerV
 // MapRequestToGetNumberOfStreaksRequest maps incoming streak-count request to the correct struct.
 func MapRequestToGetNumberOfStreaksRequest(r *http.Request, validator UsermanagerValidator) (*GetNumberOfStreaksRequest, error) {
 	parsedRequest := GetNumberOfStreaksRequest{GetNumberOfStreaksRequest: &streaker.GetNumberOfStreaksRequest{}}
-	log := logger.AcquireFrom(r.Context()).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(r.Context(), "external/usermanager")
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(r.Context())
 	if parsedRequest.UserID == "" {
-		log.Error("unable-get-user-id")
+		logger.Error("unable-get-user-id")
 		return nil, ErrUnableToIdentifyUser
 	}
 

--- a/external/usermanager/handler.go
+++ b/external/usermanager/handler.go
@@ -2,12 +2,14 @@ package usermanager
 
 import (
 	"context"
+	"github.com/ooaklee/ghatd/external/logger"
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/common"
 	"github.com/ooaklee/ghatd/external/errormanifest"
 	"github.com/ooaklee/ghatd/external/toolbox"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // UsermanagerService manages business logic around usermanager request
@@ -113,14 +115,17 @@ func NewHandler(r *NewHandlerRequest) *Handler {
 
 // GetGroupLineage handles the request to get a group's lineage
 func (h *Handler) GetGroupLineage(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-group-lineage")
 	request, err := MapRequestToGetGroupLineageRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupLineage(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -131,14 +136,17 @@ func (h *Handler) GetGroupLineage(w http.ResponseWriter, r *http.Request) {
 // GetGroupsByUserID handles the request to get groups by user ID
 // GetGroupDescendants handles the request to get group descendants
 func (h *Handler) GetGroupDescendants(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-group-descendants")
 	request, err := MapRequestToGetGroupDescendantsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupDescendants(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -148,14 +156,17 @@ func (h *Handler) GetGroupDescendants(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupsByUserID handles the request to get groups by user ID.
 func (h *Handler) GetGroupsByUserID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-groups-by-user-id")
 	request, err := MapRequestToGetGroupsByUserIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupsByUserID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -165,14 +176,17 @@ func (h *Handler) GetGroupsByUserID(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupsConfig handles the request to get the group service config
 func (h *Handler) GetGroupsConfig(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-groups-config")
 	request, err := MapRequestToGetGroupsConfigRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetGroupsConfig(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -184,6 +198,7 @@ func (h *Handler) GetGroupsConfig(w http.ResponseWriter, r *http.Request) {
 // DeleteUserPermanently returns response for request to get user's
 // profile
 func (h *Handler) DeleteUserPermanently(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-delete-user-permanently")
 	request, err := MapRequestToDeleteUserPermanentlyRequest(r, h.Validator)
 	if err != nil {
 		h.RemoveAuthCookies(w)
@@ -191,6 +206,7 @@ func (h *Handler) DeleteUserPermanently(w http.ResponseWriter, r *http.Request) 
 		h.RemoveCookiesWithName(w, common.RefreshTokenAuthInfoCookieName)
 
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -202,6 +218,7 @@ func (h *Handler) DeleteUserPermanently(w http.ResponseWriter, r *http.Request) 
 		h.RemoveCookiesWithName(w, common.RefreshTokenAuthInfoCookieName)
 
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -217,9 +234,11 @@ func (h *Handler) DeleteUserPermanently(w http.ResponseWriter, r *http.Request) 
 // UpdateUserProfile returns response for request to update updatedable attributes
 // of the user's profile
 func (h *Handler) UpdateUserProfile(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-update-user-profile")
 	request, err := MapRequestToUpdateUserProfileRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -227,6 +246,7 @@ func (h *Handler) UpdateUserProfile(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.UpdateUserProfile(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -238,9 +258,11 @@ func (h *Handler) UpdateUserProfile(w http.ResponseWriter, r *http.Request) {
 // GetUserMicroProfile returns response for request to get user's
 // micro profile
 func (h *Handler) GetUserMicroProfile(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-user-micro-profile")
 	request, err := MapRequestToGetUserMicroProfileRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -248,6 +270,7 @@ func (h *Handler) GetUserMicroProfile(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetUserMicroProfile(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -258,9 +281,11 @@ func (h *Handler) GetUserMicroProfile(w http.ResponseWriter, r *http.Request) {
 
 // GetUserByID returns response for request to get user by ID
 func (h *Handler) GetUserByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-user-by-id")
 	request, err := MapRequestToGetUserByIDRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -268,6 +293,7 @@ func (h *Handler) GetUserByID(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetUserByID(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -279,14 +305,17 @@ func (h *Handler) GetUserByID(w http.ResponseWriter, r *http.Request) {
 
 // GetUsers returns response for request to get users
 func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-users")
 	request, err := MapRequestToGetUsersRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUsers(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -302,9 +331,11 @@ func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
 // GetUserProfile returns response for request to get user's
 // profile
 func (h *Handler) GetUserProfile(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-user-profile")
 	request, err := MapRequestToGetUserProfileRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -312,6 +343,7 @@ func (h *Handler) GetUserProfile(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetUserProfile(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -322,10 +354,12 @@ func (h *Handler) GetUserProfile(w http.ResponseWriter, r *http.Request) {
 
 // CreateComms handles the request to create a comms
 func (h *Handler) CreateComms(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-create-comms")
 
 	request, err := MapRequestToCreateCommsRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -333,6 +367,7 @@ func (h *Handler) CreateComms(w http.ResponseWriter, r *http.Request) {
 	newCommsResponse, err := h.Service.CreateComms(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -343,10 +378,12 @@ func (h *Handler) CreateComms(w http.ResponseWriter, r *http.Request) {
 
 // GetComms handles the request to get a comms
 func (h *Handler) GetComms(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-comms")
 
 	request, err := mapGetCommsRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -354,6 +391,7 @@ func (h *Handler) GetComms(w http.ResponseWriter, r *http.Request) {
 	getCommsResponse, err := h.Service.GetComms(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -370,10 +408,12 @@ func (h *Handler) GetComms(w http.ResponseWriter, r *http.Request) {
 
 // GetCommsStats handles the request to get comms stats
 func (h *Handler) GetCommsStats(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-comms-stats")
 
 	request, err := mapGetCommsStatsRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -381,6 +421,7 @@ func (h *Handler) GetCommsStats(w http.ResponseWriter, r *http.Request) {
 	getCommsStatsResponse, err := h.Service.GetCommsStats(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -391,10 +432,12 @@ func (h *Handler) GetCommsStats(w http.ResponseWriter, r *http.Request) {
 
 // UpdateComms handles the request to update a comms
 func (h *Handler) UpdateComms(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-update-comms")
 
 	request, err := MapRequestToUpdateCommsRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -402,6 +445,7 @@ func (h *Handler) UpdateComms(w http.ResponseWriter, r *http.Request) {
 	updateCommsResponse, err := h.Service.UpdateComms(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -412,9 +456,11 @@ func (h *Handler) UpdateComms(w http.ResponseWriter, r *http.Request) {
 
 // GetEnrichedUserProfile handles the request to get an enriched user profile with group memberships
 func (h *Handler) GetEnrichedUserProfile(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-enriched-user-profile")
 	request, err := MapRequestToGetEnrichedUserProfileRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -422,6 +468,7 @@ func (h *Handler) GetEnrichedUserProfile(w http.ResponseWriter, r *http.Request)
 	response, err := h.Service.GetEnrichedUserProfile(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -432,9 +479,11 @@ func (h *Handler) GetEnrichedUserProfile(w http.ResponseWriter, r *http.Request)
 
 // GetUserGroups handles the request to get a user's group memberships
 func (h *Handler) GetUserGroups(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-user-groups")
 	request, err := MapRequestToGetUserGroupsRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -442,6 +491,7 @@ func (h *Handler) GetUserGroups(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetUserGroups(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -458,14 +508,17 @@ func (h *Handler) GetUserGroups(w http.ResponseWriter, r *http.Request) {
 
 // GetUserGroupMembershipsRequest handles the request to get a user's team memberships.
 func (h *Handler) GetUserGroupMembershipsRequest(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-user-group-memberships-request")
 	request, err := MapRequestToGetUserGroupMembershipsRequestRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetUserGroupMemberships(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -475,14 +528,17 @@ func (h *Handler) GetUserGroupMembershipsRequest(w http.ResponseWriter, r *http.
 
 // GetLatestNotificationOverviews handles the request to get latest notification overviews.
 func (h *Handler) GetLatestNotificationOverviews(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-latest-notification-overviews")
 	request, err := MapRequestToGetLatestNotificationOverviewsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetLatestNotificationOverviews(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -497,14 +553,17 @@ func (h *Handler) GetLatestNotificationOverviews(w http.ResponseWriter, r *http.
 
 // GetNotifierConfig handles the request to get notifier config.
 func (h *Handler) GetNotifierConfig(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-notifier-config")
 	request, err := MapRequestToGetNotifierConfigRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetNotifierConfig(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -514,14 +573,17 @@ func (h *Handler) GetNotifierConfig(w http.ResponseWriter, r *http.Request) {
 
 // RegisterNotificationAddress handles notification address registration.
 func (h *Handler) RegisterNotificationAddress(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-register-notification-address")
 	request, err := MapRequestToRegisterNotificationAddressRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RegisterNotificationAddress(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -531,14 +593,17 @@ func (h *Handler) RegisterNotificationAddress(w http.ResponseWriter, r *http.Req
 
 // ListNotificationAddresses handles notification address listing.
 func (h *Handler) ListNotificationAddresses(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-list-notification-addresses")
 	request, err := MapRequestToListNotificationAddressesRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ListNotificationAddresses(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -569,13 +634,16 @@ func (h *Handler) ListNotificationAddresses(w http.ResponseWriter, r *http.Reque
 
 // DeleteNotificationAddress handles notification address deletion.
 func (h *Handler) DeleteNotificationAddress(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-delete-notification-address")
 	request, err := MapRequestToDeleteNotificationAddressRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	if err := h.Service.DeleteNotificationAddress(r.Context(), request); err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -585,14 +653,17 @@ func (h *Handler) DeleteNotificationAddress(w http.ResponseWriter, r *http.Reque
 
 // GetNotificationPreferences handles notification preference lookup.
 func (h *Handler) GetNotificationPreferences(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-notification-preferences")
 	request, err := MapRequestToGetNotificationPreferencesRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetNotificationPreferences(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -607,14 +678,17 @@ func (h *Handler) GetNotificationPreferences(w http.ResponseWriter, r *http.Requ
 
 // UpdateNotificationPreferences handles notification preference updates.
 func (h *Handler) UpdateNotificationPreferences(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-update-notification-preferences")
 	request, err := MapRequestToUpdateNotificationPreferencesRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateNotificationPreferences(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -629,14 +703,17 @@ func (h *Handler) UpdateNotificationPreferences(w http.ResponseWriter, r *http.R
 
 // NotifyUser handles admin/service notification sends.
 func (h *Handler) NotifyUser(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-notify-user")
 	request, err := MapRequestToNotifyUserRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.NotifyUser(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -646,14 +723,17 @@ func (h *Handler) NotifyUser(w http.ResponseWriter, r *http.Request) {
 
 // NotifyUsers handles admin notification dispatches to multiple users.
 func (h *Handler) NotifyUsers(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-notify-users")
 	request, err := MapRequestToNotifyUsersRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.NotifyUsers(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -663,14 +743,17 @@ func (h *Handler) NotifyUsers(w http.ResponseWriter, r *http.Request) {
 
 // GetMyGroupInvitations handles the request to get the current user's outstanding group invitations.
 func (h *Handler) GetMyGroupInvitations(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-my-group-invitations")
 	request, err := MapRequestToGetMyGroupInvitationsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetMyGroupInvitations(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -680,14 +763,17 @@ func (h *Handler) GetMyGroupInvitations(w http.ResponseWriter, r *http.Request) 
 
 // AcceptMyGroupInvitation handles the request to accept one of the current user's group invitations.
 func (h *Handler) AcceptMyGroupInvitation(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-accept-my-group-invitation")
 	request, err := MapRequestToAcceptMyGroupInvitationRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.AcceptMyGroupInvitation(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -697,14 +783,17 @@ func (h *Handler) AcceptMyGroupInvitation(w http.ResponseWriter, r *http.Request
 
 // RejectMyGroupInvitation handles the request to reject one of the current user's group invitations.
 func (h *Handler) RejectMyGroupInvitation(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-reject-my-group-invitation")
 	request, err := MapRequestToRejectMyGroupInvitationRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RejectMyGroupInvitation(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -714,9 +803,11 @@ func (h *Handler) RejectMyGroupInvitation(w http.ResponseWriter, r *http.Request
 
 // GetGroupDetail handles the request to fetch a group's details for the requester
 func (h *Handler) GetGroupDetail(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-group-detail")
 	request, err := MapRequestToGetGroupDetailRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -724,6 +815,7 @@ func (h *Handler) GetGroupDetail(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetGroupDetail(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -734,9 +826,11 @@ func (h *Handler) GetGroupDetail(w http.ResponseWriter, r *http.Request) {
 
 // GetGroupStats handles the request to fetch a group's stats for the requester
 func (h *Handler) GetGroupStats(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-group-stats")
 	request, err := MapRequestToGetGroupStatsRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -744,6 +838,7 @@ func (h *Handler) GetGroupStats(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.GetGroupStats(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -754,14 +849,17 @@ func (h *Handler) GetGroupStats(w http.ResponseWriter, r *http.Request) {
 
 // ValidateGroupName handles the request to validate a proposed group name
 func (h *Handler) ValidateGroupName(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-validate-group-name")
 	request, err := MapRequestToValidateGroupNameRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ValidateGroupName(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -771,9 +869,11 @@ func (h *Handler) ValidateGroupName(w http.ResponseWriter, r *http.Request) {
 
 // CreateGroup handles the request to create a new group
 func (h *Handler) CreateGroup(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-create-group")
 	request, err := MapRequestToCreateGroupRequest(r, h.Validator)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -781,6 +881,7 @@ func (h *Handler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 	response, err := h.Service.CreateGroup(r.Context(), request)
 	if err != nil {
 		//nolint will set up default fallback later
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -791,14 +892,17 @@ func (h *Handler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 
 // UpdateGroup handles the request to update an existing group
 func (h *Handler) UpdateGroup(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-update-group")
 	request, err := MapRequestToUpdateGroupRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateGroup(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -808,14 +912,17 @@ func (h *Handler) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 
 // DeleteGroup handles the request to delete a group
 func (h *Handler) DeleteGroup(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-delete-group")
 	request, err := MapRequestToDeleteGroupRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.DeleteGroup(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -825,14 +932,17 @@ func (h *Handler) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 
 // AddGroupMember handles the request to add a member to a group
 func (h *Handler) AddGroupMember(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-add-group-member")
 	request, err := MapRequestToAddGroupMemberRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.AddGroupMember(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -842,14 +952,17 @@ func (h *Handler) AddGroupMember(w http.ResponseWriter, r *http.Request) {
 
 // RemoveGroupMember handles the request to remove a member from a group
 func (h *Handler) RemoveGroupMember(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-remove-group-member")
 	request, err := MapRequestToRemoveGroupMemberRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RemoveGroupMember(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -859,14 +972,17 @@ func (h *Handler) RemoveGroupMember(w http.ResponseWriter, r *http.Request) {
 
 // UpdateGroupMember handles the request to update a member role in a group
 func (h *Handler) UpdateGroupMember(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-update-group-member")
 	request, err := MapRequestToUpdateGroupMemberRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateGroupMember(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -876,14 +992,17 @@ func (h *Handler) UpdateGroupMember(w http.ResponseWriter, r *http.Request) {
 
 // UpdateGroupOwner handles the request to update group ownership
 func (h *Handler) UpdateGroupOwner(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-update-group-owner")
 	request, err := MapRequestToUpdateGroupOwnerRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateGroupOwner(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -893,14 +1012,17 @@ func (h *Handler) UpdateGroupOwner(w http.ResponseWriter, r *http.Request) {
 
 // CreateReminder handles the request to create a reminder.
 func (h *Handler) CreateReminder(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-create-reminder")
 	request, err := MapRequestToCreateReminderRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.CreateReminder(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -910,14 +1032,17 @@ func (h *Handler) CreateReminder(w http.ResponseWriter, r *http.Request) {
 
 // GetReminderByID handles the request to get a reminder by ID.
 func (h *Handler) GetReminderByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-reminder-by-id")
 	request, err := MapRequestToGetReminderByIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetReminderByID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -927,14 +1052,17 @@ func (h *Handler) GetReminderByID(w http.ResponseWriter, r *http.Request) {
 
 // ListReminders handles the request to list reminders.
 func (h *Handler) ListReminders(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-list-reminders")
 	request, err := MapRequestToListRemindersRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ListReminders(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -944,14 +1072,17 @@ func (h *Handler) ListReminders(w http.ResponseWriter, r *http.Request) {
 
 // UpdateReminderByID handles the request to update a reminder by ID.
 func (h *Handler) UpdateReminderByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-update-reminder-by-id")
 	request, err := MapRequestToUpdateReminderByIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.UpdateReminderByID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -961,13 +1092,16 @@ func (h *Handler) UpdateReminderByID(w http.ResponseWriter, r *http.Request) {
 
 // DeleteReminderByID handles the request to delete a reminder by ID.
 func (h *Handler) DeleteReminderByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-delete-reminder-by-id")
 	request, err := MapRequestToDeleteReminderByIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	if err := h.Service.DeleteReminderByID(r.Context(), request); err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -977,14 +1111,17 @@ func (h *Handler) DeleteReminderByID(w http.ResponseWriter, r *http.Request) {
 
 // DisableReminderByID handles the request to disable a reminder by ID.
 func (h *Handler) DisableReminderByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-disable-reminder-by-id")
 	request, err := MapRequestToDisableReminderByIDRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.DisableReminderByID(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -994,14 +1131,17 @@ func (h *Handler) DisableReminderByID(w http.ResponseWriter, r *http.Request) {
 
 // GetReminderStats handles the request to get reminder statistics.
 func (h *Handler) GetReminderStats(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-reminder-stats")
 	request, err := MapRequestToGetReminderStatsRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetReminderStats(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -1011,14 +1151,17 @@ func (h *Handler) GetReminderStats(w http.ResponseWriter, r *http.Request) {
 
 // GetDueReminders handles the request to get due reminders.
 func (h *Handler) GetDueReminders(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-due-reminders")
 	request, err := MapRequestToGetDueRemindersRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetDueReminders(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -1028,14 +1171,17 @@ func (h *Handler) GetDueReminders(w http.ResponseWriter, r *http.Request) {
 
 // RecordStreak handles the request to record a streak.
 func (h *Handler) RecordStreak(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-record-streak")
 	request, err := MapRequestToRecordStreakRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.RecordStreak(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -1045,14 +1191,17 @@ func (h *Handler) RecordStreak(w http.ResponseWriter, r *http.Request) {
 
 // ListStreaks handles the request to list streaks.
 func (h *Handler) ListStreaks(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-list-streaks")
 	request, err := MapRequestToListStreaksRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.ListStreaks(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -1062,14 +1211,17 @@ func (h *Handler) ListStreaks(w http.ResponseWriter, r *http.Request) {
 
 // GetCurrentStreak handles the request to get the current streak count.
 func (h *Handler) GetCurrentStreak(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-current-streak")
 	request, err := MapRequestToGetCurrentStreakRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetCurrentStreak(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -1079,14 +1231,17 @@ func (h *Handler) GetCurrentStreak(w http.ResponseWriter, r *http.Request) {
 
 // GetLongestStreak handles the request to get the longest streak count.
 func (h *Handler) GetLongestStreak(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-longest-streak")
 	request, err := MapRequestToGetLongestStreakRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetLongestStreak(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
@@ -1096,14 +1251,17 @@ func (h *Handler) GetLongestStreak(w http.ResponseWriter, r *http.Request) {
 
 // GetNumberOfStreaks handles the request to count streak entries.
 func (h *Handler) GetNumberOfStreaks(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "external/usermanager", "handle-get-number-of-streaks")
 	request, err := MapRequestToGetNumberOfStreaksRequest(r, h.Validator)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.Service.GetNumberOfStreaks(r.Context(), request)
 	if err != nil {
+		logger.Warn("handler-returning-error-response", zap.Error(err))
 		h.GetBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}

--- a/external/usermanager/logging.go
+++ b/external/usermanager/logging.go
@@ -1,0 +1,7 @@
+package usermanager
+
+import "github.com/ooaklee/ghatd/external/logger"
+
+func safeLogValue(value any) any {
+	return logger.SafeValue(value)
+}

--- a/external/usermanager/service.go
+++ b/external/usermanager/service.go
@@ -176,6 +176,9 @@ func (s *Service) WithNotifierService(notifierSvc NotifierService) *Service {
 
 // UpdateUserProfile handles the business logic of updating the requesting user's profile
 func (s *Service) UpdateUserProfile(ctx context.Context, r *UpdateUserProfileRequest) (*UpdateUserProfileResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/usermanager", "update-user-profile")
+	logger.Debug("handling-update-user-profile-request")
+
 	serviceResponse, err := s.UserService.UpdateUser(ctx, &userv2.UpdateUserRequest{
 		ID:        r.UserId,
 		FirstName: r.FirstName,
@@ -192,6 +195,8 @@ func (s *Service) UpdateUserProfile(ctx context.Context, r *UpdateUserProfileReq
 
 // GetUserMicroProfile handles the business logic of fetching the requesting user's micro profile
 func (s *Service) GetUserMicroProfile(ctx context.Context, r *GetUserMicroProfileRequest) (*GetUserMicroProfileResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "external/usermanager", "get-user-micro-profile")
+	logger.Debug("handling-get-user-micro-profile-request")
 
 	serviceResponse, err := s.UserService.GetUserMicroProfile(ctx, &userv2.GetUserMicroProfileRequest{
 		ID: r.UserId,
@@ -208,7 +213,7 @@ func (s *Service) GetUserMicroProfile(ctx context.Context, r *GetUserMicroProfil
 // GetUserByID handles the business logic of fetching a user by ID.
 func (s *Service) GetUserByID(ctx context.Context, r *GetUserByIDRequest) (*GetUserByIDResponse, error) {
 
-	logger := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	logger.Debug("fetching-user-by-id", zap.String("user-id", r.ID))
 
@@ -239,9 +244,9 @@ func (s *Service) GetUserByID(ctx context.Context, r *GetUserByIDRequest) (*GetU
 // GetUsers handles the business logic of fetching users.
 func (s *Service) GetUsers(ctx context.Context, r *GetUsersRequest) (*GetUsersResponse, error) {
 
-	logger := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
-	logger.Debug("fetching-users", zap.Any("filters", r.GetUsersRequest))
+	logger.Debug("fetching-users", zap.Any("filters", safeLogValue(r.GetUsersRequest)))
 	requestingUser, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: r.UserId})
 	if err != nil {
 		return nil, err
@@ -314,7 +319,7 @@ func (s *Service) GetUsers(ctx context.Context, r *GetUsersRequest) (*GetUsersRe
 // GetUserProfile handles the business logic of fetching the requesting user's profile
 func (s *Service) GetUserProfile(ctx context.Context, r *GetUserProfileRequest) (*GetUserProfileResponse, error) {
 
-	logger := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	logger.Debug("fetching-user-profile", zap.String("user-id", r.UserId))
 
@@ -348,7 +353,7 @@ func (s *Service) GetUserProfile(ctx context.Context, r *GetUserProfileRequest) 
 // TODO: Add audit logs, add more resource types
 func (s *Service) DeleteUserPermanently(ctx context.Context, r *DeleteUserPermanentlyRequest) error {
 
-	var logger = logger.AcquireFrom(ctx)
+	var logger = logger.AcquirePackageFrom(ctx, "external/usermanager")
 	var err error
 	targetUserID := strings.TrimSpace(r.ID)
 	if targetUserID == "" {
@@ -465,16 +470,14 @@ func (s *Service) DeleteUserPermanently(ctx context.Context, r *DeleteUserPerman
 func (s *Service) CreateComms(ctx context.Context, req *CreateCommsRequest) (*CreateCommsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/usermanager")
 	)
 
-	logger.Info("initiating-create-comms-request", zap.Any("request", req))
+	logger.Info("initiating-create-comms-request", zap.Any("request", safeLogValue(req)))
 
 	createdCommsResponse, err := s.ContacterService.CreateComms(ctx, req.CreateCommsRequest)
 	if err != nil {
-		logger.Error("failed-to-create-comms-error-creating-comms", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-create-comms-error-creating-comms", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &CreateCommsResponse{}, err
 	}
 
@@ -487,20 +490,18 @@ func (s *Service) CreateComms(ctx context.Context, req *CreateCommsRequest) (*Cr
 func (s *Service) GetComms(ctx context.Context, req *GetCommsRequest) (*GetCommsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 		response = GetCommsResponse{
 			Comms: []contacter.Comms{},
 		}
 	)
 
-	logger.Info("initiating-get-comms-request", zap.Any("request", req))
+	logger.Info("initiating-get-comms-request", zap.Any("request", safeLogValue(req)))
 
 	commsResponse, err := s.ContacterService.GetComms(ctx, req.GetCommsRequest)
 	if err != nil {
-		logger.Error("failed-to-get-comms-error-getting-comms", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-comms-error-getting-comms", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetCommsResponse{}, err
 	}
 
@@ -514,16 +515,14 @@ func (s *Service) GetComms(ctx context.Context, req *GetCommsRequest) (*GetComms
 func (s *Service) UpdateComms(ctx context.Context, req *UpdateCommsRequest) (*UpdateCommsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/usermanager")
 	)
 
-	logger.Info("initiating-update-comms-request", zap.Any("request", req))
+	logger.Info("initiating-update-comms-request", zap.Any("request", safeLogValue(req)))
 
 	updateCommsResponse, err := s.ContacterService.UpdateComms(ctx, req.UpdateCommsRequest)
 	if err != nil {
-		logger.Error("failed-to-update-comms-error-updating-comms", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-update-comms-error-updating-comms", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &UpdateCommsResponse{}, err
 	}
 
@@ -536,16 +535,14 @@ func (s *Service) UpdateComms(ctx context.Context, req *UpdateCommsRequest) (*Up
 func (s *Service) GetCommsStats(ctx context.Context, req *GetCommsStatsRequest) (*GetCommsStatsResponse, error) {
 
 	var (
-		logger *zap.Logger = logger.AcquireFrom(ctx).WithOptions(
-			zap.AddStacktrace(zap.DPanicLevel),
-		)
+		logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/usermanager")
 	)
 
-	logger.Info("initiating-get-comms-stats-request", zap.Any("request", req))
+	logger.Info("initiating-get-comms-stats-request", zap.Any("request", safeLogValue(req)))
 
 	statsResponse, err := s.ContacterService.GetCommsStats(ctx, req.GetCommsStatsRequest)
 	if err != nil {
-		logger.Error("failed-to-get-comms-stats-error-getting-comms-stats", zap.Any("request", req), zap.Error(err))
+		logger.Error("failed-to-get-comms-stats-error-getting-comms-stats", zap.Any("request", safeLogValue(req)), zap.Error(err))
 		return &GetCommsStatsResponse{}, err
 	}
 

--- a/external/usermanager/service.group.admin.go
+++ b/external/usermanager/service.group.admin.go
@@ -53,8 +53,8 @@ func (s *Service) ValidateGroupName(ctx context.Context, r *ValidateGroupNameReq
 			if accessErr != nil {
 				logger.Error(
 					"failed-to-resolve-requester-group-access-map",
-					zap.String("requester_user_id", r.UserID),
-					zap.String("group_id", parentGroupID),
+					zap.String("requester-user-id", r.UserID),
+					zap.String("group-id", parentGroupID),
 					zap.Error(accessErr),
 				)
 				return nil, ErrFailedToResolveGroupAccessMap
@@ -99,8 +99,8 @@ func (s *Service) CreateGroup(ctx context.Context, r *CreateGroupRequest) (*Crea
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserID),
-				zap.String("group_id", r.ParentGroupID),
+				zap.String("requester-user-id", r.UserID),
+				zap.String("group-id", r.ParentGroupID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -151,8 +151,8 @@ func (s *Service) UpdateGroup(ctx context.Context, r *UpdateGroupRequest) (*Upda
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserId),
-				zap.String("group_id", r.UpdateGroupRequest.ID),
+				zap.String("requester-user-id", r.UserId),
+				zap.String("group-id", r.UpdateGroupRequest.ID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -166,7 +166,7 @@ func (s *Service) UpdateGroup(ctx context.Context, r *UpdateGroupRequest) (*Upda
 
 	resp, err := s.GroupService.UpdateGroup(ctx, r.UpdateGroupRequest)
 	if err != nil {
-		logger.Error("failed-to-update-group", zap.String("group_id", r.UpdateGroupRequest.ID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group-id", r.UpdateGroupRequest.ID), zap.Error(err))
 		return nil, err
 	}
 
@@ -189,8 +189,8 @@ func (s *Service) DeleteGroup(ctx context.Context, r *DeleteGroupRequest) (*Dele
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserID),
-				zap.String("group_id", r.DeleteGroupRequest.ID),
+				zap.String("requester-user-id", r.UserID),
+				zap.String("group-id", r.DeleteGroupRequest.ID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -205,8 +205,8 @@ func (s *Service) DeleteGroup(ctx context.Context, r *DeleteGroupRequest) (*Dele
 		if groupErr != nil {
 			logger.Error(
 				"failed-to-resolve-group-for-delete-ownership-check",
-				zap.String("requester_user_id", r.UserID),
-				zap.String("group_id", r.DeleteGroupRequest.ID),
+				zap.String("requester-user-id", r.UserID),
+				zap.String("group-id", r.DeleteGroupRequest.ID),
 				zap.Error(groupErr),
 			)
 			return nil, groupErr
@@ -225,7 +225,7 @@ func (s *Service) DeleteGroup(ctx context.Context, r *DeleteGroupRequest) (*Dele
 
 	groupResp, err := s.GroupService.DeleteGroup(ctx, r.DeleteGroupRequest)
 	if err != nil {
-		logger.Error("failed-to-delete-group", zap.String("group_id", r.DeleteGroupRequest.ID), zap.Error(err))
+		logger.Error("failed-to-delete-group", zap.String("group-id", r.DeleteGroupRequest.ID), zap.Error(err))
 		return nil, err
 	}
 
@@ -250,8 +250,8 @@ func (s *Service) AddGroupMember(ctx context.Context, r *AddGroupMemberRequest) 
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserID),
-				zap.String("group_id", r.GroupID),
+				zap.String("requester-user-id", r.UserID),
+				zap.String("group-id", r.GroupID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -294,8 +294,8 @@ func (s *Service) RemoveGroupMember(ctx context.Context, r *RemoveGroupMemberReq
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserID),
-				zap.String("group_id", r.GroupID),
+				zap.String("requester-user-id", r.UserID),
+				zap.String("group-id", r.GroupID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -335,8 +335,8 @@ func (s *Service) UpdateGroupMember(ctx context.Context, r *UpdateGroupMemberReq
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserID),
-				zap.String("group_id", r.GroupID),
+				zap.String("requester-user-id", r.UserID),
+				zap.String("group-id", r.GroupID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -379,8 +379,8 @@ func (s *Service) UpdateGroupOwner(ctx context.Context, r *UpdateGroupOwnerReque
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserID),
-				zap.String("group_id", r.GroupID),
+				zap.String("requester-user-id", r.UserID),
+				zap.String("group-id", r.GroupID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap

--- a/external/usermanager/service.group.admin.go
+++ b/external/usermanager/service.group.admin.go
@@ -12,16 +12,16 @@ import (
 
 // GetGroupsConfig retrieves the group service configuration capabilities.
 func (s *Service) GetGroupsConfig(ctx context.Context, _ *GetGroupsConfigRequest) (*GetGroupsConfigResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled")
+		logger.Error("group-service-not-enabled")
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	resp, err := s.GroupService.GetGroupsConfig(ctx, &group.GetGroupsConfigRequest{})
 	if err != nil {
-		log.Error("failed-to-get-groups-config", zap.Error(err))
+		logger.Error("failed-to-get-groups-config", zap.Error(err))
 		return nil, err
 	}
 
@@ -34,10 +34,10 @@ func (s *Service) GetGroupsConfig(ctx context.Context, _ *GetGroupsConfigRequest
 // Admin requesters can validate directly. Non-admin requesters must have
 // access to the provided parent_group_id (when supplied).
 func (s *Service) ValidateGroupName(ctx context.Context, r *ValidateGroupNameRequest) (*ValidateGroupNameResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
@@ -45,13 +45,13 @@ func (s *Service) ValidateGroupName(ctx context.Context, r *ValidateGroupNameReq
 		return nil, ErrRequestFailedValidation
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, r.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserID, logger)
 	if !isAdmin {
 		parentGroupID := strings.TrimSpace(r.ParentGroupID)
 		if parentGroupID != "" {
 			hasAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserID, parentGroupID)
 			if accessErr != nil {
-				log.Error(
+				logger.Error(
 					"failed-to-resolve-requester-group-access-map",
 					zap.String("requester_user_id", r.UserID),
 					zap.String("group_id", parentGroupID),
@@ -68,7 +68,7 @@ func (s *Service) ValidateGroupName(ctx context.Context, r *ValidateGroupNameReq
 
 	resp, err := s.GroupService.ValidateGroupName(ctx, r.ValidateGroupNameRequest)
 	if err != nil {
-		log.Error("failed-to-validate-group-name", zap.Error(err))
+		logger.Error("failed-to-validate-group-name", zap.Error(err))
 		return nil, err
 	}
 
@@ -78,26 +78,26 @@ func (s *Service) ValidateGroupName(ctx context.Context, r *ValidateGroupNameReq
 // CreateGroup handles creating a new group with the provided details. Only admins or users with
 // access to the parent group (if specified) can create groups.
 func (s *Service) CreateGroup(ctx context.Context, r *CreateGroupRequest) (*CreateGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	// Auth check: only allow if requester is admin or
 	// has access to parent group (if specified)
-	isAdmin := s.isRequesterAdmin(ctx, r.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserID, logger)
 	if !isAdmin {
 
 		if r.ParentGroupID == "" {
-			log.Error("non-user-attempting-to-create-group-without-parent", zap.String("user-id", r.UserID))
+			logger.Error("non-user-attempting-to-create-group-without-parent", zap.String("user-id", r.UserID))
 			return nil, group.ErrInsufficientPermissions
 		}
 
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserID, r.ParentGroupID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserID),
 				zap.String("group_id", r.ParentGroupID),
@@ -121,7 +121,7 @@ func (s *Service) CreateGroup(ctx context.Context, r *CreateGroupRequest) (*Crea
 	// Create the group via group service
 	groupResp, err := s.GroupService.CreateGroup(ctx, r.CreateGroupRequest)
 	if err != nil {
-		log.Error("failed-to-create-group", zap.String("name", r.CreateGroupRequest.Name), zap.String("type", r.CreateGroupRequest.Type), zap.Error(err))
+		logger.Error("failed-to-create-group", zap.String("name", r.CreateGroupRequest.Name), zap.String("type", r.CreateGroupRequest.Type), zap.Error(err))
 		return nil, err
 	}
 
@@ -134,10 +134,10 @@ func (s *Service) CreateGroup(ctx context.Context, r *CreateGroupRequest) (*Crea
 // Non-admin users must have effective admin-level access to the target group,
 // which also covers admin/owner permissions inherited from parent groups.
 func (s *Service) UpdateGroup(ctx context.Context, r *UpdateGroupRequest) (*UpdateGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
@@ -145,11 +145,11 @@ func (s *Service) UpdateGroup(ctx context.Context, r *UpdateGroupRequest) (*Upda
 		return nil, ErrRequestFailedValidation
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, r.UserId, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserId, logger)
 	if !isAdmin {
 		accessMap, accessErr := s.GroupService.GetUserGroupAccessMap(ctx, r.UserId)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserId),
 				zap.String("group_id", r.UpdateGroupRequest.ID),
@@ -166,7 +166,7 @@ func (s *Service) UpdateGroup(ctx context.Context, r *UpdateGroupRequest) (*Upda
 
 	resp, err := s.GroupService.UpdateGroup(ctx, r.UpdateGroupRequest)
 	if err != nil {
-		log.Error("failed-to-update-group", zap.String("group_id", r.UpdateGroupRequest.ID), zap.Error(err))
+		logger.Error("failed-to-update-group", zap.String("group_id", r.UpdateGroupRequest.ID), zap.Error(err))
 		return nil, err
 	}
 
@@ -176,18 +176,18 @@ func (s *Service) UpdateGroup(ctx context.Context, r *UpdateGroupRequest) (*Upda
 // DeleteGroup handles deleting a group. Admin users may request hard/soft delete;
 // non-admin users must be the owner of the target group and are forced to hard-delete.
 func (s *Service) DeleteGroup(ctx context.Context, r *DeleteGroupRequest) (*DeleteGroupResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, r.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserID, logger)
 	if !isAdmin {
 		accessMap, accessErr := s.GroupService.GetUserGroupAccessMap(ctx, r.UserID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserID),
 				zap.String("group_id", r.DeleteGroupRequest.ID),
@@ -203,7 +203,7 @@ func (s *Service) DeleteGroup(ctx context.Context, r *DeleteGroupRequest) (*Dele
 
 		groupResp, groupErr := s.GroupService.GetGroupByID(ctx, &group.GetGroupByIDRequest{ID: r.DeleteGroupRequest.ID})
 		if groupErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-group-for-delete-ownership-check",
 				zap.String("requester_user_id", r.UserID),
 				zap.String("group_id", r.DeleteGroupRequest.ID),
@@ -225,7 +225,7 @@ func (s *Service) DeleteGroup(ctx context.Context, r *DeleteGroupRequest) (*Dele
 
 	groupResp, err := s.GroupService.DeleteGroup(ctx, r.DeleteGroupRequest)
 	if err != nil {
-		log.Error("failed-to-delete-group", zap.String("group_id", r.DeleteGroupRequest.ID), zap.Error(err))
+		logger.Error("failed-to-delete-group", zap.String("group_id", r.DeleteGroupRequest.ID), zap.Error(err))
 		return nil, err
 	}
 
@@ -234,21 +234,21 @@ func (s *Service) DeleteGroup(ctx context.Context, r *DeleteGroupRequest) (*Dele
 
 // AddGroupMember adds a user to a group
 func (s *Service) AddGroupMember(ctx context.Context, r *AddGroupMemberRequest) (*AddGroupMemberResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	// Auth check: only allow if requester is admin or
 	// has access to parent group (if specified)
-	isAdmin := s.isRequesterAdmin(ctx, r.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserID, logger)
 	if !isAdmin {
 
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserID, r.GroupID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserID),
 				zap.String("group_id", r.GroupID),
@@ -265,7 +265,7 @@ func (s *Service) AddGroupMember(ctx context.Context, r *AddGroupMemberRequest) 
 	r.AddMemberRequest.Type = group.MemberTypeUser
 	_, err := s.GroupService.AddMember(ctx, r.AddMemberRequest)
 	if err != nil {
-		log.Error("add-group-member-failed",
+		logger.Error("add-group-member-failed",
 			zap.String("group-id", r.GroupID),
 			zap.String("member-id", r.MemberID),
 			zap.Error(err),
@@ -278,21 +278,21 @@ func (s *Service) AddGroupMember(ctx context.Context, r *AddGroupMemberRequest) 
 
 // RemoveGroupMember removes a user from a group
 func (s *Service) RemoveGroupMember(ctx context.Context, r *RemoveGroupMemberRequest) (*RemoveGroupMemberResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	// Auth check: only allow if requester is admin or
 	// has access to parent group (if specified)
-	isAdmin := s.isRequesterAdmin(ctx, r.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserID, logger)
 	if !isAdmin {
 
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserID, r.GroupID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserID),
 				zap.String("group_id", r.GroupID),
@@ -308,7 +308,7 @@ func (s *Service) RemoveGroupMember(ctx context.Context, r *RemoveGroupMemberReq
 
 	_, err := s.GroupService.RemoveMember(ctx, r.RemoveMemberRequest)
 	if err != nil {
-		log.Error("remove-group-member-failed",
+		logger.Error("remove-group-member-failed",
 			zap.String("group-id", r.GroupID),
 			zap.String("member-id", r.MemberID),
 			zap.Error(err),
@@ -321,19 +321,19 @@ func (s *Service) RemoveGroupMember(ctx context.Context, r *RemoveGroupMemberReq
 
 // UpdateGroupMember updates a user's role in a group
 func (s *Service) UpdateGroupMember(ctx context.Context, r *UpdateGroupMemberRequest) (*UpdateGroupMemberResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, r.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserID, logger)
 	if !isAdmin {
 
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserID, r.GroupID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserID),
 				zap.String("group_id", r.GroupID),
@@ -349,7 +349,7 @@ func (s *Service) UpdateGroupMember(ctx context.Context, r *UpdateGroupMemberReq
 
 	_, err := s.GroupService.UpdateMemberRole(ctx, r.UpdateMemberRoleRequest)
 	if err != nil {
-		log.Error("update-group-member-failed",
+		logger.Error("update-group-member-failed",
 			zap.String("group-id", r.GroupID),
 			zap.String("member-id", r.MemberID),
 			zap.String("new-role", r.NewRole),
@@ -363,21 +363,21 @@ func (s *Service) UpdateGroupMember(ctx context.Context, r *UpdateGroupMemberReq
 
 // UpdateGroupOwner updates the owner of a group
 func (s *Service) UpdateGroupOwner(ctx context.Context, r *UpdateGroupOwnerRequest) (*UpdateGroupOwnerResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	// Auth check: only allow if requester is admin or
 	// has access to parent group (if specified)
-	isAdmin := s.isRequesterAdmin(ctx, r.UserID, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserID, logger)
 	if !isAdmin {
 
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserID, r.GroupID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserID),
 				zap.String("group_id", r.GroupID),
@@ -396,7 +396,7 @@ func (s *Service) UpdateGroupOwner(ctx context.Context, r *UpdateGroupOwnerReque
 		OwnerID: r.OwnerID,
 	})
 	if err != nil {
-		log.Error("update-group-owner-failed",
+		logger.Error("update-group-owner-failed",
 			zap.String("group-id", r.GroupID),
 			zap.Error(err),
 		)

--- a/external/usermanager/service.group.go
+++ b/external/usermanager/service.group.go
@@ -72,8 +72,8 @@ func (s *Service) GetGroupLineage(ctx context.Context, r *GetGroupLineageRequest
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserId),
-				zap.String("group_id", r.GetGroupLineageRequest.ID),
+				zap.String("requester-user-id", r.UserId),
+				zap.String("group-id", r.GetGroupLineageRequest.ID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -113,8 +113,8 @@ func (s *Service) GetGroupDescendants(ctx context.Context, r *GetGroupDescendant
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserId),
-				zap.String("group_id", r.GetGroupDescendantsRequest.ID),
+				zap.String("requester-user-id", r.UserId),
+				zap.String("group-id", r.GetGroupDescendantsRequest.ID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -423,8 +423,8 @@ func (s *Service) GetGroupDetail(ctx context.Context, r *GetGroupDetailRequest) 
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserId),
-				zap.String("group_id", r.GroupID),
+				zap.String("requester-user-id", r.UserId),
+				zap.String("group-id", r.GroupID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap
@@ -503,8 +503,8 @@ func (s *Service) GetGroupStats(ctx context.Context, r *GetGroupStatsRequest) (*
 		if accessErr != nil {
 			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
-				zap.String("requester_user_id", r.UserId),
-				zap.String("group_id", r.GroupID),
+				zap.String("requester-user-id", r.UserId),
+				zap.String("group-id", r.GroupID),
 				zap.Error(accessErr),
 			)
 			return nil, ErrFailedToResolveGroupAccessMap

--- a/external/usermanager/service.group.go
+++ b/external/usermanager/service.group.go
@@ -13,10 +13,10 @@ import (
 
 // GetEnrichedUserProfile handles fetching an enriched user profile with group membership data
 func (s *Service) GetEnrichedUserProfile(ctx context.Context, r *GetEnrichedUserProfileRequest) (*GetEnrichedUserProfileResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
@@ -25,7 +25,7 @@ func (s *Service) GetEnrichedUserProfile(ctx context.Context, r *GetEnrichedUser
 		ID: r.UserId,
 	})
 	if err != nil {
-		log.Error("failed-to-get-user-profile", zap.String("user-id", r.UserId), zap.Error(err))
+		logger.Error("failed-to-get-user-profile", zap.String("user-id", r.UserId), zap.Error(err))
 		return nil, err
 	}
 
@@ -46,7 +46,7 @@ func (s *Service) GetEnrichedUserProfile(ctx context.Context, r *GetEnrichedUser
 	if r.IncludeAllGroups {
 		allGroups, err := s.getUserAllGroups(ctx, r.UserId, r.PrefixName)
 		if err != nil {
-			log.Warn("failed-to-fetch-all-group-memberships", zap.String("user-id", r.UserId), zap.Error(err))
+			logger.Warn("failed-to-fetch-all-group-memberships", zap.String("user-id", r.UserId), zap.Error(err))
 		} else {
 			enrichedProfile.Groups = allGroups
 		}
@@ -59,18 +59,18 @@ func (s *Service) GetEnrichedUserProfile(ctx context.Context, r *GetEnrichedUser
 
 // GetGroupLineage handles fetching the lineage for a group, gated by group access for non-admin requesters.
 func (s *Service) GetGroupLineage(ctx context.Context, r *GetGroupLineageRequest) (*GetGroupLineageResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, r.UserId, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserId, logger)
 	if !isAdmin {
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserId, r.GetGroupLineageRequest.ID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserId),
 				zap.String("group_id", r.GetGroupLineageRequest.ID),
@@ -88,7 +88,7 @@ func (s *Service) GetGroupLineage(ctx context.Context, r *GetGroupLineageRequest
 
 	resp, err := s.GroupService.GetGroupLineage(ctx, r.GetGroupLineageRequest)
 	if err != nil {
-		log.Error("failed-to-get-group-lineage", zap.String("group-id", r.GetGroupLineageRequest.ID), zap.Error(err))
+		logger.Error("failed-to-get-group-lineage", zap.String("group-id", r.GetGroupLineageRequest.ID), zap.Error(err))
 		return nil, err
 	}
 
@@ -100,18 +100,18 @@ func (s *Service) GetGroupLineage(ctx context.Context, r *GetGroupLineageRequest
 // GetGroupsByUserID handles fetching groups for a user with filtering
 // GetGroupDescendants handles fetching group descendants with permission checks
 func (s *Service) GetGroupDescendants(ctx context.Context, r *GetGroupDescendantsRequest) (*GetGroupDescendantsResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, r.UserId, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserId, logger)
 	if !isAdmin {
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserId, r.GetGroupDescendantsRequest.ID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserId),
 				zap.String("group_id", r.GetGroupDescendantsRequest.ID),
@@ -129,7 +129,7 @@ func (s *Service) GetGroupDescendants(ctx context.Context, r *GetGroupDescendant
 
 	resp, err := s.GroupService.GetGroupDescendants(ctx, r.GetGroupDescendantsRequest)
 	if err != nil {
-		log.Error("failed-to-get-group-descendants", zap.String("group-id", r.GetGroupDescendantsRequest.ID), zap.Error(err))
+		logger.Error("failed-to-get-group-descendants", zap.String("group-id", r.GetGroupDescendantsRequest.ID), zap.Error(err))
 		return nil, err
 	}
 
@@ -144,10 +144,10 @@ func (s *Service) GetGroupsByUserID(ctx context.Context, r *GetGroupsByUserIDReq
 		return nil, ErrGroupServiceNotEnabled
 	}
 
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if r.ID != r.UserID {
-		isAdmin := s.isRequesterAdmin(ctx, r.ID, log)
+		isAdmin := s.isRequesterAdmin(ctx, r.ID, logger)
 		if !isAdmin {
 			return nil, group.ErrInsufficientPermissions
 		}
@@ -165,10 +165,10 @@ func (s *Service) GetGroupsByUserID(ctx context.Context, r *GetGroupsByUserIDReq
 
 // GetUserGroups handles fetching groups for a user with filtering
 func (s *Service) GetUserGroups(ctx context.Context, r *GetUserGroupsRequest) (*GetUserGroupsResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
@@ -200,7 +200,7 @@ func (s *Service) GetUserGroups(ctx context.Context, r *GetUserGroupsRequest) (*
 
 	groupsResp, err := s.GroupService.GetGroups(ctx, groupReq)
 	if err != nil {
-		log.Error("failed-to-get-user-groups", zap.String("user-id", r.UserId), zap.Error(err))
+		logger.Error("failed-to-get-user-groups", zap.String("user-id", r.UserId), zap.Error(err))
 		return nil, err
 	}
 
@@ -237,10 +237,10 @@ func (s *Service) GetUserGroups(ctx context.Context, r *GetUserGroupsRequest) (*
 
 // GetLatestNotificationOverviews fetches latest group notification overviews for the requester.
 func (s *Service) GetLatestNotificationOverviews(ctx context.Context, r *GetLatestNotificationOverviewsRequest) (*GetLatestNotificationOverviewsResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
@@ -253,7 +253,7 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, r *GetLate
 	if userEmail == "" {
 		userResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: targetUserID})
 		if err != nil {
-			log.Error("failed-to-resolve-user-email-for-notifications", zap.String("user-id", targetUserID), zap.Error(err))
+			logger.Error("failed-to-resolve-user-email-for-notifications", zap.String("user-id", targetUserID), zap.Error(err))
 			return nil, err
 		}
 
@@ -267,7 +267,7 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, r *GetLate
 		Limit:     r.Limit,
 	})
 	if err != nil {
-		log.Error("failed-to-get-group-notification-overviews", zap.String("user-id", targetUserID), zap.Error(err))
+		logger.Error("failed-to-get-group-notification-overviews", zap.String("user-id", targetUserID), zap.Error(err))
 		return nil, err
 	}
 
@@ -276,16 +276,16 @@ func (s *Service) GetLatestNotificationOverviews(ctx context.Context, r *GetLate
 
 // GetMyGroupInvitations fetches outstanding group invitations for the requester.
 func (s *Service) GetMyGroupInvitations(ctx context.Context, r *GetMyGroupInvitationsRequest) (*GetMyGroupInvitationsResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	userResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: r.UserId})
 	if err != nil {
-		log.Error("failed-to-resolve-user-for-group-invitations", zap.String("user-id", r.UserId), zap.Error(err))
+		logger.Error("failed-to-resolve-user-for-group-invitations", zap.String("user-id", r.UserId), zap.Error(err))
 		return nil, err
 	}
 
@@ -299,7 +299,7 @@ func (s *Service) GetMyGroupInvitations(ctx context.Context, r *GetMyGroupInvita
 		PrefixName: r.PrefixName,
 	})
 	if err != nil {
-		log.Error("failed-to-get-my-group-invitations", zap.String("user-id", r.UserId), zap.Error(err))
+		logger.Error("failed-to-get-my-group-invitations", zap.String("user-id", r.UserId), zap.Error(err))
 		return nil, err
 	}
 
@@ -348,16 +348,16 @@ func (s *Service) GetMyGroupInvitations(ctx context.Context, r *GetMyGroupInvita
 
 // AcceptMyGroupInvitation accepts a pending group invitation for the requester.
 func (s *Service) AcceptMyGroupInvitation(ctx context.Context, r *AcceptMyGroupInvitationRequest) (*AcceptMyGroupInvitationResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	userResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: r.UserId})
 	if err != nil {
-		log.Error("failed-to-resolve-user-for-accept-group-invitation", zap.String("user-id", r.UserId), zap.Error(err))
+		logger.Error("failed-to-resolve-user-for-accept-group-invitation", zap.String("user-id", r.UserId), zap.Error(err))
 		return nil, err
 	}
 
@@ -367,7 +367,7 @@ func (s *Service) AcceptMyGroupInvitation(ctx context.Context, r *AcceptMyGroupI
 		UserID:      r.UserId,
 	})
 	if err != nil {
-		log.Error("failed-to-accept-my-group-invitation", zap.String("user-id", r.UserId), zap.String("group-id", r.GroupID), zap.Error(err))
+		logger.Error("failed-to-accept-my-group-invitation", zap.String("user-id", r.UserId), zap.String("group-id", r.GroupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -376,16 +376,16 @@ func (s *Service) AcceptMyGroupInvitation(ctx context.Context, r *AcceptMyGroupI
 
 // RejectMyGroupInvitation rejects a pending group invitation for the requester.
 func (s *Service) RejectMyGroupInvitation(ctx context.Context, r *RejectMyGroupInvitationRequest) (*RejectMyGroupInvitationResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	userResponse, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: r.UserId})
 	if err != nil {
-		log.Error("failed-to-resolve-user-for-reject-group-invitation", zap.String("user-id", r.UserId), zap.Error(err))
+		logger.Error("failed-to-resolve-user-for-reject-group-invitation", zap.String("user-id", r.UserId), zap.Error(err))
 		return nil, err
 	}
 
@@ -395,7 +395,7 @@ func (s *Service) RejectMyGroupInvitation(ctx context.Context, r *RejectMyGroupI
 		RejectedByID: r.UserId,
 	})
 	if err != nil {
-		log.Error("failed-to-reject-my-group-invitation", zap.String("user-id", r.UserId), zap.String("group-id", r.GroupID), zap.Error(err))
+		logger.Error("failed-to-reject-my-group-invitation", zap.String("user-id", r.UserId), zap.String("group-id", r.GroupID), zap.Error(err))
 		return nil, err
 	}
 
@@ -404,24 +404,24 @@ func (s *Service) RejectMyGroupInvitation(ctx context.Context, r *RejectMyGroupI
 
 // GetGroupDetail handles fetching a single group for a requester with membership/owner checks
 func (s *Service) GetGroupDetail(ctx context.Context, r *GetGroupDetailRequest) (*GetGroupDetailResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	groupResp, err := s.GroupService.GetGroupByID(ctx, &group.GetGroupByIDRequest{ID: r.GroupID, PrefixName: r.PrefixName})
 	if err != nil || groupResp == nil || groupResp.Group == nil {
-		log.Warn("failed-to-get-group-detail", zap.String("group-id", r.GroupID), zap.Error(err))
+		logger.Warn("failed-to-get-group-detail", zap.String("group-id", r.GroupID), zap.Error(err))
 		return nil, ErrGroupNotFound
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, r.UserId, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserId, logger)
 	if !isAdmin {
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserId, r.GroupID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserId),
 				zap.String("group_id", r.GroupID),
@@ -484,24 +484,24 @@ func (s *Service) GetGroupDetail(ctx context.Context, r *GetGroupDetailRequest) 
 
 // GetGroupStats handles fetching group stats for a requester with membership/owner checks
 func (s *Service) GetGroupStats(ctx context.Context, r *GetGroupStatsRequest) (*GetGroupStatsResponse, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
+		logger.Error("group-service-not-enabled", zap.String("user-id", r.UserId))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
 	groupResp, err := s.GroupService.GetGroupByID(ctx, &group.GetGroupByIDRequest{ID: r.GroupID, PrefixName: r.PrefixName})
 	if err != nil || groupResp == nil || groupResp.Group == nil {
-		log.Warn("failed-to-get-group-for-stats", zap.String("group-id", r.GroupID), zap.Error(err))
+		logger.Warn("failed-to-get-group-for-stats", zap.String("group-id", r.GroupID), zap.Error(err))
 		return nil, ErrGroupNotFound
 	}
 
-	isAdmin := s.isRequesterAdmin(ctx, r.UserId, log)
+	isAdmin := s.isRequesterAdmin(ctx, r.UserId, logger)
 	if !isAdmin {
 		hasGroupAccess, accessErr := s.hasRequesterGroupAccess(ctx, r.UserId, r.GroupID)
 		if accessErr != nil {
-			log.Error(
+			logger.Error(
 				"failed-to-resolve-requester-group-access-map",
 				zap.String("requester_user_id", r.UserId),
 				zap.String("group_id", r.GroupID),
@@ -515,7 +515,7 @@ func (s *Service) GetGroupStats(ctx context.Context, r *GetGroupStatsRequest) (*
 		}
 	}
 
-	totalUsers, roleBreakdown := s.calculateGroupSeatUsage(ctx, groupResp.Group, log)
+	totalUsers, roleBreakdown := s.calculateGroupSeatUsage(ctx, groupResp.Group, logger)
 
 	capacity := 9999
 	if groupResp.Group.Settings != nil && groupResp.Group.Settings.MaxMembers > 0 {
@@ -606,10 +606,10 @@ func (s *Service) getUserAllGroups(ctx context.Context, userID string, prefixNam
 
 // GetUserGroupMemberships fetches user-referenced groups and maps them to user-facing memberships.
 func (s *Service) GetUserGroupMemberships(ctx context.Context, req *GetUserGroupMembershipsRequest) (*GetUserGroupMembershipsResponse, error) {
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", req.UserID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", req.UserID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
@@ -662,14 +662,14 @@ func (s *Service) GetUserGroupMemberships(ctx context.Context, req *GetUserGroup
 }
 
 // isRequesterAdmin safely checks if the requester has admin privileges
-func (s *Service) isRequesterAdmin(ctx context.Context, userID string, log *zap.Logger) bool {
+func (s *Service) isRequesterAdmin(ctx context.Context, userID string, logger *zap.Logger) bool {
 	if s.UserService == nil {
 		return false
 	}
 
 	userResp, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: userID})
 	if err != nil || userResp == nil || userResp.User == nil {
-		log.Warn("unable-to-resolve-requester-for-admin-check", zap.String("user-id", userID), zap.Error(err))
+		logger.Warn("unable-to-resolve-requester-for-admin-check", zap.String("user-id", userID), zap.Error(err))
 		return false
 	}
 
@@ -679,10 +679,10 @@ func (s *Service) isRequesterAdmin(ctx context.Context, userID string, log *zap.
 // hasRequesterGroupAccess checks if the requester has access to the group either as a member, admin or owner
 func (s *Service) hasRequesterGroupAccess(ctx context.Context, userID, groupID string) (*group.UserGroupAccessSummary, error) {
 
-	var log *zap.Logger = logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	var logger *zap.Logger = logger.AcquirePackageFrom(ctx, "external/usermanager")
 
 	if s.GroupService == nil {
-		log.Error("group-service-not-enabled", zap.String("user-id", userID))
+		logger.Error("group-service-not-enabled", zap.String("user-id", userID))
 		return nil, ErrGroupServiceNotEnabled
 	}
 
@@ -700,7 +700,7 @@ func (s *Service) hasRequesterGroupAccess(ctx context.Context, userID, groupID s
 }
 
 // calculateGroupSeatUsage computes total unique users including nested group members and owner
-func (s *Service) calculateGroupSeatUsage(ctx context.Context, grp *group.UniversalGroup, log *zap.Logger) (int, map[string]int) {
+func (s *Service) calculateGroupSeatUsage(ctx context.Context, grp *group.UniversalGroup, logger *zap.Logger) (int, map[string]int) {
 	seenGroups := make(map[string]struct{})
 	seenUsers := make(map[string]struct{})
 	roleBreakdown := make(map[string]int)
@@ -729,7 +729,7 @@ func (s *Service) calculateGroupSeatUsage(ctx context.Context, grp *group.Univer
 			case group.MemberTypeGroup:
 				childResp, err := s.GroupService.GetGroupByID(ctx, &group.GetGroupByIDRequest{ID: member.ID})
 				if err != nil || childResp == nil || childResp.Group == nil {
-					log.Warn("failed-to-get-nested-group", zap.String("child-group-id", member.ID), zap.Error(err))
+					logger.Warn("failed-to-get-nested-group", zap.String("child-group-id", member.ID), zap.Error(err))
 					continue
 				}
 				walk(childResp.Group)

--- a/external/usermanager/service.reminder.go
+++ b/external/usermanager/service.reminder.go
@@ -210,24 +210,24 @@ func (s *Service) ensureReminderService() error {
 
 // validateReminderRequester resolves the requesting user and reports whether the user is an admin.
 func (s *Service) validateReminderRequester(ctx context.Context, userID string) (*userv2.UniversalUser, bool, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 	requestingUserID := strings.TrimSpace(userID)
 	if requestingUserID == "" {
-		log.Warn("reminder-request-with-empty-requesting-user-id")
+		logger.Warn("reminder-request-with-empty-requesting-user-id")
 		return nil, false, ErrUnableToIdentifyUser
 	}
 	if s.UserService == nil {
-		log.Warn("reminder-request-without-user-service", zap.String("user-id", requestingUserID))
+		logger.Warn("reminder-request-without-user-service", zap.String("user-id", requestingUserID))
 		return nil, false, ErrUserManagerError
 	}
 
 	requestingUser, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: requestingUserID})
 	if err != nil {
-		log.Warn("unable-to-resolve-reminder-requester", zap.String("user-id", requestingUserID), zap.Error(err))
+		logger.Warn("unable-to-resolve-reminder-requester", zap.String("user-id", requestingUserID), zap.Error(err))
 		return nil, false, err
 	}
 	if requestingUser == nil || requestingUser.User == nil {
-		log.Warn("reminder-requester-not-found", zap.String("user-id", requestingUserID))
+		logger.Warn("reminder-requester-not-found", zap.String("user-id", requestingUserID))
 		return nil, false, ErrUserNotFound
 	}
 

--- a/external/usermanager/service.streak.go
+++ b/external/usermanager/service.streak.go
@@ -158,24 +158,24 @@ func (s *Service) ensureStreakService() error {
 }
 
 func (s *Service) validateStreakRequester(ctx context.Context, userID string) (*userv2.UniversalUser, bool, error) {
-	log := logger.AcquireFrom(ctx).WithOptions(zap.AddStacktrace(zap.DPanicLevel))
+	logger := logger.AcquirePackageFrom(ctx, "external/usermanager")
 	requestingUserID := strings.TrimSpace(userID)
 	if requestingUserID == "" {
-		log.Warn("streak-request-with-empty-requesting-user-id")
+		logger.Warn("streak-request-with-empty-requesting-user-id")
 		return nil, false, ErrUnableToIdentifyUser
 	}
 	if s.UserService == nil {
-		log.Warn("streak-request-without-user-service", zap.String("user-id", requestingUserID))
+		logger.Warn("streak-request-without-user-service", zap.String("user-id", requestingUserID))
 		return nil, false, ErrUserManagerError
 	}
 
 	requestingUser, err := s.UserService.GetUserByID(ctx, &userv2.GetUserByIDRequest{ID: requestingUserID})
 	if err != nil {
-		log.Warn("unable-to-resolve-streak-requester", zap.String("user-id", requestingUserID), zap.Error(err))
+		logger.Warn("unable-to-resolve-streak-requester", zap.String("user-id", requestingUserID), zap.Error(err))
 		return nil, false, err
 	}
 	if requestingUser == nil || requestingUser.User == nil {
-		log.Warn("streak-requester-not-found", zap.String("user-id", requestingUserID))
+		logger.Warn("streak-requester-not-found", zap.String("user-id", requestingUserID))
 		return nil, false, ErrUserNotFound
 	}
 

--- a/internal/blueprint/fender.go
+++ b/internal/blueprint/fender.go
@@ -4,61 +4,76 @@ import (
 	"net/http"
 
 	accessmanagerhelpers "github.com/ooaklee/ghatd/external/accessmanager/helpers"
+	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/ghatd/external/toolbox"
 	"github.com/ritwickdey/querydecoder"
+	"go.uber.org/zap"
 )
 
 // MapRequestToCreateBlueprintRequest maps an incoming CreateBlueprint request.
 func MapRequestToCreateBlueprintRequest(request *http.Request, validator blueprintValidator) (*CreateBlueprintRequest, error) {
 	parsedRequest := &CreateBlueprintRequest{}
+	logger := logger.AcquireOperationFrom(request.Context(), "internal/blueprint", "map-create-blueprint-request")
 
 	if err := toolbox.DecodeRequestBody(request, parsedRequest); err != nil {
+		logger.Warn("blueprint-request-body-decode-failed", zap.Error(err))
 		return nil, ErrBlueprintInvalidPayload
 	}
 
 	parsedRequest.CreatedByUserID = accessmanagerhelpers.AcquireFrom(request.Context())
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		logger.Warn("blueprint-request-validation-failed", zap.Error(err))
 		return nil, ErrBlueprintInvalidPayload
 	}
 
+	logger.Debug("blueprint-create-request-mapped", zap.String("created-by-user-id", parsedRequest.CreatedByUserID), zap.String("kind", normaliseBlueprintKind(parsedRequest.Kind)))
 	return parsedRequest, nil
 }
 
 // MapRequestToGetBlueprintsRequest maps an incoming GetBlueprints request.
 func MapRequestToGetBlueprintsRequest(request *http.Request, validator blueprintValidator) (*GetBlueprintsRequest, error) {
 	parsedRequest := &GetBlueprintsRequest{}
+	logger := logger.AcquireOperationFrom(request.Context(), "internal/blueprint", "map-get-blueprints-request")
 
 	if err := querydecoder.New(request.URL.Query()).Decode(parsedRequest); err != nil {
+		logger.Warn("blueprint-query-decode-failed", zap.Error(err))
 		return nil, ErrBlueprintInvalidQueryParam
 	}
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		logger.Warn("blueprint-query-validation-failed", zap.Error(err))
 		return nil, ErrBlueprintInvalidQueryParam
 	}
 
+	logger.Debug("blueprint-list-request-mapped", zap.Int64("page", parsedRequest.Page), zap.Int64("page-size", parsedRequest.PageSize))
 	return parsedRequest, nil
 }
 
 // MapRequestToGetBlueprintByIDRequest maps an incoming GetBlueprintByID request.
 func MapRequestToGetBlueprintByIDRequest(request *http.Request, validator blueprintValidator) (*GetBlueprintByIDRequest, error) {
 	parsedRequest := &GetBlueprintByIDRequest{}
+	logger := logger.AcquireOperationFrom(request.Context(), "internal/blueprint", "map-get-blueprint-by-id-request")
 
 	id, err := toolbox.GetVariableValueFromUri(request, BlueprintURIVariableID)
 	if err != nil {
+		logger.Warn("blueprint-id-uri-variable-missing", zap.Error(err))
 		return nil, ErrBlueprintIDIsRequired
 	}
 	parsedRequest.ID = id
 
 	parsedRequest.UserID = accessmanagerhelpers.AcquireFrom(request.Context())
 	if parsedRequest.UserID == "" {
+		logger.Warn("blueprint-request-user-id-missing", zap.String("blueprint-id", parsedRequest.ID))
 		return nil, ErrBlueprintUserIDIsRequired
 	}
 
 	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		logger.Warn("blueprint-id-request-validation-failed", zap.String("blueprint-id", parsedRequest.ID), zap.Error(err))
 		return nil, ErrBlueprintIDIsRequired
 	}
 
+	logger.Debug("blueprint-id-request-mapped", zap.String("blueprint-id", parsedRequest.ID), zap.String("user-id", parsedRequest.UserID))
 	return parsedRequest, nil
 }
 

--- a/internal/blueprint/handler.go
+++ b/internal/blueprint/handler.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 
 	"github.com/ooaklee/ghatd/external/errormanifest"
+	"github.com/ooaklee/ghatd/external/logger"
 	"github.com/ooaklee/reply/v2"
+	"go.uber.org/zap"
 )
 
 // blueprintService manages business logic around blueprint request
@@ -38,52 +40,64 @@ func NewHandler(service blueprintService, validator blueprintValidator, errorMap
 
 // CreateBlueprint handles blueprint creation.
 func (h *Handler) CreateBlueprint(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "internal/blueprint", "handle-create-blueprint")
 	request, err := MapRequestToCreateBlueprintRequest(r, h.validator)
 	if err != nil {
+		logger.Warn("blueprint-create-request-map-failed", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.service.CreateBlueprint(r.Context(), request)
 	if err != nil {
+		logger.Error("blueprint-create-service-failed", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
+	logger.Debug("blueprint-create-response-written", zap.String("blueprint-id", response.Blueprint.ID))
 	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusCreated, response.Blueprint)
 }
 
 // GetBlueprints handles listing blueprints.
 func (h *Handler) GetBlueprints(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "internal/blueprint", "handle-get-blueprints")
 	request, err := MapRequestToGetBlueprintsRequest(r, h.validator)
 	if err != nil {
+		logger.Warn("blueprint-list-request-map-failed", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.service.GetBlueprints(r.Context(), request)
 	if err != nil {
+		logger.Error("blueprint-list-service-failed", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
+	logger.Debug("blueprint-list-response-written", zap.Int("returned", len(response.Blueprints)), zap.Int64("total", response.Total))
 	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Blueprints)
 }
 
 // GetBlueprintByID handles getting a blueprint by ID.
 func (h *Handler) GetBlueprintByID(w http.ResponseWriter, r *http.Request) {
+	logger := logger.AcquireOperationFrom(r.Context(), "internal/blueprint", "handle-get-blueprint-by-id")
 	request, err := MapRequestToGetBlueprintByIDRequest(r, h.validator)
 	if err != nil {
+		logger.Warn("blueprint-get-by-id-request-map-failed", zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
 	response, err := h.service.GetBlueprintByID(r.Context(), request)
 	if err != nil {
+		logger.Error("blueprint-get-by-id-service-failed", zap.String("blueprint-id", request.ID), zap.Error(err))
 		h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
 		return
 	}
 
+	logger.Debug("blueprint-get-by-id-response-written", zap.String("blueprint-id", response.Blueprint.ID))
 	h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response.Blueprint)
 }
 

--- a/internal/blueprint/repository.go
+++ b/internal/blueprint/repository.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ooaklee/ghatd/external/logger"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
 )
 
 const defaultCollectionInitMaxAttemptsLimit = 3
@@ -56,10 +58,12 @@ func (r *Repository) WithCollectionInitMaxAttemptsLimit(limit int) *Repository {
 
 // GetBlueprintCollection returns the collection used for blueprint records.
 func (r *Repository) GetBlueprintCollection(ctx context.Context) (*mongo.Collection, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "get-blueprint-collection")
 	r.collectionMutex.Lock()
 	defer r.collectionMutex.Unlock()
 
 	if r.collection != nil {
+		logger.Debug("blueprint-collection-cache-hit")
 		return r.collection, nil
 	}
 
@@ -73,57 +77,71 @@ func (r *Repository) GetBlueprintCollection(ctx context.Context) (*mongo.Collect
 		_, err := r.Store.InitialiseClient(ctx)
 		if err != nil {
 			lastErr = err
+			logger.Warn("blueprint-collection-client-init-failed", zap.Int("attempt", attempt), zap.Error(err))
 			continue
 		}
 
 		db, err := r.Store.GetDatabase(ctx, "")
 		if err != nil {
 			lastErr = err
+			logger.Warn("blueprint-collection-database-resolve-failed", zap.Int("attempt", attempt), zap.Error(err))
 			continue
 		}
 
 		r.collection = db.Collection(BlueprintCollection)
+		logger.Info("blueprint-collection-ready", zap.Int("attempt", attempt), zap.String("collection", BlueprintCollection))
 		return r.collection, nil
 	}
 
+	logger.Error("blueprint-collection-initialisation-failed", zap.Int("max-attempts", collectionInitMaxAttemptsLimit), zap.Error(lastErr))
 	return nil, fmt.Errorf("%w: unable to initialise %s collection after %d attempts: %w", ErrBlueprintDatabaseError, BlueprintCollection, collectionInitMaxAttemptsLimit, lastErr)
 }
 
 // CreateBlueprint creates a new blueprint in the repository.
 func (r *Repository) CreateBlueprint(ctx context.Context, blueprint *Blueprint) (*Blueprint, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "create-blueprint")
 	collection, err := r.GetBlueprintCollection(ctx)
 	if err != nil {
+		logger.Error("blueprint-repository-create-collection-unavailable", zap.Error(err))
 		return nil, err
 	}
 
 	_, err = r.Store.ExecuteInsertOneCommand(ctx, collection, blueprint, "blueprint")
 	if err != nil {
+		logger.Error("blueprint-repository-create-failed", zap.String("blueprint-id", blueprint.ID), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("blueprint-repository-create-completed", zap.String("blueprint-id", blueprint.ID))
 	return blueprint, nil
 }
 
 // GetBlueprintByID retrieves a blueprint by ID.
 func (r *Repository) GetBlueprintByID(ctx context.Context, id string) (*Blueprint, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "get-blueprint-by-id")
 	collection, err := r.GetBlueprintCollection(ctx)
 	if err != nil {
+		logger.Error("blueprint-repository-get-by-id-collection-unavailable", zap.String("blueprint-id", id), zap.Error(err))
 		return nil, err
 	}
 
 	var result Blueprint
 	err = r.Store.ExecuteFindOneCommandDecodeResult(ctx, collection, bson.M{"_id": id}, &result, "blueprint", true, ErrBlueprintResourceNotFound)
 	if err != nil {
+		logger.Error("blueprint-repository-get-by-id-failed", zap.String("blueprint-id", id), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("blueprint-repository-get-by-id-completed", zap.String("blueprint-id", result.ID))
 	return &result, nil
 }
 
 // GetBlueprintByNameAndKind retrieves a blueprint by its natural key.
 func (r *Repository) GetBlueprintByNameAndKind(ctx context.Context, name, kind string) (*Blueprint, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "get-blueprint-by-name-and-kind")
 	collection, err := r.GetBlueprintCollection(ctx)
 	if err != nil {
+		logger.Error("blueprint-repository-get-by-name-collection-unavailable", zap.Error(err))
 		return nil, err
 	}
 
@@ -133,16 +151,20 @@ func (r *Repository) GetBlueprintByNameAndKind(ctx context.Context, name, kind s
 		"kind": normaliseBlueprintKind(kind),
 	}, &result, "blueprint", true, ErrBlueprintResourceNotFound)
 	if err != nil {
+		logger.Error("blueprint-repository-get-by-name-failed", zap.String("name", normaliseBlueprintName(name)), zap.String("kind", normaliseBlueprintKind(kind)), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("blueprint-repository-get-by-name-completed", zap.String("blueprint-id", result.ID))
 	return &result, nil
 }
 
 // GetBlueprints retrieves blueprints by filter.
 func (r *Repository) GetBlueprints(ctx context.Context, req *GetBlueprintsRequest) ([]Blueprint, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "get-blueprints")
 	collection, err := r.GetBlueprintCollection(ctx)
 	if err != nil {
+		logger.Error("blueprint-repository-list-collection-unavailable", zap.Error(err))
 		return nil, err
 	}
 
@@ -158,50 +180,73 @@ func (r *Repository) GetBlueprints(ctx context.Context, req *GetBlueprintsReques
 
 	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, filter, findOptions)
 	if err != nil {
+		logger.Error("blueprint-repository-list-cursor-failed", zap.Error(err))
 		return nil, err
 	}
 
 	var result []Blueprint
 	if err = r.Store.MapAllInCursorToResult(ctx, cursor, &result, "blueprints"); err != nil {
+		logger.Error("blueprint-repository-list-decode-failed", zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("blueprint-repository-list-completed", zap.Int("returned", len(result)))
 	return result, nil
 }
 
 // GetTotalBlueprints counts blueprints by filter.
 func (r *Repository) GetTotalBlueprints(ctx context.Context, req *GetBlueprintsRequest) (int64, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "get-total-blueprints")
 	collection, err := r.GetBlueprintCollection(ctx)
 	if err != nil {
+		logger.Error("blueprint-repository-count-collection-unavailable", zap.Error(err))
 		return 0, err
 	}
 
-	return r.Store.ExecuteCountDocuments(ctx, collection, buildBlueprintListFilter(req))
+	total, err := r.Store.ExecuteCountDocuments(ctx, collection, buildBlueprintListFilter(req))
+	if err != nil {
+		logger.Error("blueprint-repository-count-failed", zap.Error(err))
+		return 0, err
+	}
+	logger.Debug("blueprint-repository-count-completed", zap.Int64("total", total))
+	return total, nil
 }
 
 // UpdateBlueprint updates an existing blueprint.
 func (r *Repository) UpdateBlueprint(ctx context.Context, blueprint *Blueprint) (*Blueprint, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "update-blueprint")
 	collection, err := r.GetBlueprintCollection(ctx)
 	if err != nil {
+		logger.Error("blueprint-repository-update-collection-unavailable", zap.String("blueprint-id", blueprint.ID), zap.Error(err))
 		return nil, err
 	}
 
 	err = r.Store.ExecuteUpdateOneCommand(ctx, collection, bson.M{"_id": blueprint.ID}, bson.M{"$set": blueprint}, "blueprint")
 	if err != nil {
+		logger.Error("blueprint-repository-update-failed", zap.String("blueprint-id", blueprint.ID), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("blueprint-repository-update-completed", zap.String("blueprint-id", blueprint.ID))
 	return blueprint, nil
 }
 
 // DeleteBlueprintByID deletes a blueprint by ID.
 func (r *Repository) DeleteBlueprintByID(ctx context.Context, id string) error {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "delete-blueprint-by-id")
 	collection, err := r.GetBlueprintCollection(ctx)
 	if err != nil {
+		logger.Error("blueprint-repository-delete-collection-unavailable", zap.String("blueprint-id", id), zap.Error(err))
 		return err
 	}
 
-	return r.Store.ExecuteDeleteOneCommand(ctx, collection, bson.M{"_id": id}, "blueprint")
+	if err := r.Store.ExecuteDeleteOneCommand(ctx, collection, bson.M{"_id": id}, "blueprint"); err != nil {
+		logger.Error("blueprint-repository-delete-failed", zap.String("blueprint-id", id), zap.Error(err))
+		return err
+	}
+
+	logger.Debug("blueprint-repository-delete-completed", zap.String("blueprint-id", id))
+	return nil
 }
 
 func buildBlueprintListFilter(req *GetBlueprintsRequest) bson.M {

--- a/internal/blueprint/service.go
+++ b/internal/blueprint/service.go
@@ -3,6 +3,9 @@ package blueprint
 import (
 	"context"
 	"strings"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 // BlueprintRepository defines the repository surface used by the service.
@@ -37,10 +40,14 @@ func NewService(blueprintRepository BlueprintRepository, registry ...*Registry) 
 
 // CreateBlueprint creates a blueprint record.
 func (s *Service) CreateBlueprint(ctx context.Context, req *CreateBlueprintRequest) (*BlueprintResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "create-blueprint")
+
 	if req == nil || normaliseBlueprintName(req.Name) == "" {
+		logger.Warn("blueprint-create-missing-name")
 		return nil, ErrBlueprintNameIsRequired
 	}
 	if normaliseBlueprintKind(req.Kind) == "" {
+		logger.Warn("blueprint-create-missing-kind", zap.String("name", normaliseBlueprintName(req.Name)))
 		return nil, ErrBlueprintKindIsRequired
 	}
 
@@ -51,69 +58,92 @@ func (s *Service) CreateBlueprint(ctx context.Context, req *CreateBlueprintReque
 
 	created, err := s.BlueprintRepository.CreateBlueprint(ctx, blueprint)
 	if err != nil {
+		logger.Error("blueprint-create-failed", zap.String("blueprint-id", blueprint.ID), zap.String("kind", blueprint.Kind), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Info("blueprint-created", zap.String("blueprint-id", created.ID), zap.String("kind", created.Kind))
 	return &BlueprintResponse{Blueprint: created}, nil
 }
 
 // GetBlueprintByID retrieves a blueprint by ID.
 func (s *Service) GetBlueprintByID(ctx context.Context, req *GetBlueprintByIDRequest) (*BlueprintResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "get-blueprint-by-id")
+
 	if req == nil || strings.TrimSpace(req.ID) == "" {
+		logger.Warn("blueprint-get-by-id-missing-id")
 		return nil, ErrBlueprintIDIsRequired
 	}
 	if strings.TrimSpace(req.UserID) == "" {
+		logger.Warn("blueprint-get-by-id-missing-user-id", zap.String("blueprint-id", strings.TrimSpace(req.ID)))
 		return nil, ErrBlueprintUserIDIsRequired
 	}
 
 	blueprint, err := s.BlueprintRepository.GetBlueprintByID(ctx, strings.TrimSpace(req.ID))
 	if err != nil {
+		logger.Error("blueprint-get-by-id-failed", zap.String("blueprint-id", strings.TrimSpace(req.ID)), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("blueprint-get-by-id-completed", zap.String("blueprint-id", blueprint.ID), zap.String("kind", blueprint.Kind))
 	return &BlueprintResponse{Blueprint: blueprint}, nil
 }
 
 // GetBlueprintByName retrieves a blueprint by name and kind.
 func (s *Service) GetBlueprintByName(ctx context.Context, req *GetBlueprintByNameRequest) (*BlueprintResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "get-blueprint-by-name")
+
 	if req == nil || normaliseBlueprintName(req.Name) == "" {
+		logger.Warn("blueprint-get-by-name-missing-name")
 		return nil, ErrBlueprintNameIsRequired
 	}
 	if normaliseBlueprintKind(req.Kind) == "" {
+		logger.Warn("blueprint-get-by-name-missing-kind", zap.String("name", normaliseBlueprintName(req.Name)))
 		return nil, ErrBlueprintKindIsRequired
 	}
 
 	blueprint, err := s.BlueprintRepository.GetBlueprintByNameAndKind(ctx, req.Name, req.Kind)
 	if err != nil {
+		logger.Error("blueprint-get-by-name-failed", zap.String("name", normaliseBlueprintName(req.Name)), zap.String("kind", normaliseBlueprintKind(req.Kind)), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("blueprint-get-by-name-completed", zap.String("blueprint-id", blueprint.ID), zap.String("kind", blueprint.Kind))
 	return &BlueprintResponse{Blueprint: blueprint}, nil
 }
 
 // GetBlueprints retrieves a filtered page of blueprints.
 func (s *Service) GetBlueprints(ctx context.Context, req *GetBlueprintsRequest) (*GetBlueprintsResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "get-blueprints")
+
 	blueprints, err := s.BlueprintRepository.GetBlueprints(ctx, req)
 	if err != nil {
+		logger.Error("blueprints-list-failed", zap.Error(err))
 		return nil, err
 	}
 
 	total, err := s.BlueprintRepository.GetTotalBlueprints(ctx, req)
 	if err != nil {
+		logger.Error("blueprints-count-failed", zap.Error(err))
 		return nil, err
 	}
 
+	logger.Debug("blueprints-list-completed", zap.Int("returned", len(blueprints)), zap.Int64("total", total))
 	return &GetBlueprintsResponse{Blueprints: blueprints, Total: total}, nil
 }
 
 // UpdateBlueprint updates mutable fields on a blueprint.
 func (s *Service) UpdateBlueprint(ctx context.Context, req *UpdateBlueprintRequest) (*BlueprintResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "update-blueprint")
+
 	if req == nil || strings.TrimSpace(req.ID) == "" {
+		logger.Warn("blueprint-update-missing-id")
 		return nil, ErrBlueprintIDIsRequired
 	}
 
 	current, err := s.BlueprintRepository.GetBlueprintByID(ctx, strings.TrimSpace(req.ID))
 	if err != nil {
+		logger.Error("blueprint-update-current-lookup-failed", zap.String("blueprint-id", strings.TrimSpace(req.ID)), zap.Error(err))
 		return nil, err
 	}
 
@@ -137,22 +167,29 @@ func (s *Service) UpdateBlueprint(ctx context.Context, req *UpdateBlueprintReque
 
 	updated, err := s.BlueprintRepository.UpdateBlueprint(ctx, current)
 	if err != nil {
+		logger.Error("blueprint-update-failed", zap.String("blueprint-id", current.ID), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Info("blueprint-updated", zap.String("blueprint-id", updated.ID), zap.String("kind", updated.Kind))
 	return &BlueprintResponse{Blueprint: updated}, nil
 }
 
 // DeleteBlueprint deletes a blueprint by ID.
 func (s *Service) DeleteBlueprint(ctx context.Context, req *DeleteBlueprintRequest) (*DeleteBlueprintResponse, error) {
+	logger := logger.AcquireOperationFrom(ctx, "internal/blueprint", "delete-blueprint")
+
 	if req == nil || strings.TrimSpace(req.ID) == "" {
+		logger.Warn("blueprint-delete-missing-id")
 		return nil, ErrBlueprintIDIsRequired
 	}
 
 	if err := s.BlueprintRepository.DeleteBlueprintByID(ctx, strings.TrimSpace(req.ID)); err != nil {
+		logger.Error("blueprint-delete-failed", zap.String("blueprint-id", strings.TrimSpace(req.ID)), zap.Error(err))
 		return nil, err
 	}
 
+	logger.Info("blueprint-deleted", zap.String("blueprint-id", strings.TrimSpace(req.ID)))
 	return &DeleteBlueprintResponse{Deleted: true}, nil
 }
 

--- a/internal/cli/repository/repository.go
+++ b/internal/cli/repository/repository.go
@@ -8,6 +8,9 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/ooaklee/ghatd/external/logger"
+	"go.uber.org/zap"
 )
 
 var errMissingSource = errors.New("repository: source is required")
@@ -56,33 +59,46 @@ type CloneRequest struct {
 }
 
 func Clone(ctx context.Context, req CloneRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "internal/cli/repository", "clone")
 	req.Source = strings.TrimSpace(req.Source)
 	req.Destination = strings.TrimSpace(req.Destination)
 	req.Branch = strings.TrimSpace(req.Branch)
 
 	if strings.TrimSpace(req.Source) == "" {
+		logger.Warn("cli-repository-clone-missing-source")
 		return errMissingSource
 	}
 	if strings.TrimSpace(req.Destination) == "" {
+		logger.Warn("cli-repository-clone-missing-destination", zap.String("source", normaliseSource(req.Source)))
 		return errMissingDestination
 	}
 
+	logger.Info("cli-repository-clone-started", zap.String("source", normaliseSource(req.Source)), zap.Bool("github-source", isGitHubSource(req.Source)), zap.Bool("branch-set", req.Branch != ""), zap.Bool("recurse-submodules", req.RecurseSubmodules))
 	if isGitHubSource(req.Source) {
 		if _, err := runner.LookPath("gh"); err == nil {
 			if err := cloneWithGH(ctx, req); err == nil {
+				logger.Info("cli-repository-clone-completed", zap.String("tool", "gh"), zap.String("source", normaliseSource(req.Source)))
 				return nil
 			} else if gitErr := cloneWithGit(ctx, req); gitErr != nil {
+				logger.Error("cli-repository-clone-failed", zap.String("source", normaliseSource(req.Source)), zap.Error(gitErr))
 				return fmt.Errorf("repository: gh clone failed: %w; git clone fallback failed: %w", err, gitErr)
 			}
 
+			logger.Info("cli-repository-clone-completed", zap.String("tool", "git"), zap.String("source", normaliseSource(req.Source)))
 			return nil
 		}
 	}
 
-	return cloneWithGit(ctx, req)
+	if err := cloneWithGit(ctx, req); err != nil {
+		logger.Error("cli-repository-clone-failed", zap.String("source", normaliseSource(req.Source)), zap.Error(err))
+		return err
+	}
+	logger.Info("cli-repository-clone-completed", zap.String("tool", "git"), zap.String("source", normaliseSource(req.Source)))
+	return nil
 }
 
 func cloneWithGH(ctx context.Context, req CloneRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "internal/cli/repository", "clone-with-gh")
 	ownerRepo := normaliseSource(req.Source)
 
 	args := []string{"repo", "clone", ownerRepo, req.Destination}
@@ -100,12 +116,15 @@ func cloneWithGH(ctx context.Context, req CloneRequest) error {
 	}
 
 	if err := runner.RunCommand(ctx, "gh", args...); err != nil {
+		logger.Error("cli-repository-gh-clone-command-failed", zap.String("source", ownerRepo), zap.Error(err))
 		return fmt.Errorf("repository: gh clone failed: %w", err)
 	}
+	logger.Debug("cli-repository-gh-clone-command-completed", zap.String("source", ownerRepo))
 	return nil
 }
 
 func cloneWithGit(ctx context.Context, req CloneRequest) error {
+	logger := logger.AcquireOperationFrom(ctx, "internal/cli/repository", "clone-with-git")
 	args := []string{"clone"}
 	if req.Branch != "" {
 		args = append(args, "--branch", req.Branch)
@@ -116,8 +135,10 @@ func cloneWithGit(ctx context.Context, req CloneRequest) error {
 	args = append(args, gitCloneSource(req.Source), req.Destination)
 
 	if err := runner.RunCommand(ctx, "git", args...); err != nil {
+		logger.Error("cli-repository-git-clone-command-failed", zap.String("source", normaliseSource(req.Source)), zap.Error(err))
 		return fmt.Errorf("repository: git clone failed: %w", err)
 	}
+	logger.Debug("cli-repository-git-clone-command-completed", zap.String("source", normaliseSource(req.Source)))
 	return nil
 }
 


### PR DESCRIPTION
### Context

GHATD packages run inside host applications and usually write through the logger propagated by host request middleware. That preserves host fields such as request IDs, component names, and environment metadata, but framework log lines have not had a consistent way to identify the GHATD package or operation that produced them.

That makes framework failures difficult to troubleshoot when the only visible symptom is a host-level request summary or a generic HTTP error. Host applications need enough GHATD-side context to follow a request through handlers, fenders, services, repository helpers, auth/session flows, providers, background jobs, and cleanup paths without exposing secrets or raw payloads.

Local email development has a related pressure point. Login, verification, and custom emails need their full rendered content available so developers can open magic links and copy security codes, but writing raw email HTML into structured logs conflicts with the new logging rules.

### What Changed

- Added structured GHATD logger helpers that preserve the context logger and attach `source=ghatd`, `ghatd-package`, and `operation` fields.
- Added safe logging helpers for request/model context so packages can log useful IDs, counts, statuses, booleans, and collection shapes without serialising raw payloads.
- Standardised acquired package logger variables as `logger` across GHATD package code and documented the convention in ADR013.
- Added operation-boundary logging across HTTP handlers, fenders, service methods, repository helpers, Redis-backed ephemeral session/code flows, auth token flows, payment/email/OAuth providers, router, SPA, HTTP server lifecycle, starter cleanup, CLI repository cloning, and internal blueprint flows.
- Replaced raw request/payload logging in domain packages with safe log values.
- Removed legacy event-name prefixes such as package abbreviations now covered by the structured GHATD package fields.
- Tightened provider logs so operational failures remain visible without logging tokens, signatures, webhook payloads, email bodies, push endpoints, API keys, cookies, or authorization values.
- Added a bounded in-memory local email inbox behind `LoggingEmailProvider` so local emails can be inspected without raw bodies in logs.
- Added opt-in local inbox routes for listing captured emails, opening rendered HTML, viewing raw HTML, clearing captured messages, and exposing JSON summaries.
- Kept local inbox routes loopback-only by default, added an explicit `AllowRemote` escape hatch for trusted local proxies, sandboxed direct rendered-email views with CSP, and filtered extracted click-through links to web URLs.
- Updated `EmailManager` so both templated and pre-rendered email paths can write to local output providers when real sending is disabled.
- Added ADR013 to capture the logging strategy, level conventions, sensitive-data rules, and rollout expectations for host applications.
- Added ADR014 to capture the local email inbox decision, route boundaries, safety constraints, and rollout expectations.
- Updated the email manager guide and examples to use the local inbox workflow.

### Why

Host applications should be able to filter framework logs with `source=ghatd`, narrow failures by `ghatd-package` and `operation`, and still retain their own correlation fields from the request logger. This gives operators enough context to debug GHATD-originated failures without relying on old message prefixes or unsafe raw object logging.

The extra routine entries are intentionally mostly debug-level boundary logs. They provide detail when a host application raises log verbosity for an investigation while keeping normal production output focused on warnings, errors, lifecycle summaries, and completed work.

Local email capture keeps development login and verification flows practical while preserving the rule that logs should carry safe operational metadata, not rendered email bodies, tokens, or codes.

### Scope Notes

This changes GHATD package logging behavior and conventions only. It does not change host application logger configuration, log shipping, or dashboard queries by itself.

Existing host applications should prefer the new structured fields over parsing event-message prefixes. Legacy prefix-style event names have been removed where they duplicated package attribution.

Standalone migrations and examples may still use the standard library logger where they are not participating in host request-context logging. The new convention applies to acquired GHATD package loggers.

The local email inbox is opt-in, in-memory, and intended for trusted local development environments. Captured emails reset when the process restarts, and the default route prefix is `/_ghatd/local/emails`.

### How To Test

Requires a Go 1.25-compatible toolchain. The repo includes `.tool-versions` for asdf users.

- `asdf exec go test ./...`
- `asdf exec go test ./external/accessmanager ./external/accessmanager/helpers ./external/accessmanager/middleware ./external/oauth`
- `asdf exec go test ./external/emailprovider ./external/emailmanager`
- `git diff --check`
- Ran a zap field key kebab-case scan.
- Ran a logger variable-name scan for non-standard acquired logger names.
- Ran an unsafe raw request/payload logging scan.
- Ran a handler and service boundary logging audit.
- Ran a logger event-prefix scan for legacy package prefixes.
- Ran a public docs hygiene scan.

Equivalent with an already configured Go 1.25+ toolchain:

- `go test ./...`

For a host application using GHATD request logging, exercise any request path that enters GHATD and verify package logs include host correlation fields plus GHATD fields such as:

```text
source=ghatd
ghatd-package=external/notifier
operation=notify-user
```

For local email development, configure `LoggingEmailProvider`, attach `emailprovider.AttachLocalInboxRoutes`, trigger a login or verification email with real sending disabled, then open `/_ghatd/local/emails` from localhost. Verify the email appears, rendered HTML opens, extracted magic links are available as buttons, and raw email bodies are not emitted to structured logs.

### Rollout Notes

Host applications should update to the released GHATD version, verify their request middleware still propagates the logger through context, and add or update log filters for `source=ghatd`, `ghatd-package`, and `operation`.

Production deployments can keep normal `info` or higher log levels. Raise to `debug` when investigating a specific GHATD package path and lower it again after the investigation.

Any dashboards or alerts that parse old event-name prefixes should move to structured-field filters before relying on this change in production.

Applications that need local login, verification, or custom-email inspection can attach the local inbox routes only in local development startup code. Do not enable the inbox routes in production or untrusted environments.