### PR TITLE
Add reusable SEO sitemap package

### DIFF
--- a/docs/adr/adr016-external-seo-sitemap-package.md
+++ b/docs/adr/adr016-external-seo-sitemap-package.md
@@ -1,0 +1,75 @@
+---
+id: adrs-adr016
+title: 'ADR016: External SEO Sitemap Package'
+# prettier-ignore
+description: Architecture Decision Record for reusable sitemap ownership and host application extension points
+date: 2026-07-12
+status: accepted
+---
+
+## Status
+
+Accepted.
+
+## Context
+
+GHATD host applications need the same core sitemap capabilities: persistent URL
+entries, deterministic XML generation, a public `/sitemap.xml` route,
+administrative CRUD and batch ingestion, safe file generation, and MongoDB
+migrations. Keeping independent copies of that backend in each host application
+causes fixes and API behaviour to drift.
+
+The framework already exposes content-specific sitemap candidates through
+packages such as `external/contentmanager`. Candidate discovery is different
+from sitemap ownership: content packages know which records are public, while a
+sitemap service knows how entries are validated, stored, filtered, rendered,
+and served.
+
+Crawler policy is application-specific. A framework cannot decide which product
+routes deserve indexing, which dynamic records have sufficient canonical
+content, or what priority and change frequency a product should assign.
+
+## Decision
+
+GHATD will own the reusable sitemap backend in `external/seo`.
+
+The package will provide:
+
+- sitemap item models, validation, repository, service, handler, and routes;
+- deterministic and de-duplicated XML generation;
+- exclusion of protected route groups from generated XML;
+- safe writes and downloads below a configured writable root;
+- an embedded-file fallback for the public sitemap;
+- MongoDB index and configurable starter-route seed migrations; and
+- service methods that host applications can use for batch ingestion and
+  product-specific orchestration.
+
+Host applications will compose the package with their repository, validator,
+frontend domain, filesystem, writable path, and admin-only middleware. They may
+customise starter seed paths when registering migrations.
+
+Content packages and host applications remain responsible for discovering
+public URL candidates. They submit candidates through the SEO service instead
+of duplicating sitemap persistence or XML generation. Product-specific repair
+migrations, crawl-budget decisions, metadata, robots directives, and frontend
+administration remain outside the framework package.
+
+## Consequences
+
+Core sitemap fixes and API behaviour now have one framework implementation.
+Host applications can add content ingestion without forking the sitemap domain.
+
+Applications adopting the package must update imports and register the external
+SEO migrations. Existing collections, document shape, and route paths remain
+compatible, so the migration does not require copying stored sitemap data. A
+host with duplicate URI records must clean them up before creating the package's
+unique URI index.
+
+The framework provides conservative protected-route filtering and starter seed
+defaults, but each host application must still review its public routes and
+crawler policy. Moving the backend into GHATD does not make product-specific
+content automatically indexable.
+
+The package currently uses the framework's MongoDB driver v1 repository surface.
+Migration to a newer driver must be coordinated with the shared repository and
+migration APIs rather than performed by an individual host application.

--- a/external/seo/README.md
+++ b/external/seo/README.md
@@ -1,0 +1,24 @@
+# SEO Sitemap
+
+The `external/seo` package provides reusable sitemap persistence, management,
+generation, and HTTP routes for GHATD host applications.
+
+Sitemap items are stored in MongoDB and contain a URI, last-modified timestamp,
+priority, change frequency, and creator metadata. Relative URIs are rendered
+against the frontend domain configured by the host application. Generated XML
+is sorted and de-duplicated by absolute URL.
+
+The public sitemap route is `GET /sitemap.xml`. Administrative routes under
+`/api/v1/seo` support listing, creating, updating, deleting, batch ingestion,
+generation, and safe downloads. The host application supplies its existing
+admin-only middleware when attaching the routes.
+
+Generated files are restricted to safe relative paths below a configured
+writable root. An embedded static sitemap can be supplied as a read fallback.
+Protected route groups such as `/admin`, `/api`, `/app`, `/auth`, `/offline`,
+`/portal`, and `/settings` are excluded from generated XML.
+
+The `migrations` subpackage provides the sitemap-item index and a configurable
+starter-route seed. Host applications can add or remove paths when registering
+the seed migration. Product-specific content discovery and crawler policy stay
+in the host application and feed the generic batch-ingestion service.

--- a/external/seo/const.go
+++ b/external/seo/const.go
@@ -1,0 +1,49 @@
+package seo
+
+const (
+	defaultIdentityTagSystem = "system"
+
+	// APIV1Base is the start of the V1 API URI.
+	APIV1Base = "/api/v1"
+
+	// APISEOPrefix is the base URI prefix for SEO administration routes.
+	APISEOPrefix = APIV1Base + "/seo"
+
+	// PublicSitemapPath is the public route used by search engines.
+	PublicSitemapPath = "/sitemap.xml"
+
+	// SitemapItemsCollection is the MongoDB collection name for sitemap records.
+	SitemapItemsCollection = "sitemap_items"
+)
+
+const (
+	// ChangeFrequencyAlways is used for pages that change constantly.
+	ChangeFrequencyAlways ChangeFrequency = "always"
+
+	// ChangeFrequencyHourly is used for fast-moving pages.
+	ChangeFrequencyHourly ChangeFrequency = "hourly"
+
+	// ChangeFrequencyDaily is used for regularly updated pages.
+	ChangeFrequencyDaily ChangeFrequency = "daily"
+
+	// ChangeFrequencyWeekly is used for standard blogs or catalogues.
+	ChangeFrequencyWeekly ChangeFrequency = "weekly"
+
+	// ChangeFrequencyMonthly is used for static pages that occasionally change.
+	ChangeFrequencyMonthly ChangeFrequency = "monthly"
+
+	// ChangeFrequencyYearly is used for stable static pages.
+	ChangeFrequencyYearly ChangeFrequency = "yearly"
+
+	// ChangeFrequencyNever is used for pages that should not change.
+	ChangeFrequencyNever ChangeFrequency = "never"
+)
+
+const (
+	defaultSitemapPath          = "sitemap.xml"
+	defaultSitemapWritableRoot  = "/tmp"
+	defaultSitemapPriority      = 0.5
+	defaultSitemapFilePerm      = 0o644
+	defaultSitemapDirectoryPerm = 0o755
+	maxSitemapURIRegexLength    = 256
+)

--- a/external/seo/errormap.go
+++ b/external/seo/errormap.go
@@ -1,0 +1,17 @@
+package seo
+
+import "github.com/ooaklee/reply/v2"
+
+// SitemapErrorMap maps SEO errors to HTTP responses.
+var SitemapErrorMap = reply.ErrorManifest{
+	ErrSitemapItemError:                  {Title: "Bad Request", Detail: "Sitemap request is invalid", StatusCode: 400},
+	ErrSitemapItemDatabaseError:          {Title: "Internal Server Error", Detail: "Unable to complete sitemap database operation", StatusCode: 500},
+	ErrSitemapItemResourceNotFound:       {Title: "Sitemap item not found", StatusCode: 404},
+	ErrSitemapItemURIIsRequired:          {Title: "Bad Request", Detail: "Sitemap item URI is required", StatusCode: 400},
+	ErrSitemapItemInvalidURI:             {Title: "Bad Request", Detail: "Sitemap item URI is invalid", StatusCode: 400},
+	ErrSitemapItemInvalidChangeFrequency: {Title: "Bad Request", Detail: "Sitemap item change frequency is invalid", StatusCode: 400},
+	ErrSitemapItemInvalidPriority:        {Title: "Bad Request", Detail: "Sitemap item priority is invalid", StatusCode: 400},
+	ErrSitemapItemInvalidLastMod:         {Title: "Bad Request", Detail: "Sitemap item last_mod is invalid", StatusCode: 400},
+	ErrSitemapPathIsInvalid:              {Title: "Bad Request", Detail: "Sitemap path is invalid", StatusCode: 400},
+	ErrSitemapFrontendDomainIsRequired:   {Title: "Bad Request", Detail: "Sitemap frontend domain is required", StatusCode: 400},
+}

--- a/external/seo/errors.go
+++ b/external/seo/errors.go
@@ -1,0 +1,35 @@
+package seo
+
+import "errors"
+
+var (
+	// ErrSitemapItemError is returned for general sitemap item failures.
+	ErrSitemapItemError = errors.New("sitemap-item-request-is-invalid")
+
+	// ErrSitemapItemDatabaseError is returned when sitemap persistence fails.
+	ErrSitemapItemDatabaseError = errors.New("sitemap-item-database-operation-failed")
+
+	// ErrSitemapItemResourceNotFound is returned when the requested sitemap item cannot be found.
+	ErrSitemapItemResourceNotFound = errors.New("sitemap-item-resource-not-found")
+
+	// ErrSitemapItemURIIsRequired is returned when a sitemap item URI is missing.
+	ErrSitemapItemURIIsRequired = errors.New("sitemap-item-uri-is-required")
+
+	// ErrSitemapItemInvalidURI is returned when a sitemap item URI is malformed.
+	ErrSitemapItemInvalidURI = errors.New("sitemap-item-uri-is-invalid")
+
+	// ErrSitemapItemInvalidChangeFrequency is returned when change_frequency is not supported.
+	ErrSitemapItemInvalidChangeFrequency = errors.New("sitemap-item-change-frequency-is-invalid")
+
+	// ErrSitemapItemInvalidPriority is returned when priority is outside sitemap bounds.
+	ErrSitemapItemInvalidPriority = errors.New("sitemap-item-priority-is-invalid")
+
+	// ErrSitemapItemInvalidLastMod is returned when last_mod cannot be parsed.
+	ErrSitemapItemInvalidLastMod = errors.New("sitemap-item-last-mod-is-invalid")
+
+	// ErrSitemapPathIsInvalid is returned when a sitemap file path is unsafe.
+	ErrSitemapPathIsInvalid = errors.New("sitemap-path-is-invalid")
+
+	// ErrSitemapFrontendDomainIsRequired is returned when URL generation has no frontend domain.
+	ErrSitemapFrontendDomainIsRequired = errors.New("sitemap-frontend-domain-is-required")
+)

--- a/external/seo/fender.go
+++ b/external/seo/fender.go
@@ -1,0 +1,133 @@
+package seo
+
+import (
+	"net/http"
+	"strings"
+
+	accessmanagerhelpers "github.com/ooaklee/ghatd/external/accessmanager/helpers"
+	"github.com/ooaklee/ghatd/external/toolbox"
+	"github.com/ritwickdey/querydecoder"
+)
+
+// sitemapValidator expected methods of a valid validator.
+type sitemapValidator interface {
+	Validate(s interface{}) error
+}
+
+func validateParsedRequest(request interface{}, validator sitemapValidator) error {
+	if validator == nil {
+		return nil
+	}
+	return validator.Validate(request)
+}
+
+// MapRequestToCreateSitemapItemRequest maps incoming create request data.
+func MapRequestToCreateSitemapItemRequest(request *http.Request, validator sitemapValidator) (*CreateSitemapItemRequest, error) {
+	parsedRequest := &CreateSitemapItemRequest{}
+	if err := toolbox.DecodeRequestBody(request, parsedRequest); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	if parsedRequest.CreatedByID == "" {
+		parsedRequest.CreatedByID = accessmanagerhelpers.AcquireFrom(request.Context())
+	}
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	return parsedRequest, nil
+}
+
+// MapRequestToMassSitemapItemCreationByBatchRequest maps incoming batch create request data.
+func MapRequestToMassSitemapItemCreationByBatchRequest(request *http.Request, validator sitemapValidator) (*MassSitemapItemCreationByBatchRequest, error) {
+	parsedRequest := &MassSitemapItemCreationByBatchRequest{}
+	if err := toolbox.DecodeRequestBody(request, parsedRequest); err != nil {
+		return nil, ErrSitemapItemError
+	}
+
+	requestorID := accessmanagerhelpers.AcquireFrom(request.Context())
+	for index := range parsedRequest.Items {
+		if parsedRequest.Items[index].CreatedByID == "" {
+			parsedRequest.Items[index].CreatedByID = requestorID
+		}
+	}
+
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	return parsedRequest, nil
+}
+
+// MapRequestToGetSitemapItemsRequest maps incoming list request data.
+func MapRequestToGetSitemapItemsRequest(request *http.Request, validator sitemapValidator) (*GetSitemapItemsRequest, error) {
+	parsedRequest := &GetSitemapItemsRequest{
+		Page: 1,
+	}
+	if err := querydecoder.New(request.URL.Query()).Decode(parsedRequest); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	return parsedRequest, nil
+}
+
+// MapRequestToUpdateSitemapItemRequest maps incoming update request data.
+func MapRequestToUpdateSitemapItemRequest(request *http.Request, validator sitemapValidator) (*UpdateSitemapItemRequest, error) {
+	parsedRequest := &UpdateSitemapItemRequest{}
+	if err := toolbox.DecodeRequestBody(request, parsedRequest); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	if parsedRequest.UpdatedByID == "" {
+		parsedRequest.UpdatedByID = accessmanagerhelpers.AcquireFrom(request.Context())
+	}
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	return parsedRequest, nil
+}
+
+// MapRequestToDeleteEntriesWithURIRegexRequest maps incoming regex delete request data.
+func MapRequestToDeleteEntriesWithURIRegexRequest(request *http.Request, validator sitemapValidator) (*DeleteEntriesWithURIRegexRequest, error) {
+	parsedRequest := &DeleteEntriesWithURIRegexRequest{}
+	if err := querydecoder.New(request.URL.Query()).Decode(parsedRequest); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	if parsedRequest.URIRegex == "" {
+		parsedRequest.URIRegex = strings.TrimSpace(request.URL.Query().Get("uri_regex"))
+	}
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	return parsedRequest, nil
+}
+
+// MapRequestToGenerateSitemapRequest maps incoming generate request data.
+func MapRequestToGenerateSitemapRequest(request *http.Request, validator sitemapValidator) (*GenerateSitemapRequest, error) {
+	parsedRequest := &GenerateSitemapRequest{}
+	if request.Body != nil && request.ContentLength != 0 {
+		if err := toolbox.DecodeRequestBody(request, parsedRequest); err != nil {
+			return nil, ErrSitemapItemError
+		}
+	}
+	if len(parsedRequest.SaveToPaths) == 0 {
+		parsedRequest.SaveToPaths = request.URL.Query()["save_to_paths"]
+	}
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, ErrSitemapItemError
+	}
+	return parsedRequest, nil
+}
+
+// MapRequestToDownloadSitemapByPathRequest maps incoming download request data.
+func MapRequestToDownloadSitemapByPathRequest(request *http.Request, validator sitemapValidator) (*DownloadSitemapByPathRequest, error) {
+	parsedRequest := &DownloadSitemapByPathRequest{}
+	if err := querydecoder.New(request.URL.Query()).Decode(parsedRequest); err != nil {
+		return nil, ErrSitemapPathIsInvalid
+	}
+	if parsedRequest.Path == "" {
+		parsedRequest.Path = request.URL.Query().Get("path")
+	}
+	if err := validateParsedRequest(parsedRequest, validator); err != nil {
+		return nil, ErrSitemapPathIsInvalid
+	}
+	return parsedRequest, nil
+}

--- a/external/seo/handler.go
+++ b/external/seo/handler.go
@@ -1,0 +1,178 @@
+package seo
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ooaklee/ghatd/external/errormanifest"
+	"github.com/ooaklee/reply/v2"
+)
+
+// sitemapService manages business logic around sitemap requests.
+type sitemapService interface {
+	CreateSitemapItemIfDoesNotAlreadyExist(ctx context.Context, r *CreateSitemapItemRequest) (*SitemapItemResponse, error)
+	DeleteEntriesWithUriRegex(ctx context.Context, r *DeleteEntriesWithURIRegexRequest) (*DeleteEntriesWithURIRegexResponse, error)
+	DownloadSitemapByPath(ctx context.Context, r *DownloadSitemapByPathRequest) (*DownloadSitemapByPathResponse, error)
+	GenerateSitemap(ctx context.Context, r *GenerateSitemapRequest) (*GenerateSitemapResponse, error)
+	GetSitemapItems(ctx context.Context, r *GetSitemapItemsRequest) (*GetSitemapItemsResponse, error)
+	MassSitemapItemCreationByBatch(ctx context.Context, r *MassSitemapItemCreationByBatchRequest) (*MassSitemapItemCreationByBatchResponse, error)
+	UpdateSitemapItemByUri(ctx context.Context, r *UpdateSitemapItemRequest) (*SitemapItemResponse, error)
+}
+
+// Handler manages sitemap requests.
+type Handler struct {
+	service   sitemapService
+	validator sitemapValidator
+	errorMaps []reply.ErrorManifest
+}
+
+// NewHandler returns a sitemap handler.
+func NewHandler(service sitemapService, validator sitemapValidator, errorMaps ...reply.ErrorManifest) *Handler {
+	return &Handler{
+		service:   service,
+		validator: validator,
+		errorMaps: errorMaps,
+	}
+}
+
+// CreateSitemapItem handles sitemap item creation.
+func (h *Handler) CreateSitemapItem(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToCreateSitemapItemRequest(r, h.validator)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.service.CreateSitemapItemIfDoesNotAlreadyExist(r.Context(), request)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	_ = h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusCreated, response)
+}
+
+// MassSitemapItemCreationByBatch handles batch sitemap item creation.
+func (h *Handler) MassSitemapItemCreationByBatch(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToMassSitemapItemCreationByBatchRequest(r, h.validator)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.service.MassSitemapItemCreationByBatch(r.Context(), request)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	_ = h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusCreated, response)
+}
+
+// GetSitemapItems handles listing sitemap items.
+func (h *Handler) GetSitemapItems(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGetSitemapItemsRequest(r, h.validator)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.service.GetSitemapItems(r.Context(), request)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	_ = h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response)
+}
+
+// UpdateSitemapItemByUri handles updating sitemap items by URI.
+func (h *Handler) UpdateSitemapItemByUri(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToUpdateSitemapItemRequest(r, h.validator)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.service.UpdateSitemapItemByUri(r.Context(), request)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	_ = h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response)
+}
+
+// DeleteEntriesWithUriRegex handles deleting sitemap entries whose URI matches a regex.
+func (h *Handler) DeleteEntriesWithUriRegex(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToDeleteEntriesWithURIRegexRequest(r, h.validator)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.service.DeleteEntriesWithUriRegex(r.Context(), request)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	_ = h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response)
+}
+
+// GenerateSitemap handles XML generation and optional file saves.
+func (h *Handler) GenerateSitemap(w http.ResponseWriter, r *http.Request) {
+	request, err := MapRequestToGenerateSitemapRequest(r, h.validator)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.service.GenerateSitemap(r.Context(), request)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	_ = h.getBaseResponseHandler().NewHTTPDataResponse(w, http.StatusOK, response)
+}
+
+// DownloadSitemapByPath handles admin sitemap downloads by path.
+func (h *Handler) DownloadSitemapByPath(w http.ResponseWriter, r *http.Request) {
+	h.writeSitemapFileResponse(w, r, true)
+}
+
+// GetSitemap handles the public sitemap endpoint.
+func (h *Handler) GetSitemap(w http.ResponseWriter, r *http.Request) {
+	h.writeSitemapFileResponse(w, r, false)
+}
+
+func (h *Handler) writeSitemapFileResponse(w http.ResponseWriter, r *http.Request, attachment bool) {
+	request, err := MapRequestToDownloadSitemapByPathRequest(r, h.validator)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	response, err := h.service.DownloadSitemapByPath(r.Context(), request)
+	if err != nil {
+		_ = h.getBaseResponseHandler().NewHTTPErrorResponse(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", response.ContentType)
+	if attachment {
+		w.Header().Set("Content-Disposition", `attachment; filename="`+response.FileName+`"`)
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(response.Content)
+}
+
+func (h *Handler) getBaseResponseHandler() *reply.Replier {
+	return reply.NewReplier(
+		errormanifest.NewComposer().
+			Add(SitemapErrorMap).
+			AddOverrides(h.errorMaps...).
+			Build(),
+	)
+}

--- a/external/seo/migrations/indexes_sitemap_items.go
+++ b/external/seo/migrations/indexes_sitemap_items.go
@@ -1,0 +1,54 @@
+package migrations
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/seo"
+	"github.com/ooaklee/ghatd/external/toolbox"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const sitemapItemsURIIndexName = "sitemap_items_uri_unique"
+
+// InitSitemapItemIndexesUp creates indexes needed by sitemap item persistence.
+func InitSitemapItemIndexesUp(db *mongo.Database) error {
+	ctx := context.Background()
+	collection := db.Collection(seo.SitemapItemsCollection)
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "starting-task-to-create-sitemap-item-indexes"))
+
+	_, err := collection.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "uri", Value: 1}},
+		Options: options.Index().
+			SetName(sitemapItemsURIIndexName).
+			SetUnique(true).
+			SetSparse(true),
+	})
+	if err != nil {
+		log.Default().Println(toolbox.OutputBasicLogString("error", "failed-to-create-sitemap-item-uri-index"))
+		return err
+	}
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "completed-task-to-create-sitemap-item-indexes"))
+	return nil
+}
+
+// InitSitemapItemIndexesDown removes indexes created for sitemap item persistence.
+func InitSitemapItemIndexesDown(db *mongo.Database) error {
+	ctx := context.Background()
+	collection := db.Collection(seo.SitemapItemsCollection)
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "rolling-back-task-to-create-sitemap-item-indexes"))
+
+	if _, err := collection.Indexes().DropOne(ctx, sitemapItemsURIIndexName); err != nil && !strings.Contains(err.Error(), "index not found") {
+		log.Default().Println(toolbox.OutputBasicLogString("error", "failed-to-drop-sitemap-item-uri-index"))
+		return err
+	}
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "completed-rolling-back-task-to-create-sitemap-item-indexes"))
+	return nil
+}

--- a/external/seo/migrations/seed_default_sitemap_items.go
+++ b/external/seo/migrations/seed_default_sitemap_items.go
@@ -1,0 +1,217 @@
+package migrations
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/ooaklee/ghatd/external/seo"
+	"github.com/ooaklee/ghatd/external/toolbox"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const defaultIdentityTagSystem = "system"
+
+// Paths customises the default sitemap URI seed list.
+// These will be normalised and deduplicated against the defaults and each other.
+// If any normalised path matches a default, the default will be used (i.e. normalisation is applied before deduplication).
+// Normalisation includes trimming whitespace, ensuring a leading slash, and removing any trailing slash (except for the root path).
+//
+// Defaults:
+//   - /
+//   - /blog
+//   - /pricing
+//   - /faq
+//   - /whats-new
+//   - /policy/privacy
+//   - /policy/terms
+//   - /policy/cookies
+//   - /policy/security-and-compliance
+//   - /about
+//   - /contact
+//   - /for-business
+//   - /glossary
+type Paths struct {
+
+	// Add is a list of additional URIs to seed beyond the defaults.
+	Add []string
+
+	// Remove is a list of URIs to exclude from seeding, even if they are in the defaults or additions.
+	Remove []string
+}
+
+var defaultSitemapItemPaths = []string{
+	"/",
+	"/blog",
+	"/pricing",
+	"/faq",
+	"/whats-new",
+	"/policy/privacy",
+	"/policy/terms",
+	"/policy/cookies",
+	"/policy/security-and-compliance",
+	"/about",
+	"/contact",
+	"/for-business",
+	"/glossary",
+}
+
+// ResolveDefaultSitemapItemPaths returns the default URI list with additions and removals applied.
+func ResolveDefaultSitemapItemPaths(paths Paths) []string {
+	removed := map[string]struct{}{}
+	for _, uri := range paths.Remove {
+		if normalised := normaliseSitemapSeedPath(uri); normalised != "" {
+			removed[normalised] = struct{}{}
+		}
+	}
+
+	seen := map[string]struct{}{}
+	resolved := make([]string, 0, len(defaultSitemapItemPaths)+len(paths.Add))
+	for _, uri := range append(defaultSitemapItemPaths, paths.Add...) {
+		normalised := normaliseSitemapSeedPath(uri)
+		if normalised == "" {
+			continue
+		}
+		if _, shouldRemove := removed[normalised]; shouldRemove {
+			continue
+		}
+		if _, alreadySeen := seen[normalised]; alreadySeen {
+			continue
+		}
+
+		seen[normalised] = struct{}{}
+		resolved = append(resolved, normalised)
+	}
+
+	return resolved
+}
+
+// InitDefaultSitemapItemsUp seeds the default public sitemap entries.
+func InitDefaultSitemapItemsUp(db *mongo.Database) error {
+	return InitDefaultSitemapItemsUpWithPaths(Paths{})(db)
+}
+
+// InitDefaultSitemapItemsDown removes the default public sitemap entries.
+func InitDefaultSitemapItemsDown(db *mongo.Database) error {
+	return InitDefaultSitemapItemsDownWithPaths(Paths{})(db)
+}
+
+// InitDefaultSitemapItemsUpWithPaths returns an up migration with optional path customisations.
+func InitDefaultSitemapItemsUpWithPaths(paths Paths) func(db *mongo.Database) error {
+	return func(db *mongo.Database) error {
+		return initDefaultSitemapItemsUp(db, paths)
+	}
+}
+
+// InitDefaultSitemapItemsDownWithPaths returns a down migration with optional path customisations.
+func InitDefaultSitemapItemsDownWithPaths(paths Paths) func(db *mongo.Database) error {
+	return func(db *mongo.Database) error {
+		return initDefaultSitemapItemsDown(db, paths)
+	}
+}
+
+func initDefaultSitemapItemsUp(db *mongo.Database, paths Paths) error {
+	ctx := context.Background()
+	collection := db.Collection(seo.SitemapItemsCollection)
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "starting-task-to-seed-default-sitemap-items"))
+
+	now := toolbox.TimeNowUTC()
+	for _, uri := range ResolveDefaultSitemapItemPaths(paths) {
+		_, err := collection.UpdateOne(
+			ctx,
+			bson.M{"uri": uri},
+			bson.M{
+				"$setOnInsert": bson.M{
+					"_id":              toolbox.GenerateUuidV4(),
+					"uri":              uri,
+					"last_mod":         now,
+					"priority":         DefaultSitemapItemPriority(uri),
+					"change_frequency": DefaultSitemapItemChangeFrequency(uri),
+					"created_by_id":    defaultIdentityTagSystem,
+					"created_at":       now,
+				},
+			},
+			options.Update().SetUpsert(true),
+		)
+		if err != nil {
+			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-to-seed-default-sitemap-item: "+uri))
+			return err
+		}
+	}
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "completed-task-to-seed-default-sitemap-items"))
+	return nil
+}
+
+func initDefaultSitemapItemsDown(db *mongo.Database, paths Paths) error {
+	ctx := context.Background()
+	collection := db.Collection(seo.SitemapItemsCollection)
+	uris := ResolveDefaultSitemapItemPaths(paths)
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "rolling-back-task-to-seed-default-sitemap-items"))
+
+	if len(uris) == 0 {
+		log.Default().Println(toolbox.OutputBasicLogString("info", "completed-rolling-back-task-to-seed-default-sitemap-items"))
+		return nil
+	}
+
+	if _, err := collection.DeleteMany(ctx, bson.M{"uri": bson.M{"$in": uris}}); err != nil {
+		log.Default().Println(toolbox.OutputBasicLogString("error", "failed-to-remove-default-sitemap-items"))
+		return err
+	}
+
+	log.Default().Println(toolbox.OutputBasicLogString("info", "completed-rolling-back-task-to-seed-default-sitemap-items"))
+	return nil
+}
+
+func normaliseSitemapSeedPath(uri string) string {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return ""
+	}
+	if !strings.HasPrefix(uri, "/") {
+		uri = "/" + uri
+	}
+	if uri != "/" {
+		uri = strings.TrimRight(uri, "/")
+	}
+
+	return uri
+}
+
+// DefaultSitemapItemPriority returns the starter priority for a public route.
+func DefaultSitemapItemPriority(uri string) float64 {
+	switch uri {
+	case "/":
+		return 1.0
+	case "/pricing", "/contact", "/for-business":
+		return 0.9
+	case "/blog", "/faq", "/whats-new", "/about":
+		return 0.8
+	case "/glossary":
+		return 0.7
+	default:
+		if strings.HasPrefix(uri, "/policy/") {
+			return 0.4
+		}
+		return 0.5
+	}
+}
+
+// DefaultSitemapItemChangeFrequency returns the starter change frequency for a public route.
+func DefaultSitemapItemChangeFrequency(uri string) seo.ChangeFrequency {
+	switch uri {
+	case "/blog", "/whats-new":
+		return seo.ChangeFrequencyWeekly
+	case "/":
+		return seo.ChangeFrequencyWeekly
+	default:
+		if strings.HasPrefix(uri, "/policy/") {
+			return seo.ChangeFrequencyYearly
+		}
+		return seo.ChangeFrequencyMonthly
+	}
+}

--- a/external/seo/migrations/seed_default_sitemap_items_test.go
+++ b/external/seo/migrations/seed_default_sitemap_items_test.go
@@ -1,0 +1,122 @@
+package migrations
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveDefaultSitemapItemPaths(t *testing.T) {
+	got := ResolveDefaultSitemapItemPaths(Paths{
+		Add:    []string{"/extra", "extra", "/policy/privacy"},
+		Remove: []string{"/blog"},
+	})
+
+	want := []string{
+		"/",
+		"/pricing",
+		"/faq",
+		"/whats-new",
+		"/policy/privacy",
+		"/policy/terms",
+		"/policy/cookies",
+		"/policy/security-and-compliance",
+		"/about",
+		"/contact",
+		"/for-business",
+		"/glossary",
+		"/extra",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveDefaultSitemapItemPaths() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveDefaultSitemapItemPathsZeroValue(t *testing.T) {
+	got := ResolveDefaultSitemapItemPaths(Paths{})
+
+	if !reflect.DeepEqual(got, defaultSitemapItemPaths) {
+		t.Fatalf("ResolveDefaultSitemapItemPaths() = %#v, want %#v", got, defaultSitemapItemPaths)
+	}
+}
+
+func TestResolveDefaultSitemapItemPathsRemoveWinsOverAdd(t *testing.T) {
+	remove := append([]string{}, defaultSitemapItemPaths...)
+	remove = append(remove, "extra")
+
+	got := ResolveDefaultSitemapItemPaths(Paths{
+		Add:    []string{"/extra/", "/kept/"},
+		Remove: remove,
+	})
+
+	want := []string{"/kept"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveDefaultSitemapItemPaths() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveDefaultSitemapItemPathsCanRemoveAllDefaults(t *testing.T) {
+	got := ResolveDefaultSitemapItemPaths(Paths{
+		Remove: defaultSitemapItemPaths,
+	})
+
+	if len(got) != 0 {
+		t.Fatalf("ResolveDefaultSitemapItemPaths() = %#v, want empty", got)
+	}
+}
+
+func TestNormaliseSitemapSeedPath(t *testing.T) {
+	tests := map[string]string{
+		"":         "",
+		"   ":      "",
+		"/":        "/",
+		"blog":     "/blog",
+		" /blog/ ": "/blog",
+		"/faq/":    "/faq",
+	}
+
+	for input, want := range tests {
+		if got := normaliseSitemapSeedPath(input); got != want {
+			t.Fatalf("normaliseSitemapSeedPath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestDefaultSitemapItemPriority(t *testing.T) {
+	tests := map[string]float64{
+		"/":                               1.0,
+		"/pricing":                        0.9,
+		"/contact":                        0.9,
+		"/for-business":                   0.9,
+		"/blog":                           0.8,
+		"/faq":                            0.8,
+		"/whats-new":                      0.8,
+		"/about":                          0.8,
+		"/glossary":                       0.7,
+		"/policy/privacy":                 0.4,
+		"/policy/security-and-compliance": 0.4,
+		"/unexpected":                     0.5,
+	}
+
+	for uri, want := range tests {
+		if got := DefaultSitemapItemPriority(uri); got != want {
+			t.Fatalf("DefaultSitemapItemPriority(%q) = %v, want %v", uri, got, want)
+		}
+	}
+}
+
+func TestInitDefaultSitemapItemsWithPathsReturnsMigrationCallbacks(t *testing.T) {
+	up := InitDefaultSitemapItemsUpWithPaths(Paths{
+		Add: []string{"/extra"},
+	})
+	down := InitDefaultSitemapItemsDownWithPaths(Paths{
+		Remove: []string{"/blog"},
+	})
+
+	if up == nil {
+		t.Fatal("InitDefaultSitemapItemsUpWithPaths() returned nil")
+	}
+	if down == nil {
+		t.Fatal("InitDefaultSitemapItemsDownWithPaths() returned nil")
+	}
+}

--- a/external/seo/model.go
+++ b/external/seo/model.go
@@ -1,0 +1,218 @@
+package seo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ooaklee/ghatd/external/toolbox"
+)
+
+// ChangeFrequency is a sitemap changefreq value stored and rendered lowercase.
+type ChangeFrequency string
+
+// SitemapItem is a stored URL entry used to generate sitemap XML.
+type SitemapItem struct {
+	ID              string          `json:"id" bson:"_id"`
+	URI             string          `json:"uri" bson:"uri"`
+	LastMod         string          `json:"last_mod" bson:"last_mod"`
+	Priority        float64         `json:"priority" bson:"priority"`
+	ChangeFrequency ChangeFrequency `json:"change_frequency" bson:"change_frequency"`
+	CreatedByID     string          `json:"created_by_id,omitempty" bson:"created_by_id,omitempty"`
+	CreatedAt       string          `json:"created_at,omitempty" bson:"created_at,omitempty"`
+	UpdatedAt       string          `json:"updated_at,omitempty" bson:"updated_at,omitempty"`
+	UpdatedByID     string          `json:"updated_by_id,omitempty" bson:"updated_by_id,omitempty"`
+}
+
+// NewSitemapItem returns a normalised sitemap item with defaults.
+func NewSitemapItem(req *CreateSitemapItemRequest) *SitemapItem {
+	if req == nil {
+		return &SitemapItem{
+			Priority:        defaultSitemapPriority,
+			ChangeFrequency: ChangeFrequencyWeekly,
+		}
+	}
+
+	priority := defaultSitemapPriority
+	if req.Priority != nil {
+		priority = *req.Priority
+	}
+
+	return &SitemapItem{
+		URI:             normaliseSitemapURI(req.URI),
+		LastMod:         strings.TrimSpace(req.LastMod),
+		Priority:        priority,
+		ChangeFrequency: NormaliseChangeFrequency(req.ChangeFrequency),
+		CreatedByID:     strings.TrimSpace(req.CreatedByID),
+	}
+}
+
+// GenerateID creates a UUID for the sitemap item.
+func (s *SitemapItem) GenerateID() *SitemapItem {
+	s.ID = toolbox.GenerateUuidV4()
+	return s
+}
+
+// SetCreatedAtTimeToNow sets the created timestamp to the platform UTC format.
+func (s *SitemapItem) SetCreatedAtTimeToNow() *SitemapItem {
+	s.CreatedAt = toolbox.TimeNowUTC()
+	return s
+}
+
+// SetUpdatedAtTimeToNow sets the updated timestamp to the platform UTC format.
+func (s *SitemapItem) SetUpdatedAtTimeToNow() *SitemapItem {
+	s.UpdatedAt = toolbox.TimeNowUTC()
+	return s
+}
+
+// LastModForXML converts the platform UTC timestamp into the sitemap timestamp format.
+func (s SitemapItem) LastModForXML() (string, error) {
+	return formatSitemapTimestamp(s.LastMod)
+}
+
+// FormatPriority renders priority without losing precision, while preserving 1.0 style values.
+func (s SitemapItem) FormatPriority() string {
+	formatted := strconv.FormatFloat(s.Priority, 'f', -1, 64)
+	if !strings.Contains(formatted, ".") {
+		return formatted + ".0"
+	}
+	return formatted
+}
+
+// IsValid reports whether the change frequency is supported by the sitemap package.
+func (c ChangeFrequency) IsValid() bool {
+	switch c {
+	case ChangeFrequencyAlways,
+		ChangeFrequencyHourly,
+		ChangeFrequencyDaily,
+		ChangeFrequencyWeekly,
+		ChangeFrequencyMonthly,
+		ChangeFrequencyYearly,
+		ChangeFrequencyNever:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the lowercase change frequency value.
+func (c ChangeFrequency) String() string {
+	return string(c)
+}
+
+// MarshalJSON renders the lowercase change frequency value.
+func (c ChangeFrequency) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
+}
+
+// UnmarshalJSON normalises supported change frequency values from JSON.
+func (c *ChangeFrequency) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*c = NormaliseChangeFrequency(raw)
+	return nil
+}
+
+// NormaliseChangeFrequency trims and lowercases a change frequency value.
+func NormaliseChangeFrequency(value interface{}) ChangeFrequency {
+	return ChangeFrequency(strings.ToLower(strings.TrimSpace(fmt.Sprint(value))))
+}
+
+func validateSitemapItem(item *SitemapItem) error {
+	if item == nil {
+		return ErrSitemapItemError
+	}
+
+	item.URI = normaliseSitemapURI(item.URI)
+	if item.URI == "" {
+		return ErrSitemapItemURIIsRequired
+	}
+	if err := validateSitemapURI(item.URI); err != nil {
+		return err
+	}
+	if item.Priority < 0 || item.Priority > 1 {
+		return ErrSitemapItemInvalidPriority
+	}
+	if item.ChangeFrequency == "" {
+		item.ChangeFrequency = ChangeFrequencyWeekly
+	}
+	if !item.ChangeFrequency.IsValid() {
+		return ErrSitemapItemInvalidChangeFrequency
+	}
+	if item.LastMod == "" {
+		item.LastMod = toolbox.TimeNowUTC()
+	}
+	if _, err := formatSitemapTimestamp(item.LastMod); err != nil {
+		return ErrSitemapItemInvalidLastMod
+	}
+
+	return nil
+}
+
+func normaliseSitemapURI(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		return value
+	}
+
+	if !strings.HasPrefix(value, "/") {
+		value = "/" + value
+	}
+
+	return value
+}
+
+func validateSitemapURI(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return ErrSitemapItemInvalidURI
+	}
+	if parsed.IsAbs() {
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return ErrSitemapItemInvalidURI
+		}
+		if parsed.Host == "" {
+			return ErrSitemapItemInvalidURI
+		}
+		return nil
+	}
+	if !strings.HasPrefix(value, "/") || strings.HasPrefix(value, "//") {
+		return ErrSitemapItemInvalidURI
+	}
+	return nil
+}
+
+func formatSitemapTimestamp(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = toolbox.TimeNowUTC()
+	}
+
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	}
+
+	var parsed time.Time
+	var err error
+	for _, layout := range layouts {
+		parsed, err = time.Parse(layout, value)
+		if err == nil {
+			return parsed.UTC().Format("2006-01-02T15:04:05+00:00"), nil
+		}
+	}
+
+	return "", err
+}

--- a/external/seo/model_test.go
+++ b/external/seo/model_test.go
@@ -1,0 +1,54 @@
+package seo
+
+import "testing"
+
+func TestSitemapItemLastModForXML(t *testing.T) {
+	item := SitemapItem{LastMod: "2026-02-21T11:00:00.123456789"}
+
+	got, err := item.LastModForXML()
+	if err != nil {
+		t.Fatalf("LastModForXML() error = %v", err)
+	}
+
+	if got != "2026-02-21T11:00:00+00:00" {
+		t.Fatalf("LastModForXML() = %s, want sitemap UTC timestamp", got)
+	}
+}
+
+func TestChangeFrequencyNormalisesAndValidates(t *testing.T) {
+	got := NormaliseChangeFrequency(" Weekly ")
+	if got != ChangeFrequencyWeekly {
+		t.Fatalf("NormaliseChangeFrequency() = %s, want weekly", got)
+	}
+	if !got.IsValid() {
+		t.Fatal("weekly should be valid")
+	}
+	if NormaliseChangeFrequency("sometimes").IsValid() {
+		t.Fatal("unexpected valid change frequency")
+	}
+}
+
+func TestNewSitemapItemDefaultsPriorityToPointFive(t *testing.T) {
+	item := NewSitemapItem(&CreateSitemapItemRequest{
+		URI:             "/policy/terms",
+		LastMod:         "2026-02-21T11:00:00",
+		ChangeFrequency: ChangeFrequencyWeekly,
+	})
+
+	if item.Priority != 0.5 {
+		t.Fatalf("NewSitemapItem() priority = %v, want 0.5", item.Priority)
+	}
+}
+
+func TestValidateSitemapItemRejectsInvalidPriority(t *testing.T) {
+	item := &SitemapItem{
+		URI:             "/blog/example",
+		LastMod:         "2026-02-21T11:00:00",
+		Priority:        1.2,
+		ChangeFrequency: ChangeFrequencyWeekly,
+	}
+
+	if err := validateSitemapItem(item); err != ErrSitemapItemInvalidPriority {
+		t.Fatalf("validateSitemapItem() error = %v, want ErrSitemapItemInvalidPriority", err)
+	}
+}

--- a/external/seo/repository.go
+++ b/external/seo/repository.go
@@ -1,0 +1,277 @@
+package seo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const defaultCollectionInitMaxAttemptsLimit = 3
+
+// MongoDbStore represents the datastore methods needed by seo.
+type MongoDbStore interface {
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
+	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
+	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
+
+	GetDatabase(ctx context.Context, dbName string) (*mongo.Database, error)
+	InitialiseClient(ctx context.Context) (*mongo.Client, error)
+	MapAllInCursorToResult(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error
+}
+
+// Repository handles sitemap item data persistence.
+type Repository struct {
+	Store                          MongoDbStore
+	collectionInitMaxAttemptsLimit int
+
+	collection      *mongo.Collection
+	collectionMutex sync.Mutex
+}
+
+// NewRepository creates a new sitemap repository.
+func NewRepository(store MongoDbStore) *Repository {
+	return &Repository{
+		Store:                          store,
+		collectionInitMaxAttemptsLimit: defaultCollectionInitMaxAttemptsLimit,
+	}
+}
+
+// WithCollectionInitMaxAttemptsLimit overrides collection initialisation attempts.
+func (r *Repository) WithCollectionInitMaxAttemptsLimit(limit int) *Repository {
+	if limit > 0 {
+		r.collectionInitMaxAttemptsLimit = limit
+	}
+	return r
+}
+
+// GetSitemapItemsCollection returns the collection used for sitemap item records.
+func (r *Repository) GetSitemapItemsCollection(ctx context.Context) (*mongo.Collection, error) {
+	r.collectionMutex.Lock()
+	defer r.collectionMutex.Unlock()
+
+	if r.collection != nil {
+		return r.collection, nil
+	}
+
+	var lastErr error
+	limit := r.collectionInitMaxAttemptsLimit
+	if limit <= 0 {
+		limit = defaultCollectionInitMaxAttemptsLimit
+	}
+
+	for attempt := 1; attempt <= limit; attempt++ {
+		_, err := r.Store.InitialiseClient(ctx)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		db, err := r.Store.GetDatabase(ctx, "")
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		r.collection = db.Collection(SitemapItemsCollection)
+		return r.collection, nil
+	}
+
+	return nil, fmt.Errorf("%w: unable to initialise %s collection after %d attempts: %w", ErrSitemapItemDatabaseError, SitemapItemsCollection, limit, lastErr)
+}
+
+// CreateSitemapItem creates a new sitemap item.
+func (r *Repository) CreateSitemapItem(ctx context.Context, item *SitemapItem) (*SitemapItem, error) {
+	collection, err := r.GetSitemapItemsCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = r.Store.ExecuteInsertOneCommand(ctx, collection, item, "sitemap item"); err != nil {
+		return nil, err
+	}
+
+	return item, nil
+}
+
+// GetSitemapItemByURI retrieves a sitemap item by URI.
+func (r *Repository) GetSitemapItemByURI(ctx context.Context, uri string) (*SitemapItem, error) {
+	collection, err := r.GetSitemapItemsCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var result SitemapItem
+	err = r.Store.ExecuteFindOneCommandDecodeResult(ctx, collection, bson.M{"uri": normaliseSitemapURI(uri)}, &result, "sitemap item", true, ErrSitemapItemResourceNotFound)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetLatestSitemapItemByURIRegex retrieves the newest sitemap item whose URI matches the given regex.
+func (r *Repository) GetLatestSitemapItemByURIRegex(ctx context.Context, uriRegex string) (*SitemapItem, error) {
+	collection, err := r.GetSitemapItemsCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	findOptions := options.FindOne().SetSort(bson.D{
+		{Key: "last_mod", Value: -1},
+		{Key: "created_at", Value: -1},
+	})
+
+	var result SitemapItem
+	err = collection.FindOne(ctx, bson.M{"uri": bson.M{"$regex": uriRegex}}, findOptions).Decode(&result)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrSitemapItemResourceNotFound
+		}
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetSitemapItems retrieves sitemap items by filter.
+func (r *Repository) GetSitemapItems(ctx context.Context, req *GetSitemapItemsRequest) ([]SitemapItem, error) {
+	collection, err := r.GetSitemapItemsCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	findOptions := options.Find().SetSort(bson.D{{Key: "uri", Value: 1}})
+	page, pageSize := normalisePagination(req)
+	if pageSize > 0 {
+		findOptions.SetLimit(pageSize)
+		findOptions.SetSkip((page - 1) * pageSize)
+	}
+
+	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, buildSitemapItemListFilter(req), findOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []SitemapItem
+	if err = r.Store.MapAllInCursorToResult(ctx, cursor, &result, "sitemap items"); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetAllSitemapItems returns all sitemap items for XML generation.
+func (r *Repository) GetAllSitemapItems(ctx context.Context) ([]SitemapItem, error) {
+	return r.GetSitemapItems(ctx, &GetSitemapItemsRequest{})
+}
+
+// GetTotalSitemapItems counts sitemap items by filter.
+func (r *Repository) GetTotalSitemapItems(ctx context.Context, req *GetSitemapItemsRequest) (int64, error) {
+	collection, err := r.GetSitemapItemsCollection(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return r.Store.ExecuteCountDocuments(ctx, collection, buildSitemapItemListFilter(req))
+}
+
+// UpdateSitemapItemByURI updates an existing sitemap item by URI.
+func (r *Repository) UpdateSitemapItemByURI(ctx context.Context, item *SitemapItem) (*SitemapItem, error) {
+	collection, err := r.GetSitemapItemsCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = r.Store.ExecuteUpdateOneCommand(ctx, collection, bson.M{"uri": item.URI}, bson.M{"$set": item}, "sitemap item"); err != nil {
+		return nil, err
+	}
+
+	return item, nil
+}
+
+// UpsertSitemapItemByURI creates or replaces a sitemap item by URI.
+func (r *Repository) UpsertSitemapItemByURI(ctx context.Context, item *SitemapItem) (*SitemapItem, bool, error) {
+	collection, err := r.GetSitemapItemsCollection(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"uri":              item.URI,
+			"last_mod":         item.LastMod,
+			"priority":         item.Priority,
+			"change_frequency": item.ChangeFrequency,
+			"created_by_id":    item.CreatedByID,
+			"updated_at":       item.UpdatedAt,
+			"updated_by_id":    item.UpdatedByID,
+		},
+		"$setOnInsert": bson.M{
+			"_id":        item.ID,
+			"created_at": item.CreatedAt,
+		},
+	}
+
+	result, err := collection.UpdateOne(ctx, bson.M{"uri": item.URI}, update, options.Update().SetUpsert(true))
+	if err != nil {
+		return nil, false, err
+	}
+
+	created := result.UpsertedCount > 0
+	return item, created, nil
+}
+
+// DeleteSitemapItemsByURIs deletes sitemap items matching exact URIs.
+func (r *Repository) DeleteSitemapItemsByURIs(ctx context.Context, uris []string) error {
+	if len(uris) == 0 {
+		return nil
+	}
+
+	collection, err := r.GetSitemapItemsCollection(ctx)
+	if err != nil {
+		return err
+	}
+
+	return r.Store.ExecuteDeleteManyCommand(ctx, collection, bson.M{"uri": bson.M{"$in": uris}}, "sitemap items")
+}
+
+func buildSitemapItemListFilter(req *GetSitemapItemsRequest) bson.M {
+	filter := bson.M{"_id": bson.M{"$exists": true}}
+	if req == nil {
+		return filter
+	}
+
+	if query := strings.TrimSpace(req.Query); query != "" {
+		filter["uri"] = bson.M{"$regex": regexp.QuoteMeta(query), "$options": "i"}
+	}
+
+	return filter
+}
+
+func normalisePagination(req *GetSitemapItemsRequest) (int64, int64) {
+	if req == nil {
+		return 1, 0
+	}
+
+	page := req.Page
+	if page <= 0 {
+		page = 1
+	}
+
+	pageSize := req.PageSize
+	if pageSize < 0 {
+		pageSize = 0
+	}
+
+	return page, pageSize
+}

--- a/external/seo/request.go
+++ b/external/seo/request.go
@@ -1,0 +1,57 @@
+package seo
+
+// CreateSitemapItemRequest holds data needed to create a sitemap item.
+type CreateSitemapItemRequest struct {
+	URI             string          `json:"uri"`
+	LastMod         string          `json:"last_mod"`
+	Priority        *float64        `json:"priority,omitempty"`
+	ChangeFrequency ChangeFrequency `json:"change_frequency"`
+	CreatedByID     string          `json:"created_by_id,omitempty"`
+}
+
+// UpdateSitemapItemRequest holds data needed to update a sitemap item by URI.
+type UpdateSitemapItemRequest struct {
+	URI             string           `json:"uri"`
+	LastMod         string           `json:"last_mod,omitempty"`
+	Priority        *float64         `json:"priority,omitempty"`
+	ChangeFrequency *ChangeFrequency `json:"change_frequency,omitempty"`
+	UpdatedByID     string           `json:"updated_by_id,omitempty"`
+}
+
+// GetSitemapItemsRequest holds filters for listing sitemap items.
+type GetSitemapItemsRequest struct {
+	Query    string `query:"query"`
+	Page     int64  `query:"page"`
+	PageSize int64  `query:"page_size"`
+}
+
+// GetSitemapItemByURIRequest holds data needed to retrieve a sitemap item.
+type GetSitemapItemByURIRequest struct {
+	URI string `query:"uri"`
+}
+
+// GetLatestSitemapItemByURIRegexRequest holds data needed to retrieve the latest sitemap item matching a URI regex.
+type GetLatestSitemapItemByURIRegexRequest struct {
+	URIRegex string `query:"uri_regex"`
+}
+
+// DeleteEntriesWithURIRegexRequest holds a safe Go regex used to delete matching sitemap item URIs.
+type DeleteEntriesWithURIRegexRequest struct {
+	URIRegex string `query:"uri_regex"`
+}
+
+// GenerateSitemapRequest holds options for generating sitemap XML.
+type GenerateSitemapRequest struct {
+	SaveToPaths []string `json:"save_to_paths" query:"save_to_paths"`
+}
+
+// DownloadSitemapByPathRequest holds options for downloading a sitemap file.
+type DownloadSitemapByPathRequest struct {
+	Path string `query:"path"`
+}
+
+// MassSitemapItemCreationByBatchRequest holds batch creation data.
+type MassSitemapItemCreationByBatchRequest struct {
+	Items            []CreateSitemapItemRequest `json:"items"`
+	OverrideIfExists bool                       `json:"override_if_exists"`
+}

--- a/external/seo/response.go
+++ b/external/seo/response.go
@@ -1,0 +1,43 @@
+package seo
+
+// SitemapItemResponse wraps a sitemap item.
+type SitemapItemResponse struct {
+	SitemapItem *SitemapItem `json:"sitemap_item"`
+	Created     bool         `json:"created,omitempty"`
+	Updated     bool         `json:"updated,omitempty"`
+}
+
+// GetSitemapItemsResponse wraps sitemap item list results.
+type GetSitemapItemsResponse struct {
+	SitemapItems []SitemapItem `json:"sitemap_items"`
+	Total        int64         `json:"total"`
+}
+
+// DeleteEntriesWithURIRegexResponse describes regex delete results.
+type DeleteEntriesWithURIRegexResponse struct {
+	Deleted int64    `json:"deleted"`
+	URIs    []string `json:"uris"`
+}
+
+// GenerateSitemapResponse describes generated XML and any saved files.
+type GenerateSitemapResponse struct {
+	XML        string   `json:"xml"`
+	SavedPaths []string `json:"saved_paths,omitempty"`
+	Total      int      `json:"total"`
+}
+
+// DownloadSitemapByPathResponse wraps downloaded sitemap bytes.
+type DownloadSitemapByPathResponse struct {
+	Path        string
+	FileName    string
+	ContentType string
+	Content     []byte
+}
+
+// MassSitemapItemCreationByBatchResponse describes batch creation results.
+type MassSitemapItemCreationByBatchResponse struct {
+	SitemapItems []SitemapItem `json:"sitemap_items"`
+	Created      int           `json:"created"`
+	Updated      int           `json:"updated"`
+	Skipped      int           `json:"skipped"`
+}

--- a/external/seo/routes.go
+++ b/external/seo/routes.go
@@ -1,0 +1,47 @@
+package seo
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/ooaklee/ghatd/external/router"
+)
+
+// sitemapHandler expected methods for valid sitemap handler.
+type sitemapHandler interface {
+	CreateSitemapItem(w http.ResponseWriter, r *http.Request)
+	DeleteEntriesWithUriRegex(w http.ResponseWriter, r *http.Request)
+	DownloadSitemapByPath(w http.ResponseWriter, r *http.Request)
+	GenerateSitemap(w http.ResponseWriter, r *http.Request)
+	GetSitemap(w http.ResponseWriter, r *http.Request)
+	GetSitemapItems(w http.ResponseWriter, r *http.Request)
+	MassSitemapItemCreationByBatch(w http.ResponseWriter, r *http.Request)
+	UpdateSitemapItemByUri(w http.ResponseWriter, r *http.Request)
+}
+
+// AttachRoutesRequest holds everything needed to attach SEO routes.
+type AttachRoutesRequest struct {
+	Router              *router.Router
+	Handler             sitemapHandler
+	AdminOnlyMiddleware mux.MiddlewareFunc
+}
+
+// AttachRoutes attaches sitemap handler routes to the router.
+func AttachRoutes(request *AttachRoutesRequest) {
+	httpRouter := request.Router.GetRouter()
+
+	httpRouter.HandleFunc(PublicSitemapPath, request.Handler.GetSitemap).Methods(http.MethodGet, http.MethodOptions)
+
+	adminRoutes := httpRouter.PathPrefix(APISEOPrefix).Subrouter()
+	adminRoutes.HandleFunc("/sitemap-items", request.Handler.CreateSitemapItem).Methods(http.MethodPost, http.MethodOptions)
+	adminRoutes.HandleFunc("/sitemap-items", request.Handler.GetSitemapItems).Methods(http.MethodGet, http.MethodOptions)
+	adminRoutes.HandleFunc("/sitemap-items", request.Handler.UpdateSitemapItemByUri).Methods(http.MethodPatch, http.MethodOptions)
+	adminRoutes.HandleFunc("/sitemap-items", request.Handler.DeleteEntriesWithUriRegex).Methods(http.MethodDelete, http.MethodOptions)
+	adminRoutes.HandleFunc("/sitemap-items/batch", request.Handler.MassSitemapItemCreationByBatch).Methods(http.MethodPost, http.MethodOptions)
+	adminRoutes.HandleFunc("/sitemap.xml/generate", request.Handler.GenerateSitemap).Methods(http.MethodPost, http.MethodOptions)
+	adminRoutes.HandleFunc("/sitemap.xml/download", request.Handler.DownloadSitemapByPath).Methods(http.MethodGet, http.MethodOptions)
+
+	if request.AdminOnlyMiddleware != nil {
+		adminRoutes.Use(request.AdminOnlyMiddleware)
+	}
+}

--- a/external/seo/service.go
+++ b/external/seo/service.go
@@ -1,0 +1,566 @@
+package seo
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"io/fs"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// SitemapRepository defines the repository surface used by the service.
+type SitemapRepository interface {
+	CreateSitemapItem(ctx context.Context, item *SitemapItem) (*SitemapItem, error)
+	DeleteSitemapItemsByURIs(ctx context.Context, uris []string) error
+	GetAllSitemapItems(ctx context.Context) ([]SitemapItem, error)
+	GetLatestSitemapItemByURIRegex(ctx context.Context, uriRegex string) (*SitemapItem, error)
+	GetSitemapItemByURI(ctx context.Context, uri string) (*SitemapItem, error)
+	GetSitemapItems(ctx context.Context, req *GetSitemapItemsRequest) ([]SitemapItem, error)
+	GetTotalSitemapItems(ctx context.Context, req *GetSitemapItemsRequest) (int64, error)
+	UpdateSitemapItemByURI(ctx context.Context, item *SitemapItem) (*SitemapItem, error)
+	UpsertSitemapItemByURI(ctx context.Context, item *SitemapItem) (*SitemapItem, bool, error)
+}
+
+// Service holds and manages sitemap business logic.
+type Service struct {
+	SitemapRepository  SitemapRepository
+	FrontendDomain     string
+	FileSystem         fs.FS
+	EmbeddedPathPrefix string
+	WritableRootPath   string
+	DefaultPath        string
+
+	writeMutex sync.Mutex
+}
+
+// NewServiceRequest holds dependencies needed to initialise sitemap service.
+type NewServiceRequest struct {
+	SitemapRepository  SitemapRepository
+	FrontendDomain     string
+	FileSystem         fs.FS
+	EmbeddedPathPrefix string
+	WritableRootPath   string
+	DefaultPath        string
+}
+
+// NewService creates a sitemap service.
+func NewService(req *NewServiceRequest) *Service {
+	if req == nil {
+		req = &NewServiceRequest{}
+	}
+
+	defaultPath := strings.TrimSpace(req.DefaultPath)
+	if defaultPath == "" {
+		defaultPath = defaultSitemapPath
+	}
+
+	writableRootPath := strings.TrimSpace(req.WritableRootPath)
+	if writableRootPath == "" {
+		writableRootPath = defaultSitemapWritableRoot
+	}
+
+	return &Service{
+		SitemapRepository:  req.SitemapRepository,
+		FrontendDomain:     strings.TrimRight(strings.TrimSpace(req.FrontendDomain), "/"),
+		FileSystem:         req.FileSystem,
+		EmbeddedPathPrefix: strings.Trim(strings.TrimSpace(req.EmbeddedPathPrefix), "/"),
+		WritableRootPath:   writableRootPath,
+		DefaultPath:        defaultPath,
+	}
+}
+
+// DefaultSitemapPath returns the configured default sitemap path.
+func (s *Service) DefaultSitemapPath() string {
+	if strings.TrimSpace(s.DefaultPath) == "" {
+		return defaultSitemapPath
+	}
+	return s.DefaultPath
+}
+
+// CreateSitemapItemIfDoesNotAlreadyExist creates a sitemap item unless the URI already exists.
+func (s *Service) CreateSitemapItemIfDoesNotAlreadyExist(ctx context.Context, req *CreateSitemapItemRequest) (*SitemapItemResponse, error) {
+	item := NewSitemapItem(req)
+	if item.CreatedByID == "" {
+		item.CreatedByID = defaultIdentityTagSystem
+	}
+	if err := validateSitemapItem(item); err != nil {
+		return nil, err
+	}
+
+	existing, err := s.SitemapRepository.GetSitemapItemByURI(ctx, item.URI)
+	if err == nil {
+		return &SitemapItemResponse{SitemapItem: existing, Created: false}, nil
+	}
+	if !errors.Is(err, ErrSitemapItemResourceNotFound) {
+		return nil, err
+	}
+
+	item.GenerateID().SetCreatedAtTimeToNow()
+	created, err := s.SitemapRepository.CreateSitemapItem(ctx, item)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SitemapItemResponse{SitemapItem: created, Created: true}, nil
+}
+
+// MassSitemapItemCreationByBatch creates sitemap items in sequence with optional override.
+func (s *Service) MassSitemapItemCreationByBatch(ctx context.Context, req *MassSitemapItemCreationByBatchRequest) (*MassSitemapItemCreationByBatchResponse, error) {
+	if req == nil {
+		return nil, ErrSitemapItemError
+	}
+
+	prepared := make([]*SitemapItem, 0, len(req.Items))
+	for _, raw := range req.Items {
+		item := NewSitemapItem(&raw)
+		if item.CreatedByID == "" {
+			item.CreatedByID = defaultIdentityTagSystem
+		}
+		if err := validateSitemapItem(item); err != nil {
+			return nil, err
+		}
+		prepared = append(prepared, item)
+	}
+
+	response := &MassSitemapItemCreationByBatchResponse{}
+	for _, item := range prepared {
+		if req.OverrideIfExists {
+			item.GenerateID().SetCreatedAtTimeToNow().SetUpdatedAtTimeToNow()
+			upserted, created, err := s.SitemapRepository.UpsertSitemapItemByURI(ctx, item)
+			if err != nil {
+				return nil, err
+			}
+			response.SitemapItems = append(response.SitemapItems, *upserted)
+			if created {
+				response.Created++
+			} else {
+				response.Updated++
+			}
+			continue
+		}
+
+		created, err := s.CreateSitemapItemIfDoesNotAlreadyExist(ctx, &CreateSitemapItemRequest{
+			URI:             item.URI,
+			LastMod:         item.LastMod,
+			Priority:        &item.Priority,
+			ChangeFrequency: item.ChangeFrequency,
+			CreatedByID:     item.CreatedByID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		response.SitemapItems = append(response.SitemapItems, *created.SitemapItem)
+		if created.Created {
+			response.Created++
+		} else {
+			response.Skipped++
+		}
+	}
+
+	return response, nil
+}
+
+// GetLatestSitemapItemByURIRegex retrieves the newest sitemap item whose URI matches a safe regex.
+func (s *Service) GetLatestSitemapItemByURIRegex(ctx context.Context, req *GetLatestSitemapItemByURIRegexRequest) (*SitemapItemResponse, error) {
+	if req == nil || strings.TrimSpace(req.URIRegex) == "" {
+		return nil, ErrSitemapItemURIIsRequired
+	}
+
+	uriRegex := strings.TrimSpace(req.URIRegex)
+	if len(uriRegex) > maxSitemapURIRegexLength {
+		return nil, ErrSitemapItemInvalidURI
+	}
+	if _, err := regexp.Compile(uriRegex); err != nil {
+		return nil, ErrSitemapItemInvalidURI
+	}
+
+	item, err := s.SitemapRepository.GetLatestSitemapItemByURIRegex(ctx, uriRegex)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SitemapItemResponse{SitemapItem: item}, nil
+}
+
+// GetSitemapItems retrieves sitemap items by filter.
+func (s *Service) GetSitemapItems(ctx context.Context, req *GetSitemapItemsRequest) (*GetSitemapItemsResponse, error) {
+	items, err := s.SitemapRepository.GetSitemapItems(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	total, err := s.SitemapRepository.GetTotalSitemapItems(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetSitemapItemsResponse{SitemapItems: items, Total: total}, nil
+}
+
+// UpdateSitemapItemByUri updates mutable fields on a sitemap item.
+func (s *Service) UpdateSitemapItemByUri(ctx context.Context, req *UpdateSitemapItemRequest) (*SitemapItemResponse, error) {
+	if req == nil || normaliseSitemapURI(req.URI) == "" {
+		return nil, ErrSitemapItemURIIsRequired
+	}
+
+	current, err := s.SitemapRepository.GetSitemapItemByURI(ctx, req.URI)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.LastMod != "" {
+		current.LastMod = strings.TrimSpace(req.LastMod)
+	}
+	if req.Priority != nil {
+		current.Priority = *req.Priority
+	}
+	if req.ChangeFrequency != nil {
+		current.ChangeFrequency = NormaliseChangeFrequency(*req.ChangeFrequency)
+	}
+	current.UpdatedByID = strings.TrimSpace(req.UpdatedByID)
+	current.SetUpdatedAtTimeToNow()
+
+	if err = validateSitemapItem(current); err != nil {
+		return nil, err
+	}
+
+	updated, err := s.SitemapRepository.UpdateSitemapItemByURI(ctx, current)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SitemapItemResponse{SitemapItem: updated, Updated: true}, nil
+}
+
+// DeleteEntriesWithUriRegex deletes sitemap entries whose URI matches a safe Go regular expression.
+func (s *Service) DeleteEntriesWithUriRegex(ctx context.Context, req *DeleteEntriesWithURIRegexRequest) (*DeleteEntriesWithURIRegexResponse, error) {
+	if req == nil || strings.TrimSpace(req.URIRegex) == "" {
+		return nil, ErrSitemapItemURIIsRequired
+	}
+
+	uriRegex := strings.TrimSpace(req.URIRegex)
+	if len(uriRegex) > maxSitemapURIRegexLength {
+		return nil, ErrSitemapItemInvalidURI
+	}
+
+	matcher, err := regexp.Compile(uriRegex)
+	if err != nil {
+		return nil, ErrSitemapItemInvalidURI
+	}
+
+	items, err := s.SitemapRepository.GetAllSitemapItems(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	uris := make([]string, 0)
+	for _, item := range items {
+		if matcher.MatchString(item.URI) {
+			uris = append(uris, item.URI)
+		}
+	}
+
+	if err = s.SitemapRepository.DeleteSitemapItemsByURIs(ctx, uris); err != nil {
+		return nil, err
+	}
+
+	return &DeleteEntriesWithURIRegexResponse{Deleted: int64(len(uris)), URIs: uris}, nil
+}
+
+// GenerateSitemap generates sitemap XML from stored items and optionally saves it to paths.
+func (s *Service) GenerateSitemap(ctx context.Context, req *GenerateSitemapRequest) (*GenerateSitemapResponse, error) {
+	if strings.TrimSpace(s.FrontendDomain) == "" {
+		return nil, ErrSitemapFrontendDomainIsRequired
+	}
+
+	items, err := s.SitemapRepository.GetAllSitemapItems(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	generatedXML, err := s.GenerateXML(items)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GenerateSitemapResponse{XML: generatedXML, Total: strings.Count(generatedXML, "<url>")}
+	if req != nil {
+		for _, savePath := range req.SaveToPaths {
+			if strings.TrimSpace(savePath) == "" {
+				continue
+			}
+			if err = s.writeSitemapFile(savePath, []byte(generatedXML)); err != nil {
+				return nil, err
+			}
+			response.SavedPaths = append(response.SavedPaths, savePath)
+		}
+	}
+
+	return response, nil
+}
+
+// GenerateXML renders sitemap XML for the provided items.
+func (s *Service) GenerateXML(items []SitemapItem) (string, error) {
+	urls := make([]sitemapURLEntry, 0, len(items))
+	seenLocs := map[string]struct{}{}
+	for _, item := range items {
+		if shouldExcludeSitemapURI(item.URI) {
+			continue
+		}
+		if err := validateSitemapItem(&item); err != nil {
+			return "", err
+		}
+
+		lastMod, err := item.LastModForXML()
+		if err != nil {
+			return "", err
+		}
+
+		loc, err := s.buildLoc(item.URI)
+		if err != nil {
+			return "", err
+		}
+		if _, alreadySeen := seenLocs[loc]; alreadySeen {
+			continue
+		}
+		seenLocs[loc] = struct{}{}
+
+		urls = append(urls, sitemapURLEntry{
+			Loc:        loc,
+			LastMod:    lastMod,
+			ChangeFreq: item.ChangeFrequency.String(),
+			Priority:   item.FormatPriority(),
+		})
+	}
+	sort.Slice(urls, func(i, j int) bool {
+		return urls[i].Loc < urls[j].Loc
+	})
+
+	doc := sitemapURLSet{
+		Xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9",
+		URLs:  urls,
+	}
+
+	var buffer bytes.Buffer
+	buffer.WriteString(xml.Header)
+	encoder := xml.NewEncoder(&buffer)
+	if err := encoder.Encode(doc); err != nil {
+		return "", err
+	}
+	if err := encoder.Flush(); err != nil {
+		return "", err
+	}
+
+	return buffer.String(), nil
+}
+
+func shouldExcludeSitemapURI(uri string) bool {
+	uri = normaliseSitemapURI(uri)
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+
+	path := parsed.Path
+	if path == "" {
+		path = uri
+	}
+	path = strings.TrimRight(path, "/")
+	if path == "" {
+		path = "/"
+	}
+
+	excludedPrefixes := []string{
+		"/admin",
+		"/api",
+		"/app",
+		"/auth",
+		"/offline",
+		"/portal",
+		"/settings",
+	}
+	for _, prefix := range excludedPrefixes {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DownloadSitemapByPath returns sitemap file content from a safe local path or embedded fallback.
+func (s *Service) DownloadSitemapByPath(_ context.Context, req *DownloadSitemapByPathRequest) (*DownloadSitemapByPathResponse, error) {
+	requestedPath := s.DefaultSitemapPath()
+	if req != nil && strings.TrimSpace(req.Path) != "" {
+		requestedPath = req.Path
+	}
+
+	content, cleanPath, err := s.readSitemapFile(requestedPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DownloadSitemapByPathResponse{
+		Path:        cleanPath,
+		FileName:    path.Base(cleanPath),
+		ContentType: "application/xml; charset=utf-8",
+		Content:     content,
+	}, nil
+}
+
+func (s *Service) buildLoc(uri string) (string, error) {
+	uri = normaliseSitemapURI(uri)
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return "", ErrSitemapItemInvalidURI
+	}
+	if parsed.IsAbs() {
+		return parsed.String(), nil
+	}
+
+	base, err := url.Parse(strings.TrimRight(s.FrontendDomain, "/") + "/")
+	if err != nil || base.Scheme == "" || base.Host == "" {
+		return "", ErrSitemapFrontendDomainIsRequired
+	}
+
+	return base.ResolveReference(parsed).String(), nil
+}
+
+func (s *Service) readSitemapFile(requestedPath string) ([]byte, string, error) {
+	cleanPath, err := cleanSitemapPath(requestedPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	fullPath, err := s.resolveWritablePath(cleanPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	content, err := os.ReadFile(fullPath)
+	if err == nil {
+		return content, cleanPath, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, "", err
+	}
+	if s.FileSystem == nil {
+		return nil, "", err
+	}
+
+	embeddedPath := cleanPath
+	if s.EmbeddedPathPrefix != "" {
+		embeddedPath = path.Join(s.EmbeddedPathPrefix, cleanPath)
+	}
+
+	content, err = fs.ReadFile(s.FileSystem, embeddedPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return content, cleanPath, nil
+}
+
+func (s *Service) writeSitemapFile(requestedPath string, content []byte) error {
+	cleanPath, err := cleanSitemapPath(requestedPath)
+	if err != nil {
+		return err
+	}
+
+	fullPath, err := s.resolveWritablePath(cleanPath)
+	if err != nil {
+		return err
+	}
+
+	s.writeMutex.Lock()
+	defer s.writeMutex.Unlock()
+
+	if err = os.MkdirAll(filepath.Dir(fullPath), defaultSitemapDirectoryPerm); err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(fullPath), ".sitemap-*.xml")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err = tmpFile.Write(content); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err = tmpFile.Chmod(defaultSitemapFilePerm); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err = tmpFile.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, fullPath)
+}
+
+func (s *Service) resolveWritablePath(cleanPath string) (string, error) {
+	root := strings.TrimSpace(s.WritableRootPath)
+	if root == "" {
+		root = defaultSitemapWritableRoot
+	}
+
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+
+	fullPath := filepath.Join(absoluteRoot, filepath.FromSlash(cleanPath))
+	absoluteFullPath, err := filepath.Abs(fullPath)
+	if err != nil {
+		return "", err
+	}
+
+	if absoluteFullPath != absoluteRoot && !strings.HasPrefix(absoluteFullPath, absoluteRoot+string(os.PathSeparator)) {
+		return "", ErrSitemapPathIsInvalid
+	}
+
+	return absoluteFullPath, nil
+}
+
+func cleanSitemapPath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = defaultSitemapPath
+	}
+	if filepath.IsAbs(value) {
+		return "", ErrSitemapPathIsInvalid
+	}
+
+	cleaned := path.Clean(strings.TrimLeft(filepath.ToSlash(value), "/"))
+	if cleaned == "." || cleaned == "" || strings.HasPrefix(cleaned, "../") || cleaned == ".." {
+		return "", ErrSitemapPathIsInvalid
+	}
+
+	return cleaned, nil
+}
+
+type sitemapURLSet struct {
+	XMLName xml.Name          `xml:"urlset"`
+	Xmlns   string            `xml:"xmlns,attr"`
+	URLs    []sitemapURLEntry `xml:"url"`
+}
+
+type sitemapURLEntry struct {
+	Loc        string `xml:"loc"`
+	LastMod    string `xml:"lastmod"`
+	ChangeFreq string `xml:"changefreq"`
+	Priority   string `xml:"priority"`
+}

--- a/external/seo/service_test.go
+++ b/external/seo/service_test.go
@@ -1,0 +1,285 @@
+package seo
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+type fakeSitemapRepository struct {
+	items map[string]SitemapItem
+}
+
+func newFakeSitemapRepository(items []SitemapItem) *fakeSitemapRepository {
+	repo := &fakeSitemapRepository{items: map[string]SitemapItem{}}
+	for _, item := range items {
+		item.URI = normaliseSitemapURI(item.URI)
+		repo.items[item.URI] = item
+	}
+	return repo
+}
+
+func (f *fakeSitemapRepository) CreateSitemapItem(_ context.Context, item *SitemapItem) (*SitemapItem, error) {
+	f.items[item.URI] = *item
+	return item, nil
+}
+
+func (f *fakeSitemapRepository) DeleteSitemapItemsByURIs(_ context.Context, uris []string) error {
+	for _, uri := range uris {
+		delete(f.items, uri)
+	}
+	return nil
+}
+
+func (f *fakeSitemapRepository) GetAllSitemapItems(_ context.Context) ([]SitemapItem, error) {
+	items := make([]SitemapItem, 0, len(f.items))
+	for _, item := range f.items {
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func (f *fakeSitemapRepository) GetSitemapItemByURI(_ context.Context, uri string) (*SitemapItem, error) {
+	item, ok := f.items[normaliseSitemapURI(uri)]
+	if !ok {
+		return nil, ErrSitemapItemResourceNotFound
+	}
+	return &item, nil
+}
+
+func (f *fakeSitemapRepository) GetLatestSitemapItemByURIRegex(_ context.Context, uriRegex string) (*SitemapItem, error) {
+	matcher, err := regexp.Compile(uriRegex)
+	if err != nil {
+		return nil, err
+	}
+
+	var latest *SitemapItem
+	for _, item := range f.items {
+		item := item
+		if !matcher.MatchString(item.URI) {
+			continue
+		}
+		if latest == nil || item.LastMod > latest.LastMod {
+			latest = &item
+		}
+	}
+	if latest == nil {
+		return nil, ErrSitemapItemResourceNotFound
+	}
+
+	return latest, nil
+}
+
+func (f *fakeSitemapRepository) GetSitemapItems(_ context.Context, _ *GetSitemapItemsRequest) ([]SitemapItem, error) {
+	return f.GetAllSitemapItems(context.Background())
+}
+
+func (f *fakeSitemapRepository) GetTotalSitemapItems(_ context.Context, _ *GetSitemapItemsRequest) (int64, error) {
+	return int64(len(f.items)), nil
+}
+
+func (f *fakeSitemapRepository) UpdateSitemapItemByURI(_ context.Context, item *SitemapItem) (*SitemapItem, error) {
+	f.items[item.URI] = *item
+	return item, nil
+}
+
+func (f *fakeSitemapRepository) UpsertSitemapItemByURI(_ context.Context, item *SitemapItem) (*SitemapItem, bool, error) {
+	_, exists := f.items[item.URI]
+	f.items[item.URI] = *item
+	return item, !exists, nil
+}
+
+func TestGenerateXMLBuildsSafeSitemap(t *testing.T) {
+	service := NewService(&NewServiceRequest{
+		SitemapRepository: newFakeSitemapRepository(nil),
+		FrontendDomain:    "https://example.com/",
+	})
+
+	got, err := service.GenerateXML([]SitemapItem{
+		{
+			URI:             "/blog?ref=one&next=two",
+			LastMod:         "2026-02-21T11:00:00",
+			Priority:        0.8,
+			ChangeFrequency: ChangeFrequencyWeekly,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GenerateXML() error = %v", err)
+	}
+
+	if !strings.Contains(got, `<loc>https://example.com/blog?ref=one&amp;next=two</loc>`) {
+		t.Fatalf("GenerateXML() did not XML-escape and join loc correctly:\n%s", got)
+	}
+	if !strings.Contains(got, `<lastmod>2026-02-21T11:00:00+00:00</lastmod>`) {
+		t.Fatalf("GenerateXML() missing formatted lastmod:\n%s", got)
+	}
+}
+
+func TestGenerateXMLSkipsExcludedAndDuplicateURIs(t *testing.T) {
+	service := NewService(&NewServiceRequest{
+		SitemapRepository: newFakeSitemapRepository(nil),
+		FrontendDomain:    "https://example.com",
+	})
+
+	got, err := service.GenerateXML([]SitemapItem{
+		{URI: "/pricing", LastMod: "2026-02-21T11:00:00", Priority: 0.9, ChangeFrequency: ChangeFrequencyMonthly},
+		{URI: "/admin", LastMod: "2026-02-21T11:00:00", Priority: 0.5, ChangeFrequency: ChangeFrequencyWeekly},
+		{URI: "/app/private", LastMod: "2026-02-21T11:00:00", Priority: 0.4, ChangeFrequency: ChangeFrequencyWeekly},
+		{URI: "/pricing", LastMod: "2026-02-21T11:00:00", Priority: 0.9, ChangeFrequency: ChangeFrequencyMonthly},
+		{URI: "/faq", LastMod: "2026-02-21T11:00:00", Priority: 0.8, ChangeFrequency: ChangeFrequencyMonthly},
+	})
+	if err != nil {
+		t.Fatalf("GenerateXML() error = %v", err)
+	}
+
+	if strings.Contains(got, "/admin") || strings.Contains(got, "/app/private") {
+		t.Fatalf("GenerateXML() included non-indexable routes:\n%s", got)
+	}
+	if count := strings.Count(got, "<loc>"); count != 2 {
+		t.Fatalf("GenerateXML() loc count = %d, want 2:\n%s", count, got)
+	}
+	if strings.Index(got, "https://example.com/faq") > strings.Index(got, "https://example.com/pricing") {
+		t.Fatalf("GenerateXML() URLs should be deterministic and sorted:\n%s", got)
+	}
+}
+
+func TestGenerateSitemapSavesWithSafePath(t *testing.T) {
+	tempDir := t.TempDir()
+	service := NewService(&NewServiceRequest{
+		SitemapRepository: newFakeSitemapRepository([]SitemapItem{
+			{
+				URI:             "/policy/terms",
+				LastMod:         "2026-02-21T11:00:00",
+				Priority:        0.8,
+				ChangeFrequency: ChangeFrequencyMonthly,
+			},
+		}),
+		FrontendDomain:   "https://example.com",
+		WritableRootPath: tempDir,
+	})
+
+	response, err := service.GenerateSitemap(context.Background(), &GenerateSitemapRequest{SaveToPaths: []string{"nested/sitemap.xml"}})
+	if err != nil {
+		t.Fatalf("GenerateSitemap() error = %v", err)
+	}
+	if len(response.SavedPaths) != 1 {
+		t.Fatalf("GenerateSitemap() saved paths = %v, want one", response.SavedPaths)
+	}
+
+	if _, err := os.Stat(filepath.Join(tempDir, "nested", "sitemap.xml")); err != nil {
+		t.Fatalf("expected sitemap file to be written: %v", err)
+	}
+}
+
+func TestGenerateSitemapReportsGeneratedURLCount(t *testing.T) {
+	service := NewService(&NewServiceRequest{
+		SitemapRepository: newFakeSitemapRepository([]SitemapItem{
+			{URI: "/pricing", LastMod: "2026-02-21T11:00:00", Priority: 0.9, ChangeFrequency: ChangeFrequencyMonthly},
+			{URI: "/app/private", LastMod: "2026-02-21T11:00:00", Priority: 0.4, ChangeFrequency: ChangeFrequencyWeekly},
+		}),
+		FrontendDomain: "https://example.com",
+	})
+
+	response, err := service.GenerateSitemap(context.Background(), &GenerateSitemapRequest{})
+	if err != nil {
+		t.Fatalf("GenerateSitemap() error = %v", err)
+	}
+
+	if response.Total != 1 {
+		t.Fatalf("GenerateSitemap() total = %d, want generated URL count 1", response.Total)
+	}
+}
+
+func TestDownloadSitemapByPathRejectsTraversal(t *testing.T) {
+	service := NewService(&NewServiceRequest{
+		SitemapRepository: newFakeSitemapRepository(nil),
+		WritableRootPath:  t.TempDir(),
+	})
+
+	_, err := service.DownloadSitemapByPath(context.Background(), &DownloadSitemapByPathRequest{Path: "../secret.xml"})
+	if !errors.Is(err, ErrSitemapPathIsInvalid) {
+		t.Fatalf("DownloadSitemapByPath() error = %v, want ErrSitemapPathIsInvalid", err)
+	}
+}
+
+func TestDeleteEntriesWithUriRegexUsesGoRegexAgainstExactDeletes(t *testing.T) {
+	repo := newFakeSitemapRepository([]SitemapItem{
+		{URI: "/blog/one", LastMod: "2026-02-21T11:00:00", Priority: 0.8, ChangeFrequency: ChangeFrequencyWeekly},
+		{URI: "/policy/terms", LastMod: "2026-02-21T11:00:00", Priority: 0.8, ChangeFrequency: ChangeFrequencyMonthly},
+	})
+	service := NewService(&NewServiceRequest{SitemapRepository: repo, FrontendDomain: "https://example.com"})
+
+	response, err := service.DeleteEntriesWithUriRegex(context.Background(), &DeleteEntriesWithURIRegexRequest{URIRegex: `^/blog/`})
+	if err != nil {
+		t.Fatalf("DeleteEntriesWithUriRegex() error = %v", err)
+	}
+	if response.Deleted != 1 {
+		t.Fatalf("DeleteEntriesWithUriRegex() deleted = %d, want 1", response.Deleted)
+	}
+	if _, ok := repo.items["/policy/terms"]; !ok {
+		t.Fatal("non-matching URI should remain")
+	}
+}
+
+func TestDeleteEntriesWithUriRegexRejectsLongPattern(t *testing.T) {
+	service := NewService(&NewServiceRequest{
+		SitemapRepository: newFakeSitemapRepository(nil),
+		FrontendDomain:    "https://example.com",
+	})
+
+	_, err := service.DeleteEntriesWithUriRegex(context.Background(), &DeleteEntriesWithURIRegexRequest{
+		URIRegex: strings.Repeat("a", maxSitemapURIRegexLength+1),
+	})
+	if !errors.Is(err, ErrSitemapItemInvalidURI) {
+		t.Fatalf("DeleteEntriesWithUriRegex() error = %v, want ErrSitemapItemInvalidURI", err)
+	}
+}
+
+func TestGetLatestSitemapItemByURIRegexReturnsNewestMatch(t *testing.T) {
+	service := NewService(&NewServiceRequest{
+		SitemapRepository: newFakeSitemapRepository([]SitemapItem{
+			{URI: "/blog/one", LastMod: "2026-02-21T11:00:00", Priority: 0.8, ChangeFrequency: ChangeFrequencyWeekly},
+			{URI: "/blog/two", LastMod: "2026-02-22T11:00:00", Priority: 0.8, ChangeFrequency: ChangeFrequencyWeekly},
+			{URI: "/policy/terms", LastMod: "2026-03-01T11:00:00", Priority: 0.8, ChangeFrequency: ChangeFrequencyMonthly},
+		}),
+		FrontendDomain: "https://example.com",
+	})
+
+	response, err := service.GetLatestSitemapItemByURIRegex(context.Background(), &GetLatestSitemapItemByURIRegexRequest{
+		URIRegex: `^/blog/`,
+	})
+	if err != nil {
+		t.Fatalf("GetLatestSitemapItemByURIRegex() error = %v", err)
+	}
+	if response.SitemapItem == nil || response.SitemapItem.URI != "/blog/two" {
+		t.Fatalf("latest sitemap item = %+v, want latest article URI", response.SitemapItem)
+	}
+}
+
+func TestMassSitemapItemCreationByBatchOverride(t *testing.T) {
+	repo := newFakeSitemapRepository([]SitemapItem{
+		{URI: "/policy/terms", LastMod: "2026-02-21T11:00:00", Priority: 0.5, ChangeFrequency: ChangeFrequencyMonthly},
+	})
+	service := NewService(&NewServiceRequest{SitemapRepository: repo, FrontendDomain: "https://example.com"})
+	priority := 0.9
+
+	response, err := service.MassSitemapItemCreationByBatch(context.Background(), &MassSitemapItemCreationByBatchRequest{
+		OverrideIfExists: true,
+		Items: []CreateSitemapItemRequest{
+			{URI: "/policy/terms", LastMod: "2026-02-22T11:00:00", Priority: &priority, ChangeFrequency: ChangeFrequencyWeekly},
+		},
+	})
+	if err != nil {
+		t.Fatalf("MassSitemapItemCreationByBatch() error = %v", err)
+	}
+	if response.Updated != 1 || response.Created != 0 {
+		t.Fatalf("MassSitemapItemCreationByBatch() created=%d updated=%d, want created=0 updated=1", response.Created, response.Updated)
+	}
+	if got := repo.items["/policy/terms"].Priority; got != priority {
+		t.Fatalf("stored priority = %v, want %v", got, priority)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `external/seo`, a reusable sitemap backend for GHATD host applications.

- Provides sitemap models, validation, MongoDB persistence, service operations, HTTP handlers, and route registration.
- Generates deterministic, de-duplicated XML while excluding protected route groups.
- Supports safe file reads, atomic writes, embedded sitemap fallback, and writable-root path enforcement.
- Adds MongoDB index and configurable starter-route seed migrations.
- Documents the framework and host-application ownership boundary in ADR016.

## Architecture / Package Boundary

GHATD now owns the generic sitemap lifecycle:

- URI normalization and sitemap metadata validation
- persistence, pagination, upsert, and batch deletion
- public XML rendering and `/sitemap.xml` serving
- administrative CRUD, batch ingestion, generation, and download routes
- safe filesystem access and embedded-file fallback
- shared index and starter-seed migrations

Host applications remain responsible for discovering public URL candidates, deciding crawler policy, selecting product-specific priorities and change frequencies, providing frontend administration, and maintaining content-specific repair migrations.

## HTTP Surface

- `GET /sitemap.xml`
- `POST /api/v1/seo/sitemap-items`
- `GET /api/v1/seo/sitemap-items`
- `PATCH /api/v1/seo/sitemap-items`
- `DELETE /api/v1/seo/sitemap-items`
- `POST /api/v1/seo/sitemap-items/batch`
- `POST /api/v1/seo/sitemap.xml/generate`
- `GET /api/v1/seo/sitemap.xml/download`

Administrative routes accept the host application admin-only middleware during attachment.

## Migration Notes

Host applications adopting the package should:

1. Import `github.com/ooaklee/ghatd/external/seo` and `github.com/ooaklee/ghatd/external/seo/migrations`.
2. Register the sitemap-item index migration and the desired starter seed migration.
3. Remove duplicate URI records before creating the unique sparse URI index.
4. Compose the service with the host repository, validator, frontend domain, filesystem, writable root, and default sitemap path.
5. Feed content-specific URL candidates through the single-item or batch-ingestion service APIs.

Existing collection names, document shape, and HTTP paths remain compatible, so adopting hosts do not need to copy sitemap data.

## Validation

- `asdf exec go test ./...`
- `asdf exec go mod verify`
- `git diff --check`
