### PR TITLE
Migrate repository layer to MongoDB Go Driver v2

### DIFF
--- a/docs/adr/adr015-harden-go-toolchain-and-dependencies.md
+++ b/docs/adr/adr015-harden-go-toolchain-and-dependencies.md
@@ -16,7 +16,7 @@ The direct dependency graph also still used `github.com/dgrijalva/jwt-go`, which
 Some dependencies have important provenance or migration considerations:
 
 - `github.com/ooaklee/http-cache` was pinned to a forked pseudo-version because the upstream module had not yet accepted the skip-cache controls GHATD needs. The upstream maintainer later accepted the behaviour and [reimplemented it in `github.com/victorspringer/http-cache`](https://github.com/victorspringer/http-cache/pull/21#issuecomment-4499679232), preserving the response-writer path while adding tests for skipping storage by response header and skipping lookup and storage by URI path regex.
-- `go.mongodb.org/mongo-driver` v1 is deprecated by MongoDB in favour of `go.mongodb.org/mongo-driver/v2`. GHATD imports the v1 driver across many repository packages, while the updated `github.com/xakep666/mongo-migrate` package now uses v2. A full repository-wide MongoDB v2 migration is larger than this hardening pass.
+- `go.mongodb.org/mongo-driver` v1 was deprecated by MongoDB in favour of `go.mongodb.org/mongo-driver/v2`. GHATD subsequently migrated its repository packages and MongoDB migrator to v2.
 
 ## Decision
 
@@ -28,7 +28,7 @@ We will replace direct `github.com/dgrijalva/jwt-go` usage with `github.com/gola
 
 We will update `github.com/xakep666/mongo-migrate` and adapt the `cmd/mongo-migrator` command to the package's context-aware API and MongoDB driver v2 connection type.
 
-We will keep the wider GHATD repository packages on `go.mongodb.org/mongo-driver` v1.17.x for this change and treat a repository-wide MongoDB v2 migration as a separate breaking-change project.
+The original hardening pass retained `go.mongodb.org/mongo-driver` v1.17.x. The later repository-wide migration moved GHATD's MongoDB integrations to v2.
 
 We will replace `github.com/ooaklee/http-cache` with upstream `github.com/victorspringer/http-cache` now that upstream provides the required skip-cache response-header and URI-path-regex options.
 

--- a/docs/getting-started/billing/README.md
+++ b/docs/getting-started/billing/README.md
@@ -90,13 +90,13 @@ The billing package uses two MongoDB collections:
 
 - MongoDB 4.2 or higher.
 - `mongo-migrate` library: `github.com/xakep666/mongo-migrate`.
-- Go mongo driver: `go.mongodb.org/mongo-driver/mongo`.
+- Go mongo driver: `go.mongodb.org/mongo-driver/v2/mongo`.
 
 ### Installing Dependencies
 
 ```bash
 go get github.com/xakep666/mongo-migrate
-go get go.mongodb.org/mongo-driver/mongo
+go get go.mongodb.org/mongo-driver/v2/mongo
 ```
 
 ### Running Migrations
@@ -113,8 +113,8 @@ import (
     
     billingMigration "github.com/ooaklee/ghatd/external/billing/migrations"
     migrate "github.com/xakep666/mongo-migrate"
-    "go.mongodb.org/mongo-driver/mongo"
-    "go.mongodb.org/mongo-driver/mongo/options"
+    "go.mongodb.org/mongo-driver/v2/mongo"
+    "go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 func main() {

--- a/docs/getting-started/post/README.md
+++ b/docs/getting-started/post/README.md
@@ -107,8 +107,8 @@ import (
     "context"
 
     migrate "github.com/xakep666/mongo-migrate"
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo"
+    "go.mongodb.org/mongo-driver/v2/bson"
+    "go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 func init() {

--- a/docs/getting-started/user/v2/README.md
+++ b/docs/getting-started/user/v2/README.md
@@ -172,13 +172,13 @@ dept, exists := user.GetExtension("department")
 
 - MongoDB 4.2 or higher
 - mongo-migrate library: `github.com/xakep666/mongo-migrate`
-- Go mongo driver: `go.mongodb.org/mongo-driver/mongo`
+- Go mongo driver: `go.mongodb.org/mongo-driver/v2/mongo`
 
 ### Installing Dependencies
 
 ```bash
 go get github.com/xakep666/mongo-migrate
-go get go.mongodb.org/mongo-driver/mongo
+go get go.mongodb.org/mongo-driver/v2/mongo
 ```
 
 ### Running Migrations
@@ -195,8 +195,8 @@ import (
     
     userMigration "github.com/ooaklee/ghatd/external/user/v2/migrations"
     migrate "github.com/xakep666/mongo-migrate"
-    "go.mongodb.org/mongo-driver/mongo"
-    "go.mongodb.org/mongo-driver/mongo/options"
+    "go.mongodb.org/mongo-driver/v2/mongo"
+    "go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 func main() {

--- a/external/apitoken/repository.go
+++ b/external/apitoken/repository.go
@@ -6,10 +6,9 @@ import (
 	"sync"
 
 	"github.com/ooaklee/ghatd/external/repository"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const (
@@ -25,9 +24,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore to hold resource data
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
@@ -150,14 +149,14 @@ func (r *Repository) GetTotalApiTokens(ctx context.Context, userId, userNanoId, 
 	}
 
 	if descriptionFilter != "" {
-		apiTokenFilter["description"] = primitive.Regex{
+		apiTokenFilter["description"] = bson.Regex{
 			Pattern: fmt.Sprintf(MongoRegexStringFormat, descriptionFilter),
 			Options: "i",
 		}
 	}
 
 	if statusFilter != "" {
-		apiTokenFilter["status"] = primitive.Regex{
+		apiTokenFilter["status"] = bson.Regex{
 			Pattern: fmt.Sprintf(MongoRegexStringFormat, statusFilter),
 			Options: "i",
 		}
@@ -273,12 +272,12 @@ func (r *Repository) GetAPITokens(ctx context.Context, req *GetAPITokensRequest)
 
 	findOptions := options.Find()
 
-	findOptions.Limit = paginationLimit
-	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+	findOptions.SetLimit(*paginationLimit)
+	findOptions.SetSkip(*repository.GetPaginationSkip(int64(req.Page), paginationLimit))
 
 	// generate query filter from request
 	if req.Description != "" {
-		queryFilter = append(queryFilter, bson.E{Key: "description", Value: primitive.Regex{
+		queryFilter = append(queryFilter, bson.E{Key: "description", Value: bson.Regex{
 			Pattern: fmt.Sprintf(MongoRegexStringFormat, req.Description),
 			Options: "i",
 		},
@@ -286,7 +285,7 @@ func (r *Repository) GetAPITokens(ctx context.Context, req *GetAPITokensRequest)
 	}
 
 	if req.Status != "" {
-		queryFilter = append(queryFilter, bson.E{Key: "status", Value: primitive.Regex{
+		queryFilter = append(queryFilter, bson.E{Key: "status", Value: bson.Regex{
 			Pattern: fmt.Sprintf(MongoRegexStringFormat, req.Status),
 			Options: "i",
 		},

--- a/external/audit/repository.go
+++ b/external/audit/repository.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"sync"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // AuditCollection collection name for audit events
@@ -19,9 +19,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 // MongoDbStore represents the datastore to hold resource data
 type MongoDbStore interface {
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	// ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	// ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	// ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	// ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	// ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
 	// ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error

--- a/external/billing/migrations/indexes_billing_events.go
+++ b/external/billing/migrations/indexes_billing_events.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/billing"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 func InitBillingEventsIndexesUp(db *mongo.Database) error { //Up
@@ -76,7 +76,7 @@ func InitBillingEventsIndexesDown(db *mongo.Database) error { //Down
 	}
 
 	for _, indexName := range indexNames {
-		_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err

--- a/external/billing/migrations/indexes_billing_subscriptions.go
+++ b/external/billing/migrations/indexes_billing_subscriptions.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/billing"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InitSubscriptionIndexes initializes indexes for the billing subscriptions collection
@@ -83,7 +83,7 @@ func InitBillingSubscriptionIndexesDown(db *mongo.Database) error { //Down
 	}
 
 	for _, indexName := range indexNames {
-		_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err

--- a/external/billing/repository.go
+++ b/external/billing/repository.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/repository"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // BillingEventsCollection collection name for billing events
@@ -22,9 +22,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore to hold resource data
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteAggregateCommand(ctx context.Context, collection *mongo.Collection, mongoPipeline []bson.D) (*mongo.Cursor, error)
@@ -227,8 +227,8 @@ func (r *Repository) GetSubscriptions(ctx context.Context, req *GetSubscriptions
 
 	findOptions := options.Find()
 
-	findOptions.Limit = paginationLimit
-	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+	findOptions.SetLimit(*paginationLimit)
+	findOptions.SetSkip(*repository.GetPaginationSkip(int64(req.Page), paginationLimit))
 
 	// generate query filter from request
 	if req.IntegratorName != "" {
@@ -493,8 +493,8 @@ func (r *Repository) GetBillingEvents(ctx context.Context, req *GetBillingEvents
 
 	findOptions := options.Find()
 
-	findOptions.Limit = paginationLimit
-	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+	findOptions.SetLimit(*paginationLimit)
+	findOptions.SetSkip(*repository.GetPaginationSkip(int64(req.Page), paginationLimit))
 
 	// generate query filter from request
 	if req.IntegratorName != "" {

--- a/external/contacter/repository.go
+++ b/external/contacter/repository.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/repository"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // CommsCollection collection name for comms
@@ -20,9 +20,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore to hold resource data
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteAggregateCommand(ctx context.Context, collection *mongo.Collection, mongoPipeline []bson.D) (*mongo.Cursor, error)
@@ -296,8 +296,8 @@ func (r *Repository) GetComms(ctx context.Context, req *GetCommsRequest) ([]Comm
 
 	findOptions := options.Find()
 
-	findOptions.Limit = paginationLimit
-	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+	findOptions.SetLimit(*paginationLimit)
+	findOptions.SetSkip(*repository.GetPaginationSkip(int64(req.Page), paginationLimit))
 
 	// generate query filter from request
 	if req.FullName != "" {

--- a/external/group/migrations/indexes_groups.go
+++ b/external/group/migrations/indexes_groups.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/group"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InitGroupsIndexesUp initializes indexes for the groups collection
@@ -200,7 +200,7 @@ func InitGroupsIndexesDown(db *mongo.Database) error { //Down
 	}
 
 	for _, indexName := range indexNames {
-		_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err

--- a/external/group/migrations/indexes_groups_lineage.go
+++ b/external/group/migrations/indexes_groups_lineage.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/group"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InitGroupsLineageIndexUp adds the lineage index used by descendants queries.
@@ -40,7 +40,7 @@ func InitGroupsLineageIndexDown(db *mongo.Database) error { //Down
 
 	log.Default().Println(toolbox.OutputBasicLogString("info", "rolling-back-task-to-add-groups-lineage-index"))
 
-	_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), "idx_groups_lineage")
+	err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), "idx_groups_lineage")
 	if err != nil {
 		log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-groups-lineage-index"))
 		return err

--- a/external/group/repository.go
+++ b/external/group/repository.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"sync"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // GroupCollection collection name for groups
@@ -18,9 +18,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore to hold group data
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error

--- a/external/notifier/migrations/indexes_notifier.go
+++ b/external/notifier/migrations/indexes_notifier.go
@@ -32,9 +32,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/notifier"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InitNotifierIndexesUp creates all the indexes the notifier package needs.
@@ -100,13 +100,13 @@ func InitNotifierIndexesDown(db *mongo.Database) error { //Down
 		"idx_notification_addresses_updated_at",
 	}
 	for _, indexName := range addressIndexNames {
-		if _, err := db.Collection(notifier.NotificationAddressesCollection).Indexes().DropOne(context.TODO(), indexName); err != nil {
+		if err := db.Collection(notifier.NotificationAddressesCollection).Indexes().DropOne(context.TODO(), indexName); err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err
 		}
 	}
 
-	if _, err := db.Collection(notifier.NotificationPreferencesCollection).Indexes().DropOne(context.TODO(), "idx_notification_preferences_enabled"); err != nil {
+	if err := db.Collection(notifier.NotificationPreferencesCollection).Indexes().DropOne(context.TODO(), "idx_notification_preferences_enabled"); err != nil {
 		log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: idx_notification_preferences_enabled"))
 		return err
 	}

--- a/external/notifier/repository.go
+++ b/external/notifier/repository.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // MongoDbStore describes the MongoDB operations that the notifier repository
@@ -18,8 +18,8 @@ import (
 // This is a subset of the full data store interface – only the read, write,
 // and collection-management methods that notifier actually uses.
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
 	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
@@ -292,7 +292,7 @@ func buildAddressListFilter(req *ListNotificationAddressesRequest) bson.M {
 	return filter
 }
 
-func buildAddressListOptions(req *ListNotificationAddressesRequest) *options.FindOptions {
+func buildAddressListOptions(req *ListNotificationAddressesRequest) *options.FindOptionsBuilder {
 	findOptions := options.Find().SetSort(bson.D{{Key: "metadata.updated_at", Value: -1}})
 	if req == nil {
 		return findOptions
@@ -312,14 +312,14 @@ func buildAddressListOptions(req *ListNotificationAddressesRequest) *options.Fin
 
 // findAddresses runs a find query against the notification_addresses
 // collection and returns the results sorted by most-recently-updated first.
-func (r *Repository) findAddresses(ctx context.Context, filter bson.M, opts ...*options.FindOptions) ([]NotificationAddress, error) {
+func (r *Repository) findAddresses(ctx context.Context, filter bson.M, opts ...options.Lister[options.FindOptions]) ([]NotificationAddress, error) {
 	collection, err := r.GetNotificationAddressesCollection(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(opts) == 0 {
-		opts = []*options.FindOptions{options.Find().SetSort(bson.D{{Key: "metadata.updated_at", Value: -1}})}
+		opts = []options.Lister[options.FindOptions]{options.Find().SetSort(bson.D{{Key: "metadata.updated_at", Value: -1}})}
 	}
 
 	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, filter, opts...)

--- a/external/notifier/repository_test.go
+++ b/external/notifier/repository_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // mockNotifierMongoDbStore is a small repository double used to test the
@@ -18,8 +18,8 @@ import (
 type mockNotifierMongoDbStore struct {
 	initialiseClientFunc func(ctx context.Context) (*mongo.Client, error)
 	getDatabaseFunc      func(ctx context.Context, dbName string) (*mongo.Database, error)
-	countFunc            func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
-	findFunc             func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	countFunc            func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
+	findFunc             func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	findOneFunc          func(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
 	deleteOneFunc        func(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
 	deleteManyFunc       func(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
@@ -27,14 +27,23 @@ type mockNotifierMongoDbStore struct {
 	mapAllFunc           func(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error
 }
 
-func (m *mockNotifierMongoDbStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+func materializeFindOptions(t *testing.T, lister options.Lister[options.FindOptions]) *options.FindOptions {
+	t.Helper()
+	opts := &options.FindOptions{}
+	for _, setter := range lister.List() {
+		require.NoError(t, setter(opts))
+	}
+	return opts
+}
+
+func (m *mockNotifierMongoDbStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error) {
 	if m.countFunc != nil {
 		return m.countFunc(ctx, collection, filter, opts...)
 	}
 	return 0, errors.New("not implemented")
 }
 
-func (m *mockNotifierMongoDbStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+func (m *mockNotifierMongoDbStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 	if m.findFunc != nil {
 		return m.findFunc(ctx, collection, filter, opts...)
 	}
@@ -96,7 +105,7 @@ func (m *mockNotifierMongoDbStore) MapAllInCursorToResult(ctx context.Context, c
 func TestRepository_GetNotificationAddressesCollectionRetriesFailuresAndCachesSuccess(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	initialiseAttempts := 0
@@ -132,7 +141,7 @@ func TestRepository_GetNotificationAddressesCollectionRetriesFailuresAndCachesSu
 func TestRepository_GetNotificationPreferencesCollectionRetriesFailuresAndCachesSuccess(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	initialiseAttempts := 0
@@ -215,7 +224,7 @@ func TestRepository_WithCollectionInitMaxAttemptsLimitOverridesDefault(t *testin
 func TestRepository_DeleteAddressByIDForUserUsesRepositoryHelpers(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	findOneCalls := 0
@@ -254,7 +263,7 @@ func TestRepository_DeleteAddressByIDForUserUsesRepositoryHelpers(t *testing.T) 
 func TestRepository_GetAddressesBuildsAdminFilter(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	findCalls := 0
@@ -265,7 +274,7 @@ func TestRepository_GetAddressesBuildsAdminFilter(t *testing.T) {
 		getDatabaseFunc: func(ctx context.Context, dbName string) (*mongo.Database, error) {
 			return client.Database("notifier_test"), nil
 		},
-		findFunc: func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+		findFunc: func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 			findCalls++
 			assert.Equal(t, NotificationAddressesCollection, collection.Name())
 			assert.Equal(t, bson.M{
@@ -274,10 +283,11 @@ func TestRepository_GetAddressesBuildsAdminFilter(t *testing.T) {
 				"status":  NotificationAddressStatusActive,
 			}, filter)
 			require.Len(t, opts, 1)
-			require.NotNil(t, opts[0].Limit)
-			require.NotNil(t, opts[0].Skip)
-			assert.Equal(t, int64(25), *opts[0].Limit)
-			assert.Equal(t, int64(50), *opts[0].Skip)
+			findOptions := materializeFindOptions(t, opts[0])
+			require.NotNil(t, findOptions.Limit)
+			require.NotNil(t, findOptions.Skip)
+			assert.Equal(t, int64(25), *findOptions.Limit)
+			assert.Equal(t, int64(50), *findOptions.Skip)
 			return mongo.NewCursorFromDocuments([]interface{}{}, nil, nil)
 		},
 		mapAllFunc: func(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error {
@@ -303,7 +313,7 @@ func TestRepository_GetAddressesBuildsAdminFilter(t *testing.T) {
 func TestRepository_CountAddressesBuildsAdminFilter(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	countCalls := 0
@@ -314,7 +324,7 @@ func TestRepository_CountAddressesBuildsAdminFilter(t *testing.T) {
 		getDatabaseFunc: func(ctx context.Context, dbName string) (*mongo.Database, error) {
 			return client.Database("notifier_test"), nil
 		},
-		countFunc: func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+		countFunc: func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error) {
 			countCalls++
 			assert.Equal(t, NotificationAddressesCollection, collection.Name())
 			assert.Equal(t, bson.M{
@@ -343,7 +353,7 @@ func TestRepository_CountAddressesBuildsAdminFilter(t *testing.T) {
 func TestRepository_DeleteAddressByIDForUserStopsWhenAddressIsNotFound(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	deleteOneCalls := 0
@@ -375,7 +385,7 @@ func TestRepository_DeleteAddressByIDForUserStopsWhenAddressIsNotFound(t *testin
 func TestRepository_DeleteAddressesByUserIDUsesDeleteManyHelper(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	deleteManyCalls := 0
@@ -408,7 +418,7 @@ func TestRepository_DeleteAddressesByUserIDUsesDeleteManyHelper(t *testing.T) {
 func TestRepository_DisableAddressByHashUsesExecuteUpdateOneCommand(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	updateOneCalls := 0
@@ -446,7 +456,7 @@ func TestRepository_DisableAddressByHashUsesExecuteUpdateOneCommand(t *testing.T
 func TestRepository_DisableAddressByHashWrapsExecutorError(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	store := &mockNotifierMongoDbStore{

--- a/external/post/repository.go
+++ b/external/post/repository.go
@@ -9,10 +9,9 @@ import (
 	"github.com/ooaklee/ghatd/external/repository"
 	"github.com/ooaklee/ghatd/external/toolbox"
 	internalToolbox "github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // PostCollection collection name for posts
@@ -22,9 +21,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore to hold resource data
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
@@ -392,7 +391,7 @@ func (r *Repository) GetTotalPosts(ctx context.Context, req *GetTotalPostsReques
 			), " ", "|"),
 		)
 
-		queryFilter["title"] = bson.M{"$regex": primitive.Regex{Pattern: regexQueryString, Options: "i"}}
+		queryFilter["title"] = bson.M{"$regex": bson.Regex{Pattern: regexQueryString, Options: "i"}}
 	}
 
 	if req.PublishedWithAlias {
@@ -446,7 +445,7 @@ func (r *Repository) GetTotalPosts(ctx context.Context, req *GetTotalPostsReques
 			), " ", "|"),
 		)
 
-		queryFilter["text"] = bson.M{"$regex": primitive.Regex{Pattern: regexQueryString, Options: "i"}}
+		queryFilter["text"] = bson.M{"$regex": bson.Regex{Pattern: regexQueryString, Options: "i"}}
 	}
 
 	if len(req.PostHeaderImageTypes) > 0 {
@@ -542,8 +541,8 @@ func (r *Repository) GetPosts(ctx context.Context, req *GetPostsRequest) ([]Post
 
 	findOptions := options.Find()
 
-	findOptions.Limit = paginationLimit
-	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+	findOptions.SetLimit(*paginationLimit)
+	findOptions.SetSkip(*repository.GetPaginationSkip(int64(req.Page), paginationLimit))
 
 	// generate query filter from request
 	if req.Title != "" {
@@ -555,7 +554,7 @@ func (r *Repository) GetPosts(ctx context.Context, req *GetPostsRequest) ([]Post
 			), " ", "|"),
 		)
 
-		queryFilter = append(queryFilter, bson.E{Key: "title", Value: bson.M{"$regex": primitive.Regex{Pattern: regexQueryString, Options: "i"}}})
+		queryFilter = append(queryFilter, bson.E{Key: "title", Value: bson.M{"$regex": bson.Regex{Pattern: regexQueryString, Options: "i"}}})
 	}
 
 	if req.PublishedWithAlias {
@@ -608,7 +607,7 @@ func (r *Repository) GetPosts(ctx context.Context, req *GetPostsRequest) ([]Post
 			), " ", "|"),
 		)
 
-		queryFilter = append(queryFilter, bson.E{Key: "text", Value: bson.M{"$regex": primitive.Regex{Pattern: regexQueryString, Options: "i"}}})
+		queryFilter = append(queryFilter, bson.E{Key: "text", Value: bson.M{"$regex": bson.Regex{Pattern: regexQueryString, Options: "i"}}})
 	}
 
 	if req.WithHeaderImageType != "" {

--- a/external/pricer/migrations/e2e_pricing_cards_test.go
+++ b/external/pricer/migrations/e2e_pricing_cards_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/benweissmann/memongo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"github.com/ooaklee/ghatd/external/pricer"
 	pricermigrations "github.com/ooaklee/ghatd/external/pricer/migrations"

--- a/external/pricer/migrations/indexes_pricing.go
+++ b/external/pricer/migrations/indexes_pricing.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/pricer"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 func InitPricingIndexesUp(db *mongo.Database) error { //Up
@@ -97,7 +97,7 @@ func InitPricingIndexesDown(db *mongo.Database) error { //Down
 	}
 
 	for _, indexName := range planIndexNames {
-		_, err := db.Collection(pricer.PricePlansCollection).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(pricer.PricePlansCollection).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err
@@ -111,7 +111,7 @@ func InitPricingIndexesDown(db *mongo.Database) error { //Down
 	}
 
 	for _, indexName := range featureIndexNames {
-		_, err := db.Collection(pricer.PriceFeaturesCollection).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(pricer.PriceFeaturesCollection).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err

--- a/external/pricer/migrations/seed_pricing.go
+++ b/external/pricer/migrations/seed_pricing.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ooaklee/ghatd/external/pricer"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 var (

--- a/external/pricer/migrations/seed_test_plans.go
+++ b/external/pricer/migrations/seed_test_plans.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ooaklee/ghatd/external/pricer"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // TestPlansSeedCreatedByID identifies all documents inserted by the test plans

--- a/external/pricer/repository.go
+++ b/external/pricer/repository.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/repository"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const (
@@ -28,9 +28,9 @@ const (
 
 // MongoDbStore represents the datastore to hold pricer data.
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
@@ -289,8 +289,8 @@ func (r *Repository) GetPricePlans(ctx context.Context, req *GetPricePlansReques
 	var results []PricePlan
 	findOptions := options.Find()
 	paginationLimit := repository.GetPaginationLimit(int64(req.PerPage))
-	findOptions.Limit = paginationLimit
-	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+	findOptions.SetLimit(*paginationLimit)
+	findOptions.SetSkip(*repository.GetPaginationSkip(int64(req.Page), paginationLimit))
 	findOptions.SetSort(buildPricerSortOptions(req.Order))
 	applyPricePlanFindProjection(findOptions, pricePlanIncludeOptions{
 		includeFeatures:  req.IncludeFeatures,
@@ -481,8 +481,8 @@ func (r *Repository) GetFeatures(ctx context.Context, req *GetFeaturesRequest) (
 	var results []PriceFeature
 	findOptions := options.Find()
 	paginationLimit := repository.GetPaginationLimit(int64(req.PerPage))
-	findOptions.Limit = paginationLimit
-	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+	findOptions.SetLimit(*paginationLimit)
+	findOptions.SetSkip(*repository.GetPaginationSkip(int64(req.Page), paginationLimit))
 	findOptions.SetSort(buildPricerSortOptions(req.Order))
 
 	cursor, err := r.Store.ExecuteFindCommand(ctx, collection, buildPriceFeatureQueryFilter(req), findOptions)
@@ -673,7 +673,7 @@ func buildPricerSortOptions(order string) bson.D {
 	}
 }
 
-func applyPricePlanFindProjection(findOptions *options.FindOptions, includeOptions pricePlanIncludeOptions) {
+func applyPricePlanFindProjection(findOptions *options.FindOptionsBuilder, includeOptions pricePlanIncludeOptions) {
 	projection := buildPricePlanProjection(includeOptions)
 	if len(projection) > 0 {
 		findOptions.SetProjection(projection)

--- a/external/reminder/migrations/indexes_reminders.go
+++ b/external/reminder/migrations/indexes_reminders.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/reminder"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InitRemindersIndexesUp creates indexes for reminder declarations and execution tracking.
@@ -177,7 +177,7 @@ func InitRemindersIndexesDown(db *mongo.Database) error {
 	}
 
 	for _, indexName := range indexNames {
-		_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err
@@ -191,7 +191,7 @@ func InitRemindersIndexesDown(db *mongo.Database) error {
 		"idx_reminder_executions_status_scheduled",
 	}
 	for _, indexName := range executionIndexNames {
-		_, err := db.Collection(reminder.ReminderExecutionsCollection).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(reminder.ReminderExecutionsCollection).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err

--- a/external/reminder/repository.go
+++ b/external/reminder/repository.go
@@ -7,17 +7,17 @@ import (
 	"sync"
 
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore describes the MongoDB helper operations the reminder repository uses.
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, update interface{}, resultObjectName string) error
@@ -264,7 +264,7 @@ func buildReminderExecutionFilter(req *ReminderExecutionFilter) bson.M {
 	return queryFilter
 }
 
-func buildReminderPaginationOptions(page, perPage int) *options.FindOptions {
+func buildReminderPaginationOptions(page, perPage int) *options.FindOptionsBuilder {
 	if page <= 0 {
 		page = 1
 	}

--- a/external/reminder/repository_test.go
+++ b/external/reminder/repository_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 type mockMongoDbStore struct {
@@ -17,11 +17,20 @@ type mockMongoDbStore struct {
 	getDatabaseFunc      func(ctx context.Context, dbName string) (*mongo.Database, error)
 }
 
-func (m *mockMongoDbStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+func materializeFindOptions(t *testing.T, lister options.Lister[options.FindOptions]) *options.FindOptions {
+	t.Helper()
+	opts := &options.FindOptions{}
+	for _, setter := range lister.List() {
+		require.NoError(t, setter(opts))
+	}
+	return opts
+}
+
+func (m *mockMongoDbStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error) {
 	return 0, errors.New("not implemented")
 }
 
-func (m *mockMongoDbStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+func (m *mockMongoDbStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -66,7 +75,7 @@ func (m *mockMongoDbStore) MapOneInCursorToResult(ctx context.Context, cursor *m
 func TestRepository_GetReminderCollectionRetriesFailuresAndCachesSuccess(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	initialiseAttempts := 0
@@ -215,7 +224,7 @@ func TestBuildReminderPaginationOptions(t *testing.T) {
 	t.Parallel()
 
 	t.Run("default pagination", func(t *testing.T) {
-		opts := buildReminderPaginationOptions(0, 0)
+		opts := materializeFindOptions(t, buildReminderPaginationOptions(0, 0))
 		skip := opts.Skip
 		limit := opts.Limit
 		require.NotNil(t, skip)
@@ -225,7 +234,7 @@ func TestBuildReminderPaginationOptions(t *testing.T) {
 	})
 
 	t.Run("custom pagination", func(t *testing.T) {
-		opts := buildReminderPaginationOptions(2, 10)
+		opts := materializeFindOptions(t, buildReminderPaginationOptions(2, 10))
 		skip := opts.Skip
 		limit := opts.Limit
 		require.NotNil(t, skip)

--- a/external/repository/README.md
+++ b/external/repository/README.md
@@ -113,7 +113,7 @@ This example illustrates how to utilise the core repository's helper methods to 
 
 // MongoDbStore represents the datastore to hold resource data
 type MongoDbStore interface {
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	GetDatabase(ctx context.Context, dbName string) (*mongo.Database, error)
 	InitialiseClient(ctx context.Context) (*mongo.Client, error)
 	MapAllInCursorToResult(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error

--- a/external/repository/helpers/mongo_client_interface.go
+++ b/external/repository/helpers/mongo_client_interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // MongoClient defines the interface for MongoDB client operations

--- a/external/repository/helpers/mongo_config.go
+++ b/external/repository/helpers/mongo_config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 )
 
 // Config holds all configuration for MongoDB connection
@@ -22,7 +22,10 @@ type Config struct {
 	// Timeout Settings
 	ConnectTimeout         *time.Duration
 	ServerSelectionTimeout *time.Duration
-	SocketTimeout          *time.Duration
+	OperationTimeout       *time.Duration
+	// SocketTimeout is retained for source compatibility with v1-era config.
+	// Deprecated: the v2 driver uses OperationTimeout instead.
+	SocketTimeout *time.Duration
 
 	// Retry Settings
 	RetryWrites  *bool
@@ -77,12 +80,12 @@ func WithConnectionPool(maxPool, minPool uint64, maxIdleTime time.Duration) Conf
 	}
 }
 
-// WithTimeouts sets various timeout options
-func WithTimeouts(connect, serverSelection, socket time.Duration) ConfigOption {
+// WithTimeouts sets connect, server selection, and operation timeouts.
+func WithTimeouts(connect, serverSelection, operation time.Duration) ConfigOption {
 	return func(c *Config) {
 		c.ConnectTimeout = &connect
 		c.ServerSelectionTimeout = &serverSelection
-		c.SocketTimeout = &socket
+		c.OperationTimeout = &operation
 	}
 }
 
@@ -138,8 +141,10 @@ func (c *Config) BuildClientOptions() *options.ClientOptions {
 	if c.ServerSelectionTimeout != nil {
 		clientOpts.SetServerSelectionTimeout(*c.ServerSelectionTimeout)
 	}
-	if c.SocketTimeout != nil {
-		clientOpts.SetSocketTimeout(*c.SocketTimeout)
+	if c.OperationTimeout != nil {
+		clientOpts.SetTimeout(*c.OperationTimeout)
+	} else if c.SocketTimeout != nil {
+		clientOpts.SetTimeout(*c.SocketTimeout)
 	}
 	if c.RetryWrites != nil {
 		clientOpts.SetRetryWrites(*c.RetryWrites)

--- a/external/repository/helpers/mongo_config_test.go
+++ b/external/repository/helpers/mongo_config_test.go
@@ -1,0 +1,31 @@
+package repositoryhelpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTimeoutsBuildsV2OperationTimeout(t *testing.T) {
+	operationTimeout := 30 * time.Second
+	config := DefaultConfig("mongodb://localhost:27017", "test")
+	WithTimeouts(5*time.Second, 3*time.Second, operationTimeout)(config)
+
+	clientOptions := config.BuildClientOptions()
+
+	require.NotNil(t, clientOptions.Timeout)
+	assert.Equal(t, operationTimeout, *clientOptions.Timeout)
+}
+
+func TestBuildClientOptionsMapsLegacySocketTimeout(t *testing.T) {
+	legacyTimeout := 45 * time.Second
+	config := DefaultConfig("mongodb://localhost:27017", "test")
+	config.SocketTimeout = &legacyTimeout
+
+	clientOptions := config.BuildClientOptions()
+
+	require.NotNil(t, clientOptions.Timeout)
+	assert.Equal(t, legacyTimeout, *clientOptions.Timeout)
+}

--- a/external/repository/helpers/mongo_handler.go
+++ b/external/repository/helpers/mongo_handler.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/ooaklee/ghatd/external/logger"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.uber.org/zap"
 )
 
@@ -88,7 +88,7 @@ func (h *Handler) connect(ctx context.Context) (*mongo.Client, error) {
 
 	clientOptions := h.config.BuildClientOptions()
 
-	client, err := mongo.Connect(ctx, clientOptions)
+	client, err := mongo.Connect(clientOptions)
 	if err != nil {
 		h.handleError(ctx, err, "connect")
 		logger.Error("mongo-connect-failed", zap.Error(err))

--- a/external/repository/mongo_examples.go
+++ b/external/repository/mongo_examples.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	repositoryhelpers "github.com/ooaklee/ghatd/external/repository/helpers"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 )
 
 // Example: How to migrate from old to new structure
@@ -194,7 +194,7 @@ func (m *MockRepositoryHelper) Stats() repositoryhelpers.ConnectionStats {
 	return repositoryhelpers.ConnectionStats{}
 }
 
-func (m *MockRepositoryHelper) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+func (m *MockRepositoryHelper) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error) {
 	return 0, nil
 }
 func (m *MockRepositoryHelper) ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error {
@@ -215,7 +215,7 @@ func (m *MockRepositoryHelper) ExecuteFindOneCommandDecodeResult(ctx context.Con
 func (m *MockRepositoryHelper) ExecuteReplaceOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, replacementObject interface{}, resultObjectName string) error {
 	return nil
 }
-func (m *MockRepositoryHelper) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+func (m *MockRepositoryHelper) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 	return nil, nil
 }
 func (m *MockRepositoryHelper) ExecuteAggregateCommand(ctx context.Context, collection *mongo.Collection, mongoPipeline []bson.D) (*mongo.Cursor, error) {

--- a/external/repository/mongo_repository.go
+++ b/external/repository/mongo_repository.go
@@ -15,9 +15,9 @@ import (
 	"context"
 
 	repositoryhelpers "github.com/ooaklee/ghatd/external/repository/helpers"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // MongoDbRepository uses the new extensible pattern
@@ -117,7 +117,7 @@ func (r *MongoDbRepository) MapOneInCursorToResult(ctx context.Context, cursor *
 }
 
 // ExecuteCountDocuments executes a count documents command
-func (r *MongoDbRepository) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+func (r *MongoDbRepository) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error) {
 	return r.helper.ExecuteCountDocuments(ctx, collection, filter, opts...)
 }
 
@@ -152,7 +152,7 @@ func (r *MongoDbRepository) ExecuteReplaceOneCommand(ctx context.Context, collec
 }
 
 // ExecuteFindCommand executes a find command
-func (r *MongoDbRepository) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+func (r *MongoDbRepository) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 	return r.helper.ExecuteFindCommand(ctx, collection, filter, opts...)
 }
 

--- a/external/repository/mongo_utils.go
+++ b/external/repository/mongo_utils.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	repositoryhelpers "github.com/ooaklee/ghatd/external/repository/helpers"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // RepositoryLogger defines interface for repository-level logging
@@ -33,14 +33,14 @@ type CursorMapper interface {
 
 // CommonOperations defines interface for common MongoDB operations
 type CommonOperations interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
 	ExecuteUpdateManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
 	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
 	ExecuteReplaceOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, replacementObject interface{}, resultObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteAggregateCommand(ctx context.Context, collection *mongo.Collection, mongoPipeline []bson.D) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteInsertManyCommand(ctx context.Context, collection *mongo.Collection, documents []interface{}, resultObjectName string) (*mongo.InsertManyResult, error)
@@ -233,7 +233,7 @@ func (r *MongoRepositoryHelper) MapOneToResult(ctx context.Context, cursor *mong
 }
 
 // ExecuteCountDocuments returns a int64 count if successful, otherwise an error is returned
-func (r *MongoRepositoryHelper) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+func (r *MongoRepositoryHelper) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error) {
 
 	count, err := collection.CountDocuments(ctx, filter, opts...)
 	if err != nil {
@@ -362,7 +362,7 @@ func (r *MongoRepositoryHelper) ExecuteReplaceOneCommand(ctx context.Context, co
 }
 
 // ExecuteFindCommand returns a cursor if successful, otherwise an error is returned
-func (r *MongoRepositoryHelper) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+func (r *MongoRepositoryHelper) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 
 	c, err := collection.Find(ctx, filter, opts...)
 	if err != nil {

--- a/external/seo/migrations/indexes_sitemap_items.go
+++ b/external/seo/migrations/indexes_sitemap_items.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/seo"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const sitemapItemsURIIndexName = "sitemap_items_uri_unique"
@@ -44,7 +44,7 @@ func InitSitemapItemIndexesDown(db *mongo.Database) error {
 
 	log.Default().Println(toolbox.OutputBasicLogString("info", "rolling-back-task-to-create-sitemap-item-indexes"))
 
-	if _, err := collection.Indexes().DropOne(ctx, sitemapItemsURIIndexName); err != nil && !strings.Contains(err.Error(), "index not found") {
+	if err := collection.Indexes().DropOne(ctx, sitemapItemsURIIndexName); err != nil && !strings.Contains(err.Error(), "index not found") {
 		log.Default().Println(toolbox.OutputBasicLogString("error", "failed-to-drop-sitemap-item-uri-index"))
 		return err
 	}

--- a/external/seo/migrations/seed_default_sitemap_items.go
+++ b/external/seo/migrations/seed_default_sitemap_items.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/seo"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const defaultIdentityTagSystem = "system"
@@ -134,7 +134,7 @@ func initDefaultSitemapItemsUp(db *mongo.Database, paths Paths) error {
 					"created_at":       now,
 				},
 			},
-			options.Update().SetUpsert(true),
+			options.UpdateOne().SetUpsert(true),
 		)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-to-seed-default-sitemap-item: "+uri))

--- a/external/seo/repository.go
+++ b/external/seo/repository.go
@@ -8,18 +8,18 @@ import (
 	"strings"
 	"sync"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore methods needed by seo.
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
@@ -222,7 +222,7 @@ func (r *Repository) UpsertSitemapItemByURI(ctx context.Context, item *SitemapIt
 		},
 	}
 
-	result, err := collection.UpdateOne(ctx, bson.M{"uri": item.URI}, update, options.Update().SetUpsert(true))
+	result, err := collection.UpdateOne(ctx, bson.M{"uri": item.URI}, update, options.UpdateOne().SetUpsert(true))
 	if err != nil {
 		return nil, false, err
 	}

--- a/external/streaker/migrations/indexes_streaks.go
+++ b/external/streaker/migrations/indexes_streaks.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/streaker"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InitStreaksIndexesUp initializes indexes for the streaks collection.
@@ -115,7 +115,7 @@ func InitStreaksIndexesDown(db *mongo.Database) error { //Down
 	}
 
 	for _, indexName := range indexNames {
-		_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err

--- a/external/streaker/repository.go
+++ b/external/streaker/repository.go
@@ -6,17 +6,17 @@ import (
 	"strings"
 	"sync"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore methods needed by streaker.
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
 

--- a/external/streaker/repository_test.go
+++ b/external/streaker/repository_test.go
@@ -7,23 +7,32 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 type mockMongoDbStore struct {
 	initialiseClientFunc func(ctx context.Context) (*mongo.Client, error)
 	getDatabaseFunc      func(ctx context.Context, dbName string) (*mongo.Database, error)
-	executeFindFunc      func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	executeFindFunc      func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	mapAllFunc           func(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error
 }
 
-func (m *mockMongoDbStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+func materializeFindOptions(t *testing.T, lister options.Lister[options.FindOptions]) *options.FindOptions {
+	t.Helper()
+	opts := &options.FindOptions{}
+	for _, setter := range lister.List() {
+		require.NoError(t, setter(opts))
+	}
+	return opts
+}
+
+func (m *mockMongoDbStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error) {
 	return 0, errors.New("not implemented")
 }
 
-func (m *mockMongoDbStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+func (m *mockMongoDbStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 	if m.executeFindFunc != nil {
 		return m.executeFindFunc(ctx, collection, filter, opts...)
 	}
@@ -70,7 +79,7 @@ func (m *mockMongoDbStore) MapOneInCursorToResult(ctx context.Context, cursor *m
 func TestRepository_GetStreakCollectionRetriesFailuresAndCachesSuccess(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	initialiseAttempts := 0
@@ -143,16 +152,16 @@ func TestRepository_WithCollectionInitMaxAttemptsLimitOverridesDefault(t *testin
 func TestRepository_ListStreaksBuildsHistoryFilter(t *testing.T) {
 	t.Parallel()
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
 	var capturedFilter bson.M
 	var capturedOptions *options.FindOptions
 	store := &mockMongoDbStore{
-		executeFindFunc: func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+		executeFindFunc: func(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 			capturedFilter = filter.(bson.M)
 			require.Len(t, opts, 1)
-			capturedOptions = opts[0]
+			capturedOptions = materializeFindOptions(t, opts[0])
 			return nil, nil
 		},
 		mapAllFunc: func(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error {

--- a/external/user/repository.go
+++ b/external/user/repository.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ooaklee/ghatd/external/common"
 	"github.com/ooaklee/ghatd/external/repository"
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const UserCollection = "users"
@@ -20,9 +20,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore to hold resource data
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
@@ -217,8 +217,8 @@ func (r *Repository) GetUsers(ctx context.Context, req *GetUsersRequest) ([]User
 
 	findOptions := options.Find()
 
-	findOptions.Limit = paginationLimit
-	findOptions.Skip = repository.GetPaginationSkip(int64(req.Page), paginationLimit)
+	findOptions.SetLimit(*paginationLimit)
+	findOptions.SetSkip(*repository.GetPaginationSkip(int64(req.Page), paginationLimit))
 
 	// generate query filter from request
 	if req.FirstName != "" {

--- a/external/user/v2/migrations/indexes_users.go
+++ b/external/user/v2/migrations/indexes_users.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/toolbox"
 	user "github.com/ooaklee/ghatd/external/user/v2"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InitUsersIndexesUp initializes indexes for the users collection
@@ -147,7 +147,7 @@ func InitUsersIndexesDown(db *mongo.Database) error { //Down
 	}
 
 	for _, indexName := range indexNames {
-		_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err

--- a/external/user/v2/repository.go
+++ b/external/user/v2/repository.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 
 	"github.com/ooaklee/ghatd/external/toolbox"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // UserCollection collection name for users
@@ -19,9 +19,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore to hold user data
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error
 	ExecuteDeleteManyCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error

--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/testify v1.11.1
 	github.com/tdewolff/minify v2.3.6+incompatible
-	go.mongodb.org/mongo-driver v1.17.9
+	go.mongodb.org/mongo-driver v1.17.9 // indirect
 	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/internal/blueprint/migrations/indexes_blueprints.go
+++ b/internal/blueprint/migrations/indexes_blueprints.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ooaklee/ghatd/external/toolbox"
 	"github.com/ooaklee/ghatd/internal/blueprint"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InitBlueprintIndexesUp initialises indexes for the blueprints collection.
@@ -82,7 +82,7 @@ func InitBlueprintIndexesDown(db *mongo.Database) error { //Down
 	}
 
 	for _, indexName := range indexNames {
-		_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
+		err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), indexName)
 		if err != nil {
 			log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-index: "+indexName))
 			return err

--- a/internal/blueprint/repository.go
+++ b/internal/blueprint/repository.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 
 	"github.com/ooaklee/ghatd/external/logger"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.uber.org/zap"
 )
 
@@ -18,9 +18,9 @@ const defaultCollectionInitMaxAttemptsLimit = 3
 
 // MongoDbStore represents the datastore methods needed by blueprint.
 type MongoDbStore interface {
-	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error)
 	ExecuteDeleteOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, targetObjectName string) error
-	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error)
+	ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 	ExecuteFindOneCommandDecodeResult(ctx context.Context, collection *mongo.Collection, filter interface{}, result interface{}, resultObjectName string, logError bool, onFailureErr error) error
 	ExecuteInsertOneCommand(ctx context.Context, collection *mongo.Collection, document interface{}, resultObjectName string) (*mongo.InsertOneResult, error)
 	ExecuteUpdateOneCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, updateFilter interface{}, resultObjectName string) error

--- a/internal/blueprint/repository_test.go
+++ b/internal/blueprint/repository_test.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 type mockMongoStore struct {
@@ -23,7 +23,7 @@ type mockMongoStore struct {
 	lastFilter            interface{}
 }
 
-func (m *mockMongoStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+func (m *mockMongoStore) ExecuteCountDocuments(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.CountOptions]) (int64, error) {
 	m.countDocumentsCalls++
 	m.lastCollectionName = collection.Name()
 	m.lastFilter = filter
@@ -36,7 +36,7 @@ func (m *mockMongoStore) ExecuteDeleteOneCommand(ctx context.Context, collection
 	return nil
 }
 
-func (m *mockMongoStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+func (m *mockMongoStore) ExecuteFindCommand(ctx context.Context, collection *mongo.Collection, filter interface{}, opts ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 	m.lastCollectionName = collection.Name()
 	m.lastFilter = filter
 	return nil, nil
@@ -70,7 +70,7 @@ func (m *mockMongoStore) GetDatabase(ctx context.Context, dbName string) (*mongo
 		return nil, m.getDatabaseErrs[callIndex]
 	}
 
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (m *mockMongoStore) InitialiseClient(ctx context.Context) (*mongo.Client, e
 		return nil, m.initialiseClientErrs[callIndex]
 	}
 
-	return mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	return mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 }
 
 func (m *mockMongoStore) MapAllInCursorToResult(ctx context.Context, cursor *mongo.Cursor, result interface{}, resultObjectName string) error {

--- a/migrations/mongo/template.go
+++ b/migrations/mongo/template.go
@@ -6,9 +6,9 @@ package migrations
 
 // 	"github.com/ooaklee/ghatd/external/toolbox"
 // 	migrate "github.com/xakep666/mongo-migrate"
-// 	"go.mongodb.org/mongo-driver/bson"
-// 	"go.mongodb.org/mongo-driver/mongo"
-// 	"go.mongodb.org/mongo-driver/mongo/options"
+// 	"go.mongodb.org/mongo-driver/v2/bson"
+// 	"go.mongodb.org/mongo-driver/v2/mongo"
+// 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 // )
 
 func init() {
@@ -36,7 +36,7 @@ func init() {
 	// }, func(db *mongo.Database) error { //Down
 	// 	log.Default().Println(toolbox.OutputBasicLogString("info", "rolling-back-task-to-create-users-created-at-index"))
 
-	// 	_, err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), "users-created-at-index")
+	// 	err := db.Collection(mongoCollectionName).Indexes().DropOne(context.TODO(), "users-created-at-index")
 	// 	if err != nil {
 	// 		log.Default().Println(toolbox.OutputBasicLogString("error", "failed-rolling-back-task-to-create-users-created-at-index"))
 	// 		return err


### PR DESCRIPTION
## Summary

- migrate GHATD repositories, migrations, tests, templates, and MongoDB documentation to `go.mongodb.org/mongo-driver/v2` v2.6.0
- adapt repository interfaces and call sites to v2 option builders, `options.Lister`, BSON types, client construction, update options, and index rollback signatures
- map the removed socket timeout setting to the v2 operation timeout while preserving the legacy configuration field as a deprecated fallback
- add coverage for the new operation-timeout mapping and the legacy timeout compatibility path

## Compatibility notes

Repository interfaces that accept find and count options now use the v2 `options.Lister` types. Host applications implementing these interfaces must use the v2 driver and its option builders.

MongoDB Go Driver v1 remains in `go.mod` only as an indirect dependency of the `memongo` integration-test harness. GHATD application source no longer imports v1.
